### PR TITLE
Pass "--yes" to rustup.sh for non-interactive Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - sudo apt-get update
 
 install:
-  - curl https://static.rust-lang.org/rustup.sh | bash
+  - curl https://static.rust-lang.org/rustup.sh | bash -s - --yes
   - sudo apt-get install redis-server
 
 script:


### PR DESCRIPTION
Looks like rustup.sh became interactive by default with https://github.com/rust-lang/rustup/commit/5e5bf08d5c7523ca5645aa61a797a9d37932d5d3 . This change passes the "--yes" option to make sure it doesn't prompt when running from Travis CI.