### PR TITLE
swapped the order of arguments for setex

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -141,7 +141,7 @@ implement_commands! {
 
     /// Set the value and expiration of a key.
     fn set_ex<K: ToRedisArgs, V: ToRedisArgs>(key: K, value: V, seconds: usize) {
-        cmd("SETEX").arg(key).arg(value).arg(seconds)
+        cmd("SETEX").arg(key).arg(seconds).arg(value)
     }
 
     /// Set the value of a key, only if the key does not exist


### PR DESCRIPTION
swapped the order of arguments send for ```setex```. First argument to redis  is key and the second is the ```ttl ``` in seconds and third param being the value. The signature of method is kept the same
#67