### PR TITLE
Added function:  zadd_with_option

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -512,10 +512,10 @@ implement_commands! {
     /// Add one member to a sorted set with option (only for redis version 3.0.2 or greater)
     fn zadd_with_option <K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, opt: Options, member: M, score: S) {
         match opt {
-            Options::XX     -> cmd("ZADD").arg(key).arg("XX").arg(score).arg(member)
-            Options::NX     -> cmd("ZADD").arg(key).arg("NX").arg(score).arg(member)
-            Options::CH     -> cmd("ZADD").arg(key).arg("CH").arg(score).arg(member)
-            Options::INCR   -> cmd("ZADD").arg(key).arg("INCR").arg(score).arg(member)
+            Options::XX     => cmd("ZADD").arg(key).arg("XX").arg(score).arg(member)
+            Options::NX     => cmd("ZADD").arg(key).arg("NX").arg(score).arg(member)
+            Options::CH     => cmd("ZADD").arg(key).arg("CH").arg(score).arg(member)
+            Options::INCR   => cmd("ZADD").arg(key).arg("INCR").arg(score).arg(member)
         } 
     }
     

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,4 +1,4 @@
-use types::{FromRedisValue, ToRedisArgs, RedisResult, NumericBehavior};
+use types::{FromRedisValue, ToRedisArgs, RedisResult, NumericBehavior, Options};
 use client::Client;
 use connection::{Connection, ConnectionLike};
 use cmd::{cmd, Cmd, Pipeline, Iter};
@@ -510,8 +510,13 @@ implement_commands! {
     }
 
     /// Add one member to a sorted set with option (only for redis version 3.0.2 or greater)
-    fn zadd_with_option <K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, option: S, member: M, score: S) {
-        cmd("ZADD").arg(key).arg(option).arg(score).arg(member)
+    fn zadd_with_option <K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, opt: Options, member: M, score: S) {
+        match opt {
+            Options::XX     -> cmd("ZADD").arg(key).arg("XX").arg(score).arg(member)
+            Options::NX     -> cmd("ZADD").arg(key).arg("NX").arg(score).arg(member)
+            Options::CH     -> cmd("ZADD").arg(key).arg("CH").arg(score).arg(member)
+            Options::INCR   -> cmd("ZADD").arg(key).arg("INCR").arg(score).arg(member)
+        } 
     }
     
     /// Add multiple members to a sorted set, or update its score if it already exists.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -509,6 +509,11 @@ implement_commands! {
         cmd("ZADD").arg(key).arg(score).arg(member)
     }
 
+    /// Add one member to a sorted set with option (only for redis version 3.0.2 or greater)
+    fn zadd_with_option <K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, option: S, member: M, score: S) {
+        cmd("ZADD").arg(key).arg(option).arg(score).arg(member)
+    }
+    
     /// Add multiple members to a sorted set, or update its score if it already exists.
     fn zadd_multiple<K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, items: &[(S, M)]) {
         cmd("ZADD").arg(key).arg(items)

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -512,9 +512,9 @@ implement_commands! {
     /// Add one member to a sorted set with option (only for redis version 3.0.2 or greater)
     fn zadd_with_option <K: ToRedisArgs, S: ToRedisArgs, M: ToRedisArgs>(key: K, opt: Options, member: M, score: S) {
         match opt {
-            Options::XX     => cmd("ZADD").arg(key).arg("XX").arg(score).arg(member)
-            Options::NX     => cmd("ZADD").arg(key).arg("NX").arg(score).arg(member)
-            Options::CH     => cmd("ZADD").arg(key).arg("CH").arg(score).arg(member)
+            Options::XX     => cmd("ZADD").arg(key).arg("XX").arg(score).arg(member),
+            Options::NX     => cmd("ZADD").arg(key).arg("NX").arg(score).arg(member),
+            Options::CH     => cmd("ZADD").arg(key).arg("CH").arg(score).arg(member),
             Options::INCR   => cmd("ZADD").arg(key).arg("INCR").arg(score).arg(member)
         } 
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,11 +17,12 @@ pub enum NumericBehavior {
     NumberIsFloat,
 }
 
+//Option to support zadd function to receive an option as argument
 pub enum Options {
-    XX,
-    NX,
-    CH,
-    INCR
+    XX, //Only update elements that already exist. Never add elements.
+    NX, //Don't update already existing elements. Always add new elements.
+    CH, //Modify the return value from the number of new elements added, to the total number of elements changed
+    INCR //Only one score-element pair can be specified in this mode.
 }
 
 /// An enum of all error kinds.

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,12 @@ pub enum NumericBehavior {
     NumberIsFloat,
 }
 
+pub enum Options {
+    XX,
+    NX,
+    CH,
+    INCR
+}
 
 /// An enum of all error kinds.
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]


### PR DESCRIPTION
I propose to add the add_with_option function which is a new possibility proposed by Redis (3.0.2 or greater version). In this way the client can say to the database to not update scores with the same value.
