### PR TITLE
Relax ScriptInvocation lifetimes

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -97,7 +97,9 @@ impl<'a> ScriptInvocation<'a> {
     /// Adds a regular argument to the invocation.  This ends up as `ARGV[i]`
     /// in the script.
     #[inline]
-    pub fn arg<T: ToRedisArgs>(&'a mut self, arg: T) -> &'a mut ScriptInvocation {
+    pub fn arg<'b, T: ToRedisArgs>(&'b mut self, arg: T) -> &'b mut ScriptInvocation<'a>
+        where 'a: 'b
+    {
         self.args.extend(arg.to_redis_args().into_iter());
         self
     }
@@ -105,7 +107,9 @@ impl<'a> ScriptInvocation<'a> {
     /// Adds a key argument to the invocation.  This ends up as `KEYS[i]`
     /// in the script.
     #[inline]
-    pub fn key<T: ToRedisArgs>(&'a mut self, key: T) -> &'a mut ScriptInvocation {
+    pub fn key<'b, T: ToRedisArgs>(&'b mut self, key: T) -> &'b mut ScriptInvocation<'a>
+        where 'a: 'b
+    {
         self.keys.extend(key.to_redis_args().into_iter());
         self
     }


### PR DESCRIPTION
The `arg` and `key` methods could only be used in a chain as
demonstrated in the docs. If `arg` and `key` are to be called
programmatically as in

    for arg in &args {
        invocation.arg(arg);
    }

There was a borrowing error, and `invoke` could never be called. This
detaches the lifetime of the mutable borrow from the lifetime of
ScriptInvocation (specifically, says it will be shorter) to support the
above use case.