### PR TITLE
Connection read/write timeout setting

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -298,6 +298,21 @@ impl RedisError {
         }
     }
 
+    /// Returns true if error was caused by I/O time out.
+    /// Note that this may not be accurate depending on platform.
+    pub fn is_timeout(&self) -> bool {
+        match self.repr {
+            ErrorRepr::IoError(ref err) => {
+                match err.kind() {
+                    io::ErrorKind::TimedOut => true,
+                    io::ErrorKind::WouldBlock => true,
+                    _ => false,
+                }
+            }
+            _ => { false }
+        }
+    }
+
     /// Returns the extension error code
     pub fn extension_error_code(&self) -> Option<&str> {
         match self.repr {


### PR DESCRIPTION
Hi,

I have added a way to set read/write time out on Redis connection.
This is needed in order to be able to handle half-open TCP connection scenario when you get_message() on PubSub. Without that it may block indefinitely when physical network connection goes away without taking down the client TCP connection half (still ESTABLISHED while Redis server is gone); see: http://blog.stephencleary.com/2009/05/detection-of-half-open-dropped.html.

I have also added is_timeout() function to RedisError so you can take appropriate action in case of time out.
This could also be useful for other scenarios.
Note that I have not tested this with Unix sockets.

Regards,
Jakub