### PR TITLE
Slicing syntax was put behind a feature gate

### DIFF
--- a/src/redis/lib.rs
+++ b/src/redis/lib.rs
@@ -175,6 +175,7 @@
 
 #![feature(macro_rules)]
 #![feature(default_type_params)]
+#![feature(slicing_syntax)]
 
 #![experimental]
 


### PR DESCRIPTION
Fix for rust-nightly.
