### PR TITLE
Fix new enum scoping rules

### DIFF
--- a/src/redis/cmd.rs
+++ b/src/redis/cmd.rs
@@ -2,6 +2,8 @@ use types::{ToRedisArgs, FromRedisValue, Value, RedisResult,
             ResponseError, Bulk, Nil, from_redis_value};
 use connection::ConnectionLike;
 
+use self::Arg::{SimpleArg, CursorArg, BorrowedArg};
+
 #[deriving(Clone)]
 enum Arg<'a> {
     SimpleArg(Vec<u8>),

--- a/src/redis/types.rs
+++ b/src/redis/types.rs
@@ -2,10 +2,18 @@ use std::error;
 use std::fmt;
 use std::hash::Hash;
 use std::io::{IoError, ConnectionRefused};
-use std::from_str::from_str;
+use std::str::from_str;
 use std::str::from_utf8;
 use std::collections::{HashMap, HashSet};
 use serialize::json;
+
+
+pub use self::Value::{Nil, Int, Data, Bulk, Status, Okay};
+pub use self::ErrorKind::{
+    ResponseError, AuthenticationFailed, TypeError, ExecAbortError, BusyLoadingError,
+    NoScriptError, InvalidClientConfig, ExtensionError, InternalIoError
+};
+pub use self::NumericBehavior::{NonNumeric, NumberIsInteger, NumberIsFloat};
 
 
 /// Helper enum that is used in some situations to describe


### PR DESCRIPTION
This commit fixes the new rules for scoping enum variants under the namespace of their type. Also, `from_str` was moved into `std::str`.
