### PR TITLE
Fix incorrect default port.

### DIFF
--- a/src/redis/connection.rs
+++ b/src/redis/connection.rs
@@ -13,7 +13,7 @@ use types::{RedisResult, Okay, Error, Value, Data, Nil, InternalIoError,
 use parser::Parser;
 
 
-static DEFAULT_PORT: u16 = 6370;
+static DEFAULT_PORT: u16 = 6379;
 
 fn redis_scheme_type_mapper(scheme: &str) -> url::SchemeType {
     match scheme {


### PR DESCRIPTION
This fixes a typo in the default Redis port that was introduced with the new password changes you pushed, caused me a few minutes of confusion with connection refused errors.
