### PR TITLE
Make redis-rs asynchronous using mioco

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ readme = "README.md"
 sha1 = "0.1.1"
 url = "0.5.4"
 rustc-serialize = "0.3.16"
-unix_socket = { version ="0.5.0", optional = true }
+unix_socket = { version = "0.5.0", optional = true }
+mioco = { version = "0.6.0", optional = true }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,0 +1,36 @@
+extern crate redis;
+extern crate mioco;
+
+fn follow_channel(channel: &str, coro_id: i32) -> redis::RedisResult<()> {
+    let client = try!(redis::Client::open("redis://127.0.0.1/"));
+    let mut pubsub = try!(client.get_pubsub());
+    try!(pubsub.subscribe(channel));
+
+    loop {
+        let msg = try!(pubsub.get_message());
+        let payload : String = try!(msg.get_payload());
+        println!("Coroutine {}: {}: {}", coro_id, msg.get_channel_name(), payload);
+    }
+}
+
+fn send_messages(channel: &str, message: &str) -> redis::RedisResult<()> {
+    let client = try!(redis::Client::open("redis://127.0.0.1/"));
+    let con = try!(client.get_connection());
+    loop {
+        let _ : () = try!(redis::cmd("PUBLISH").arg(channel).arg(message).query(&con));
+        mioco::sleep_ms(1000);
+    }
+}
+
+fn main() {
+    mioco::start(move || {
+        for i in 0..10 {
+            mioco::spawn(move || {
+                follow_channel("chan1", i).unwrap();
+            });
+        }
+        mioco::spawn(move || {
+            send_messages("chan1", "Hi followers!").unwrap();
+        });
+    }).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,9 @@ extern crate sha1;
 #[cfg(feature="unix_socket")]
 extern crate unix_socket;
 
+#[cfg(feature="mioco")]
+extern crate mioco;
+
 /* public api */
 pub use parser::{parse_redis_value, Parser};
 pub use client::Client;

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -1,5 +1,6 @@
 extern crate redis;
 extern crate rustc_serialize as serialize;
+extern crate mioco;
 
 use redis::{Commands, PipelineCommands};
 
@@ -112,14 +113,16 @@ impl TestContext {
 
 #[test]
 fn test_args() {
-    let ctx = TestContext::new();
-    let con = ctx.connection();
+    mioco::spawn(move || {
+        let ctx = TestContext::new();
+        let con = ctx.connection();
 
-    redis::cmd("SET").arg("key1").arg(b"foo").execute(&con);
-    redis::cmd("SET").arg(&["key2", "bar"]).execute(&con);
+        redis::cmd("SET").arg("key1").arg(b"foo").execute(&con);
+        redis::cmd("SET").arg(&["key2", "bar"]).execute(&con);
 
-    assert_eq!(redis::cmd("MGET").arg(&["key1", "key2"]).query(&con),
-               Ok(("foo".to_string(), b"bar".to_vec())));
+        assert_eq!(redis::cmd("MGET").arg(&["key1", "key2"]).query(&con),
+                   Ok(("foo".to_string(), b"bar".to_vec())));
+    });
 }
 
 #[test]


### PR DESCRIPTION
This PR is meant to open a discussion on how to make redis-rs asynchronous.

Here it is done by using mioco coroutines. TcpStream is replaced by the one from mioco which makes TCP connections non-blocking when run in a coroutine. An example of async pubsub is available, it creates 10 consumers and a producer, all running in the same thread.

Note that timeouts are not handled currently.