### PR TITLE
crate is dependencies.redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ development experience.
 The crate is called `redis` and you can depend on it via cargo:
 
 ```ini
-[dependencies.redis-rs]
+[dependencies.redis]
 git = "https://github.com/mitsuhiko/redis-rs.git"
 ```
 


### PR DESCRIPTION
changed `[dependencies.redis-rs]` to `[dependencies.redis]` in the README.md instructions.
