### PR TITLE
Replace [] syntax with .as_slice()

### DIFF
--- a/src/redis/connection.rs
+++ b/src/redis/connection.rs
@@ -164,7 +164,7 @@ impl PubSub {
     fn get_channel<T: ToRedisArgs>(&mut self, channel: &T) -> Vec<u8> {
         let mut chan = vec![];
         for item in channel.to_redis_args().iter() {
-            chan.push_all(item[]);
+            chan.push_all(item.as_slice());
         }
         chan
     }
@@ -172,7 +172,7 @@ impl PubSub {
     /// Subscribes to a new channel.
     pub fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
         let chan = self.get_channel(&channel);
-        let _ : () = try!(cmd("SUBSCRIBE").arg(chan[]).query(&self.con));
+        let _ : () = try!(cmd("SUBSCRIBE").arg(chan.as_slice()).query(&self.con));
         self.channels.insert(chan);
         Ok(())
     }
@@ -180,7 +180,7 @@ impl PubSub {
     /// Subscribes to a new channel with a pattern.
     pub fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
         let chan = self.get_channel(&pchannel);
-        let _ : () = try!(cmd("PSUBSCRIBE").arg(chan[]).query(&self.con));
+        let _ : () = try!(cmd("PSUBSCRIBE").arg(chan.as_slice()).query(&self.con));
         self.pchannels.insert(chan);
         Ok(())
     }
@@ -188,7 +188,7 @@ impl PubSub {
     /// Unsubscribes from a channel.
     pub fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
         let chan = self.get_channel(&channel);
-        let _ : () = try!(cmd("UNSUBSCRIBE").arg(chan[]).query(&self.con));
+        let _ : () = try!(cmd("UNSUBSCRIBE").arg(chan.as_slice()).query(&self.con));
         self.channels.remove(&chan);
         Ok(())
     }
@@ -196,7 +196,7 @@ impl PubSub {
     /// Unsubscribes from a channel with a pattern.
     pub fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
         let chan = self.get_channel(&pchannel);
-        let _ : () = try!(cmd("PUNSUBSCRIBE").arg(chan[]).query(&self.con));
+        let _ : () = try!(cmd("PUNSUBSCRIBE").arg(chan.as_slice()).query(&self.con));
         self.pchannels.remove(&chan);
         Ok(())
     }
@@ -254,7 +254,7 @@ impl Msg {
     /// not happen) then the return value is `"?"`.
     pub fn get_channel_name<'a>(&'a self) -> &'a str {
         match self.channel {
-            Data(ref bytes) => str::from_utf8(bytes[]).unwrap_or("?"),
+            Data(ref bytes) => str::from_utf8(bytes.as_slice()).unwrap_or("?"),
             _ => "?"
         }
     }
@@ -269,7 +269,7 @@ impl Msg {
     /// in the raw bytes in it.
     pub fn get_payload_bytes<'a>(&'a self) -> &'a [u8] {
         match self.channel {
-            Data(ref bytes) => bytes[],
+            Data(ref bytes) => bytes.as_slice(),
             _ => b""
         }
     }

