### PR TITLE
Updated Travis CI path back to the base CI location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redis-rs
 
-[![Build Status](https://travis-ci.org/harrydevnull/redis-rs.svg?branch=master)](https://travis-ci.org/harrydevnull/redis-rs)
+[![Build Status](https://travis-ci.org/mitsuhiko/redis-rs.svg?branch=master)](https://travis-ci.org/mitsuhiko/redis-rs)
 
 Redis-rs is a high level redis library for rust.  It provides convenient access
 to all redis functionality through a very flexible but low-level API.  It


### PR DESCRIPTION
the build image was pointing to forked Travis CI location, changed to the base's travis CI build location. changed from https://travis-ci.org/harrydevnull/redis-rs to https://travis-ci.org/mitsuhiko/redis-rs