### PR TITLE
Fix two attributes to tuple

### DIFF
--- a/src/redis/connection.rs
+++ b/src/redis/connection.rs
@@ -120,7 +120,7 @@ pub struct Msg {
 impl ActualConnection {
 
     pub fn new(host: &str, port: u16) -> RedisResult<ActualConnection> {
-        let sock = try!(TcpStream::connect(host, port));
+        let sock = try!(TcpStream::connect((host, port)));
         Ok(ActualConnection { sock: sock })
     }
 


### PR DESCRIPTION
When I tried to use library with latest Nightly Rust, this line gave me: this function takes 1 parameter but 2 parameters were supplied.

This change fixed it for me. I am total nub with Rust tho, so maybe there is better way. Just heads-up.