--- a/src/redis/types.rs
+++ b/src/redis/types.rs
@@ -89,7 +89,7 @@ impl fmt::Show for Value {
             &Nil => write!(fmt, "nil"),
             &Int(val) => write!(fmt, "int({})", val),
             &Data(ref val) => {
-                match from_utf8(val[]) {
+                match from_utf8(val.as_slice()) {
                     Some(x) => write!(fmt, "string-data('{}')", x.escape_default()),
                     None => write!(fmt, "binary-data({})", val),
                 }
@@ -338,7 +338,7 @@ macro_rules! from_redis_value_for_num_internal(
             match v {
                 &Int(val) => Ok(val as $t),
                 &Data(ref bytes) => {
-                    match from_utf8(bytes[]) {
+                    match from_utf8(bytes.as_slice()) {
                         Some(s) => match from_str(s.as_slice()) {
                             Some(rv) => Ok(rv),
                             None => invalid_type_error!(v,
@@ -411,7 +411,7 @@ impl FromRedisValue for String {
     fn from_redis_value(v: &Value) -> RedisResult<String> {
         match v {
             &Data(ref bytes) => {
-                match from_utf8(bytes[]) {
+                match from_utf8(bytes.as_slice()) {
                     Some(s) => Ok(s.to_string()),
                     None => invalid_type_error!(v,
                         "Invalid UTF-8 string."),
@@ -558,7 +558,7 @@ impl FromRedisValue for json::Json {
     fn from_redis_value(v: &Value) -> RedisResult<json::Json> {
         let rv = match v {
             &Data(ref b) => json::from_str(unwrap_or!(
-                from_utf8(b[]), invalid_type_error!(v, "Invalid UTF-8"))),
+                from_utf8(b.as_slice()), invalid_type_error!(v, "Invalid UTF-8"))),
             &Status(ref s) => json::from_str(s.as_slice()),
             _ => invalid_type_error!(v, "Not JSON compatible"),
         };

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -95,9 +95,9 @@ fn test_args() {
     let con = ctx.connection();
 
     redis::cmd("SET").arg("key1").arg(b"foo").execute(&con);
-    redis::cmd("SET").arg(["key2", "bar"][]).execute(&con);
+    redis::cmd("SET").arg(["key2", "bar"].as_slice()).execute(&con);
 
-    assert_eq!(redis::cmd("MGET").arg(["key1", "key2"][]).query(&con),
+    assert_eq!(redis::cmd("MGET").arg(["key1", "key2"].as_slice()).query(&con),
                Ok(("foo".to_string(), b"bar".to_vec())));
 }
 
@@ -161,7 +161,7 @@ fn test_set_ops() {
     let mut s : Vec<i32> = redis::cmd("SMEMBERS").arg("foo").query(&con).unwrap();
     s.sort();
     assert_eq!(s.len(), 3);
-    assert_eq!(s[], [1, 2, 3][]);
+    assert_eq!(s.as_slice(), [1, 2, 3].as_slice());
 
     let set : HashSet<i32> = redis::cmd("SMEMBERS").arg("foo").query(&con).unwrap();
     assert_eq!(set.len(), 3);
@@ -183,7 +183,7 @@ fn test_scan() {
     s.sort();
     assert_eq!(cur, 0i32);
     assert_eq!(s.len(), 3);
-    assert_eq!(s[], [1, 2, 3][]);
+    assert_eq!(s.as_slice(), [1, 2, 3].as_slice());
 }
 
 #[test]
@@ -248,7 +248,7 @@ fn test_pipeline() {
     let ((k1, k2),) : ((i32, i32),) = redis::pipe()
         .cmd("SET").arg("key_1").arg(42i).ignore()
         .cmd("SET").arg("key_2").arg(43i).ignore()
-        .cmd("MGET").arg(["key_1", "key_2"][]).query(&con).unwrap();
+        .cmd("MGET").arg(["key_1", "key_2"].as_slice()).query(&con).unwrap();
 
     assert_eq!(k1, 42);
     assert_eq!(k2, 43);
@@ -275,7 +275,7 @@ fn test_pipeline_transaction() {
         .atomic()
         .cmd("SET").arg("key_1").arg(42i).ignore()
         .cmd("SET").arg("key_2").arg(43i).ignore()
-        .cmd("MGET").arg(["key_1", "key_2"][]).query(&con).unwrap();
+        .cmd("MGET").arg(["key_1", "key_2"].as_slice()).query(&con).unwrap();
 
     assert_eq!(k1, 42);
     assert_eq!(k2, 43);


### PR DESCRIPTION
Latest nightly seems to have removed the [] syntax for complete slices ([a:b] doesn't work either). The new syntax is a bit more verbose but also much more clear.

This should be merged once current nightly becomes the stable release.
Tested with `rustc 0.12.0-nightly (af3889f69 2014-09-18 21:20:38 +0000)`
Closes #6.
