### PR TITLE
Allow user to provide a redis instance for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,20 @@ To run benchmarks:
 To build the docs:
 
     $ make docs
+
+The tests need a redis server.  By default they assume that a redis
+server can be started with the `redis-server` command.  If this
+command is not available locally, you can run provide a redis instance
+on `localhost:38991` and run the tests with `REDISRS_NO_SERVER=1`.
+
+One way to start such a server is with [docker](https://www.docker.com/):
+
+    docker run -d -p 38991:6379 --name redis redis:latest
+
+Another way would be to port forward a remote redis server instance
+using `ssh`:
+
+    ssh -L 38991:localhost:6379
+
+On OS X, you might need a combination of `docker` and `ssh`
+port-forwarding to use [`boot2docker`](http://boot2docker.io/).

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -1,4 +1,4 @@
-#![feature(slicing_syntax)]
+#![feature(env,slicing_syntax)]
 
 extern crate redis;
 extern crate libc;
@@ -6,6 +6,7 @@ extern crate serialize;
 
 use redis::{Commands, PipelineCommands};
 
+use std::env;
 use std::io::process;
 use std::time::Duration;
 use std::sync::Future;
@@ -52,15 +53,17 @@ impl Drop for RedisServer {
 }
 
 pub struct TestContext {
-    pub server: RedisServer,
+    pub server: Option<RedisServer>,
     pub client: redis::Client,
 }
 
 impl TestContext {
 
     fn new() -> TestContext {
-        let server = RedisServer::new();
-
+        let mut server = None;
+        if env::var("REDISRS_NO_SERVER").is_err() {
+            server = Some(RedisServer::new());
+        }
         let client = redis::Client::open(redis::ConnectionInfo {
             host: "127.0.0.1".to_string(),
             port: SERVER_PORT,


### PR DESCRIPTION
The `redis-server` command may not be available locally.  Running the tests
with REDISRS_NO_SERVER=1 will stop the tests from trying to start a server,
and will expect to find a redis instance on localhost:38991.
