### PR TITLE
Fix documentation on adding as a dependency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! The crate is called `redis` and you can depend on it via cargo:
 //!
 //! ```ini
-//! [dependencies.redis-rs]
+//! [dependencies.redis]
 //! git = "https://github.com/mitsuhiko/redis-rs.git"
 //! ```
 //!


### PR DESCRIPTION
Documentation on how to add the package as a library dependency in Cargo is incorrect as it refers to `redis-rs` rather than the proper package name `redis`. It also differs from the `README.md` file (which is correct).
