### PR TITLE
Test on travis stable, beta, and nightly releases separately, and switch to travis-ci's container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
-before_install:
-  - yes | sudo add-apt-repository ppa:rwky/redis
-  - sudo apt-get update
+sudo: false
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
 
-install:
-  - curl https://static.rust-lang.org/rustup.sh | sudo bash
-  - sudo apt-get install redis-server
+addons:
+  apt:
+    packages:
+      - redis-server
 
 script:
   - make test


### PR DESCRIPTION
This changes the usage of `rustup.sh` directly to instead use travis-ci's built-in rust language support, and adds a build matrix to test on both the latest beta and the latest nightly.

This also switches to the container-based infrastructure, which disables sudo, but starts up faster. This switches to installing redis-server with the apt addon instead of with apt-get directly. Note: this does switch to the ubuntu version of redis-server instead of the one in the ppa, but as far as I can tell both work for testing.