### PR TITLE
Replace FromError by convert::From

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,7 +8,7 @@ macro_rules! ensure {
 
 macro_rules! fail {
     ($expr:expr) => (
-        return Err(::std::error::FromError::from_error($expr));
+        return Err(::std::convert::From::from($expr));
     )
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,5 @@
 use std::error;
+use std::convert;
 use std::fmt;
 use std::hash::Hash;
 use std::io::ErrorKind::ConnectionRefused;
@@ -145,9 +146,9 @@ pub struct RedisError {
     pub detail: Option<String>,
 }
 
-impl error::FromError<IoError> for RedisError {
+impl convert::From<IoError> for RedisError {
 
-    fn from_error(err: IoError) -> RedisError {
+    fn from(err: IoError) -> RedisError {
         RedisError {
             kind: InternalIoError(err),
             desc: "An internal IO error ocurred.",
@@ -156,9 +157,9 @@ impl error::FromError<IoError> for RedisError {
     }
 }
 
-impl error::FromError<Utf8Error> for RedisError {
+impl convert::From<Utf8Error> for RedisError {
 
-    fn from_error(_: Utf8Error) -> RedisError {
+    fn from(_: Utf8Error) -> RedisError {
         RedisError {
             kind: TypeError,
             desc: "Invalid UTF-8.",
@@ -167,9 +168,9 @@ impl error::FromError<Utf8Error> for RedisError {
     }
 }
 
-impl error::FromError<(ErrorKind, &'static str)> for RedisError {
+impl convert::From<(ErrorKind, &'static str)> for RedisError {
 
-    fn from_error((kind, desc): (ErrorKind, &'static str)) -> RedisError {
+    fn from((kind, desc): (ErrorKind, &'static str)) -> RedisError {
         RedisError {
             kind: kind,
             desc: desc,


### PR DESCRIPTION
This fixes the error mentioned in #40, but it brings up the next error:

```
src/types.rs:50:21: 50:28 error: the trait `core::clone::Clone` is not implemented for the type `std::io::error::Error` [E0277]
src/types.rs:50     InternalIoError(IoError),
```

`Clone`, `Eq` and `PartialEq` where removed from `io::Error`, see https://github.com/rust-lang/rust/pull/23919

Not sure how to go from here.