### PR TITLE
Faster encoding

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -64,8 +64,35 @@ impl<'a, T: FromRedisValue> Iterator for Iter<'a, T> {
     }
 }
 
+fn countdigits(mut v: usize) -> usize {
+    let mut result = 1;
+    loop {
+        if v < 10 { return result; }
+        if v < 100 { return result + 1; }
+        if v < 1000 { return result + 2; }
+        if v < 10000 { return result + 3; }
+
+        v /= 10000;
+        result += 4;
+    }
+}
+
+#[inline]
+fn bulklen(len: usize) -> usize {
+    return 1+countdigits(len)+2+len+2;
+}
+
 fn encode_command(args: &Vec<Arg>, cursor: u64) -> Vec<u8> {
-    let mut cmd = Vec::with_capacity(8192);
+    let mut totlen = 1 + countdigits(args.len()) + 2;
+    for item in args {
+        totlen += bulklen(match *item {
+            Arg::Cursor => countdigits(cursor as usize),
+            Arg::Simple(ref val) => val.len(),
+            Arg::Borrowed(ptr) => ptr.len(),
+        });
+    }
+
+    let mut cmd = Vec::with_capacity(totlen);
     cmd.push('*' as u8);
     cmd.extend(args.len().to_string().as_bytes());
     cmd.push('\r' as u8);

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -65,14 +65,21 @@ impl<'a, T: FromRedisValue> Iterator for Iter<'a, T> {
 }
 
 fn encode_command(args: &Vec<Arg>, cursor: u64) -> Vec<u8> {
-    let mut cmd = vec![];
-    cmd.extend(format!("*{}\r\n", args.len()).as_bytes().iter().cloned());
+    let mut cmd = Vec::with_capacity(8192);
+    cmd.push('*' as u8);
+    cmd.extend(args.len().to_string().as_bytes());
+    cmd.push('\r' as u8);
+    cmd.push('\n' as u8);
 
     {
         let mut encode = |item: &[u8]| {
-            cmd.extend(format!("${}\r\n", item.len()).as_bytes().iter().cloned());
-            cmd.extend(item.iter().cloned());
-            cmd.extend(b"\r\n".iter().cloned());
+            cmd.push('$' as u8);
+            cmd.extend(item.len().to_string().as_bytes());
+            cmd.push('\r' as u8);
+            cmd.push('\n' as u8);
+            cmd.extend(item.iter());
+            cmd.push('\r' as u8);
+            cmd.push('\n' as u8);
         };
 
         for item in args.iter() {


### PR DESCRIPTION
So I run a few benchmarks (also the one mentioned in #81) and flamegraphs and identified the vector resize as one problem when creating the pipelined commands.
With this small change I see some improvement.

redis-rs' own benchmarks:

```
name                                        master.txt ns/iter  faster-encoding.txt ns/iter    diff ns/iter  diff %
bench_simple_getsetdel                      37,027              37,401                                  374   1.01%
bench_simple_getsetdel_pipeline             17,230              16,305                                 -925  -5.37%
bench_simple_getsetdel_pipeline_precreated  16,370              15,409                                 -961  -5.87%
```

client-benchmark on master:

```
./target/release/client-benchmark  1.30s user 0.13s system 73% cpu 1.936 total
```

client-benchmark on faster-encoding:

```
./target/release/client-benchmark  0.91s user 0.12s system 66% cpu 1.538 total
```

hiredis does the same for the encoding (I just copied over the countdigits and bulklen functions and the totlen calculation)