### PR TITLE
Use long command names

### DIFF
--- a/upload-docs.sh
+++ b/upload-docs.sh
@@ -17,7 +17,7 @@ EOF
 # Add, commit and push files
 git add -f --all .
 git commit -m "Built documentation"
-git co -b gh-pages
+git checkout -b gh-pages
 git remote add origin git@github.com:mitsuhiko/redis-rs.git
 git push -qf origin gh-pages
 


### PR DESCRIPTION
`git co` doesn't work on all systems. Just bit me when using the script as a reference :).
