### PR TITLE
Pre beta fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ build:
 	@cargo build
 
 test:
-	@RUST_TEST_TASKS=1 cargo test
+	@RUST_TEST_THREADS=1 cargo test
 
 bench:
-	@RUST_TEST_TASKS=1 cargo bench
+	@RUST_TEST_THREADS=1 cargo bench
 
 docs: build
 	@cargo doc --no-deps

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn fetch_an_integer() -> redis::RedisResult<int> {
     let client = try!(redis::Client::open("redis://127.0.0.1/"));
     let con = try!(client.get_connection());
     // throw away the result, just make sure it does not fail
-    let _ : () = try!(con.set("my_key", 42i));
+    let _ : () = try!(con.set("my_key", 42));
     // read back the key and return it.  Because the return value
     // from the function is a result for integer this will automatically
     // convert into one.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ command creation is also possible.
 extern crate redis;
 use redis::Commands;
 
-fn fetch_an_integer() -> redis::RedisResult<int> {
+fn fetch_an_integer() -> redis::RedisResult<isize> {
     // connect to redis
     let client = try!(redis::Client::open("redis://127.0.0.1/"));
     let con = try!(client.get_connection());

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,3 @@
-#![feature(core)]
-
 extern crate redis;
 use std::error::Error;
 use redis::{Commands, PipelineCommands, transaction};
@@ -40,7 +38,7 @@ fn do_show_scanning(con: &redis::Connection) -> redis::RedisResult<()> {
     // modified in place we can just ignore the return value upon the end
     // of each iteration.
     let mut pipe = redis::pipe();
-    for num in range(0, 1000) {
+    for num in 0..1000 {
         pipe.cmd("SADD").arg("my_set").arg(num).ignore();
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -25,8 +25,8 @@ macro_rules! implement_commands {
         /// # fn do_something() -> redis::RedisResult<()> {
         /// let client = try!(redis::Client::open("redis://127.0.0.1/"));
         /// let con = try!(client.get_connection());
-        /// redis::cmd("SET").arg("my_key").arg(42i).execute(&con);
-        /// assert_eq!(redis::cmd("GET").arg("my_key").query(&con), Ok(42i));
+        /// redis::cmd("SET").arg("my_key").arg(42).execute(&con);
+        /// assert_eq!(redis::cmd("GET").arg("my_key").query(&con), Ok(42));
         /// # Ok(()) }
         /// ```
         ///
@@ -37,7 +37,7 @@ macro_rules! implement_commands {
         /// use redis::Commands;
         /// let client = try!(redis::Client::open("redis://127.0.0.1/"));
         /// let con = try!(client.get_connection());
-        /// assert_eq!(con.get("my_key"), Ok(42i));
+        /// assert_eq!(con.get("my_key"), Ok(42));
         /// # Ok(()) }
         /// ```
         pub trait Commands : ConnectionLike+Sized {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -30,7 +30,7 @@ pub fn parse_redis_url(input: &str) -> url::ParseResult<url::Url> {
     parser.scheme_type_mapper(redis_scheme_type_mapper);
     match parser.parse(input) {
         Ok(result) => {
-            if result.scheme.as_slice() != "redis" {
+            if result.scheme != "redis" {
                 Err(url::ParseError::InvalidScheme)
             } else {
                 Ok(result)
@@ -73,7 +73,7 @@ impl<'a> IntoConnectionInfo for &'a str {
 
 impl IntoConnectionInfo for url::Url {
     fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
-        ensure!(self.scheme.as_slice() == "redis",
+        ensure!(self.scheme == "redis",
             fail!((InvalidClientConfig, "URL provided is not a redis URL")));
 
         Ok(ConnectionInfo {
@@ -81,7 +81,7 @@ impl IntoConnectionInfo for url::Url {
                 fail!((InvalidClientConfig, "Missing hostname"))),
             port: self.port().unwrap_or(DEFAULT_PORT),
             db: match self.serialize_path().unwrap_or("".to_string())
-                    .as_slice().trim_matches('/') {
+                    .trim_matches('/') {
                 "" => 0,
                 path => path.parse::<i64>().unwrap_or(
                     fail!((InvalidClientConfig, "Invalid database number"))),
@@ -356,10 +356,10 @@ impl PubSub {
             let mut payload;
             let mut channel;
 
-            if msg_type.as_slice() == "message" {
+            if msg_type == "message" {
                 channel = unwrap_or!(iter.next(), continue);
                 payload = unwrap_or!(iter.next(), continue);
-            } else if msg_type.as_slice() == "pmessage" {
+            } else if msg_type == "pmessage" {
                 pattern = Some(unwrap_or!(iter.next(), continue));
                 channel = unwrap_or!(iter.next(), continue);
                 payload = unwrap_or!(iter.next(), continue);
@@ -453,8 +453,8 @@ impl Msg {
 /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 /// # let con = client.get_connection().unwrap();
 /// let key = "the_key";
-/// let (new_val,) : (int,) = try!(redis::transaction(&con, &[key], |pipe| {
-///     let old_val : int = try!(con.get(key));
+/// let (new_val,) : (isize,) = try!(redis::transaction(&con, &[key], |pipe| {
+///     let old_val : isize = try!(con.get(key));
 ///     pipe
 ///         .set(key, old_val + 1).ignore()
 ///         .get(key).query(&con)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -237,7 +237,7 @@ impl ConnectionLike for Connection {
         let mut con = self.con.borrow_mut();
         try!(con.send_bytes(cmd));
         let mut rv = vec![];
-        for idx in range(0, offset + count) {
+        for idx in 0..(offset + count) {
             let item = try!(con.read_response());
             if idx >= offset {
                 rv.push(item);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //!
 //! ```rust,no_run
 //! fn do_something(con: &redis::Connection) -> redis::RedisResult<()> {
-//!     let _ : () = try!(redis::cmd("SET").arg("my_key").arg(42i).query(con));
+//!     let _ : () = try!(redis::cmd("SET").arg("my_key").arg(42).query(con));
 //!     Ok(())
 //! }
 //! ```
@@ -82,7 +82,7 @@
 //! use redis::Commands;
 //!
 //! fn do_something(con: &redis::Connection) -> redis::RedisResult<()> {
-//!     let _ : () = try!(con.set("my_key", 42i));
+//!     let _ : () = try!(con.set("my_key", 42));
 //!     Ok(())
 //! }
 //! # fn main() {}
@@ -135,7 +135,7 @@
 //! # fn do_something() -> redis::RedisResult<()> {
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let con = client.get_connection().unwrap();
-//! let mut iter : redis::Iter<int> = try!(redis::cmd("SSCAN").arg("my_set")
+//! let mut iter : redis::Iter<isize> = try!(redis::cmd("SSCAN").arg("my_set")
 //!     .cursor_arg(0).iter(&con));
 //! for x in iter {
 //!     // do something with the item
@@ -160,8 +160,8 @@
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let con = client.get_connection().unwrap();
 //! let (k1, k2) : (i32, i32) = try!(redis::pipe()
-//!     .cmd("SET").arg("key_1").arg(42i).ignore()
-//!     .cmd("SET").arg("key_2").arg(43i).ignore()
+//!     .cmd("SET").arg("key_1").arg(42).ignore()
+//!     .cmd("SET").arg("key_2").arg(43).ignore()
 //!     .cmd("GET").arg("key_1")
 //!     .cmd("GET").arg("key_2").query(&con));
 //! # Ok(()) }
@@ -178,8 +178,8 @@
 //! # let con = client.get_connection().unwrap();
 //! let (k1, k2) : (i32, i32) = try!(redis::pipe()
 //!     .atomic()
-//!     .cmd("SET").arg("key_1").arg(42i).ignore()
-//!     .cmd("SET").arg("key_2").arg(43i).ignore()
+//!     .cmd("SET").arg("key_1").arg(42).ignore()
+//!     .cmd("SET").arg("key_2").arg(43).ignore()
 //!     .cmd("GET").arg("key_1")
 //!     .cmd("GET").arg("key_2").query(&con));
 //! # Ok(()) }
@@ -195,8 +195,8 @@
 //! # let con = client.get_connection().unwrap();
 //! let (k1, k2) : (i32, i32) = try!(redis::pipe()
 //!     .atomic()
-//!     .set("key_1", 42i).ignore()
-//!     .set("key_2", 43i).ignore()
+//!     .set("key_1", 42).ignore()
+//!     .set("key_2", 43).ignore()
 //!     .get("key_1")
 //!     .get("key_2").query(&con));
 //! # Ok(()) }
@@ -214,8 +214,8 @@
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let con = client.get_connection().unwrap();
 //! let key = "the_key";
-//! let (new_val,) : (int,) = try!(redis::transaction(&con, &[key], |pipe| {
-//!     let old_val : int = try!(con.get(key));
+//! let (new_val,) : (isize,) = try!(redis::transaction(&con, &[key], |pipe| {
+//!     let old_val : isize = try!(con.get(key));
 //!     pipe
 //!         .set(key, old_val + 1).ignore()
 //!         .get(key).query(&con)
@@ -265,14 +265,14 @@
 //! let script = redis::Script::new(r"
 //!     return tonumber(ARGV[1]) + tonumber(ARGV[2]);
 //! ");
-//! let result : int = try!(script.arg(1i).arg(2i).invoke(&con));
+//! let result : isize = try!(script.arg(1).arg(2).invoke(&con));
 //! assert_eq!(result, 3);
 //! # Ok(()) }
 //! ```
 
 #![deny(non_camel_case_types)]
 
-#![feature(collections, core, io, net, plugin)]
+#![feature(collections, core)]
 
 extern crate url;
 extern crate rustc_serialize as serialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@
 #![feature(collections, core, io, net, plugin)]
 
 extern crate url;
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 extern crate sha1;
 
 /* public api */

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -104,7 +104,7 @@ impl<'a, T: Read> Parser<T> {
         let mut rv = vec![];
         rv.reserve(bytes);
 
-        for _ in range(0, bytes) {
+        for _ in 0..bytes {
             rv.push(try!(self.read_byte()));
         }
 
@@ -150,7 +150,7 @@ impl<'a, T: Read> Parser<T> {
         } else {
             let mut rv = vec![];
             rv.reserve(length as usize);
-            for _ in range(0, length) {
+            for _ in 0..length {
                 rv.push(try!(self.parse_value()));
             }
             Ok(Value::Bulk(rv))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -113,7 +113,7 @@ impl<'a, T: Read> Parser<T> {
 
     fn read_int_line(&mut self) -> RedisResult<i64> {
         let line = try!(self.read_string_line());
-        match line.as_slice().trim().parse::<i64>() {
+        match line.trim().parse::<i64>() {
             Err(_) => fail!((ResponseError, "Expected integer, got garbage")),
             Ok(value) => Ok(value)
         }
@@ -121,7 +121,7 @@ impl<'a, T: Read> Parser<T> {
 
     fn parse_status(&mut self) -> RedisResult<Value> {
         let line = try!(self.read_string_line());
-        if line.as_slice() == "OK" {
+        if line == "OK" {
             Ok(Value::Okay)
         } else {
             Ok(Value::Status(line))
@@ -159,7 +159,7 @@ impl<'a, T: Read> Parser<T> {
 
     fn parse_error(&mut self) -> RedisResult<Value> {
         let line = try!(self.read_string_line());
-        let mut pieces = line.as_slice().splitn(1, ' ');
+        let mut pieces = line.splitn(1, ' ');
         let kind = match pieces.next().unwrap() {
             "ERR" => ResponseError,
             "EXECABORT" => ExecAbortError,

--- a/src/script.rs
+++ b/src/script.rs
@@ -22,8 +22,8 @@ pub struct Script {
 /// let script = redis::Script::new(r"
 ///     return tonumber(ARGV[1]) + tonumber(ARGV[2]);
 /// ");
-/// let result = script.arg(1i).arg(2i).invoke(&con);
-/// assert_eq!(result, Ok(3i));
+/// let result = script.arg(1).arg(2).invoke(&con);
+/// assert_eq!(result, Ok(3));
 /// ```
 impl Script {
 
@@ -39,7 +39,7 @@ impl Script {
 
     /// Returns the script's SHA1 hash in hexadecimal format.
     pub fn get_hash(&self) -> &str {
-        self.hash.as_slice()
+        &self.hash
     }
 
     /// Creates a script invocation object with a key filled in.

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -1,8 +1,7 @@
 #![feature(core, old_io, libc, std_misc)]
 
 extern crate redis;
-extern crate libc;
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 
 use redis::{Commands, PipelineCommands};
 
@@ -105,9 +104,9 @@ fn test_args() {
     let con = ctx.connection();
 
     redis::cmd("SET").arg("key1").arg(b"foo").execute(&con);
-    redis::cmd("SET").arg(["key2", "bar"].as_slice()).execute(&con);
+    redis::cmd("SET").arg(&["key2", "bar"]).execute(&con);
 
-    assert_eq!(redis::cmd("MGET").arg(["key1", "key2"].as_slice()).query(&con),
+    assert_eq!(redis::cmd("MGET").arg(&["key1", "key2"]).query(&con),
                Ok(("foo".to_string(), b"bar".to_vec())));
 }
 
@@ -235,7 +234,7 @@ fn test_scanning() {
     let con = ctx.connection();
     let mut unseen = HashSet::new();
 
-    for x in range(0, 1000) {
+    for x in 0..1000 {
         redis::cmd("SADD").arg("foo").arg(x).execute(&con);
         unseen.insert(x);
     }
@@ -257,7 +256,7 @@ fn test_filtered_scanning() {
     let con = ctx.connection();
     let mut unseen = HashSet::new();
 
-    for x in range(0, 3000) {
+    for x in 0..3000 {
         let _ : () = con.hset("foo", format!("key_{}_{}", x % 100, x), x).unwrap();
         if x % 100 == 0 {
             unseen.insert(x);
@@ -283,7 +282,7 @@ fn test_pipeline() {
     let ((k1, k2),) : ((i32, i32),) = redis::pipe()
         .cmd("SET").arg("key_1").arg(42).ignore()
         .cmd("SET").arg("key_2").arg(43).ignore()
-        .cmd("MGET").arg(["key_1", "key_2"].as_slice()).query(&con).unwrap();
+        .cmd("MGET").arg(&["key_1", "key_2"]).query(&con).unwrap();
 
     assert_eq!(k1, 42);
     assert_eq!(k2, 43);
@@ -310,7 +309,7 @@ fn test_pipeline_transaction() {
         .atomic()
         .cmd("SET").arg("key_1").arg(42).ignore()
         .cmd("SET").arg("key_2").arg(43).ignore()
-        .cmd("MGET").arg(["key_1", "key_2"].as_slice()).query(&con).unwrap();
+        .cmd("MGET").arg(&["key_1", "key_2"]).query(&con).unwrap();
 
     assert_eq!(k1, 42);
     assert_eq!(k2, 43);
@@ -408,10 +407,10 @@ fn test_tuple_args() {
     let ctx = TestContext::new();
     let con = ctx.connection();
 
-    redis::cmd("HMSET").arg("my_key").arg([
+    redis::cmd("HMSET").arg("my_key").arg(&[
         ("field_1", 42),
         ("field_2", 23),
-    ].as_slice()).execute(&con);
+    ]).execute(&con);
 
     assert_eq!(redis::cmd("HGET").arg("my_key").arg("field_1").query(&con), Ok(42));
     assert_eq!(redis::cmd("HGET").arg("my_key").arg("field_2").query(&con), Ok(23));
@@ -441,8 +440,8 @@ fn test_auto_m_versions() {
     let ctx = TestContext::new();
     let con = ctx.connection();
 
-    assert_eq!(con.set_multiple([("key1", 1), ("key2", 2)].as_slice()), Ok(()));
-    assert_eq!(con.get(["key1", "key2"].as_slice()), Ok((1, 2)));
+    assert_eq!(con.set_multiple(&[("key1", 1), ("key2", 2)]), Ok(()));
+    assert_eq!(con.get(&["key1", "key2"]), Ok((1, 2)));
 }
 
 #[test]
@@ -472,11 +471,11 @@ fn test_nice_hash_api() {
         ("f4".to_string(), 8),
     ]);
 
-    assert_eq!(con.hget("my_hash", ["f2", "f4"].as_slice()), Ok((2, 8)));
+    assert_eq!(con.hget("my_hash", &["f2", "f4"]), Ok((2, 8)));
     assert_eq!(con.hincr("my_hash", "f1", 1), Ok((2)));
     assert_eq!(con.hincr("my_hash", "f2", 1.5f32), Ok((3.5f32)));
     assert_eq!(con.hexists("my_hash", "f2"), Ok(true));
-    assert_eq!(con.hdel("my_hash", ["f1", "f2"].as_slice()), Ok(()));
+    assert_eq!(con.hdel("my_hash", &["f1", "f2"]), Ok(()));
     assert_eq!(con.hexists("my_hash", "f2"), Ok(false));
 
     let iter : redis::Iter<(String, isize)> = con.hscan("my_hash").unwrap();
@@ -495,8 +494,8 @@ fn test_nice_list_api() {
     let ctx = TestContext::new();
     let con = ctx.connection();
 
-    assert_eq!(con.rpush("my_list", [1, 2, 3, 4].as_slice()), Ok(4));
-    assert_eq!(con.rpush("my_list", [5, 6, 7, 8].as_slice()), Ok(8));
+    assert_eq!(con.rpush("my_list", &[1, 2, 3, 4]), Ok(4));
+    assert_eq!(con.rpush("my_list", &[5, 6, 7, 8]), Ok(8));
     assert_eq!(con.llen("my_list"), Ok(8));
 
     assert_eq!(con.lpop("my_list"), Ok(1));


### PR DESCRIPTION
Once mitsuhiko/rust-sha1#10 is merged, this PR will make sure `redis-rs` works on latest Rust again.

It includes:

* Removal of all integer suffixes
* Replacement of `range` by range syntax
* Usage of updated `io::process` module (hard-killing the server on drop now)
* Replacement of `as_slice()` everywhere with appropiate syntax
* Removal of unused features (only a few remain)
* Update of `rustc_serialize` crate name
* Rename of `RUST_TEST_TASKS` to `RUST_TEST_THREADS` in Makefile

All tests pass locally (with the updated `rust-sha1` of course).