### PR TITLE
Return early if there are no items to process

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -828,6 +828,9 @@ macro_rules! from_redis_value_for_tuple {
                 // this is pretty ugly too.  The { i += 1; i - 1} is rust's
                 // postfix increment :)
                 let mut rv = vec![];
+                if items.len() == 0 {
+                    return Ok(rv)
+                }
                 let mut offset = 0;
                 while offset < items.len() - 1 {
                     rv.push(($({let $name = (); try!(from_redis_value(

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -494,3 +494,21 @@ fn test_nice_list_api() {
 
     assert_eq!(con.lrange("my_list", 0, 2), Ok((2, 3, 4)));
 }
+
+#[test]
+fn test_tuple_decoding_regression() {
+    let ctx = TestContext::new();
+    let con = ctx.connection();
+
+    assert!(con.del("my_zset").is_ok());
+    assert_eq!(con.zadd("my_zset", "one", 1), Ok(1));
+    assert_eq!(con.zadd("my_zset", "two", 2), Ok(1));
+
+    let vec : Vec<(String,u32)> = con.zrangebyscore_withscores("my_zset", 0, 10).unwrap();
+    assert_eq!(vec.len(), 2);
+
+    assert_eq!(con.del("my_zset"), Ok(1));
+
+    let vec : Vec<(String,u32)> = con.zrangebyscore_withscores("my_zset", 0, 10).unwrap();
+    assert_eq!(vec.len(), 0);
+}


### PR DESCRIPTION
The result decoding will fail for empty return values where it expected an array.

Example:

```rust
 let zset : Vec<(String,u32)> = try!(con.zrangebyscore_withscores("non-existent-set", 0, 3));
```

will fail with:

```
thread '<main>' panicked at 'arithmetic operation overflowed', /home/badboy/.multirust/toolchains/stable/cargo/git/checkouts/redis-rs-44dbe34b2682f27b/master/src/types.rs:832
```

It does not fail for a simple `Vec<String>`
Returning early when we are sure there is nothing to parse will prevent this and return a useful empty vector.