### PR TITLE
Fix FromRedisValue for bool

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -742,6 +742,13 @@ impl FromRedisValue for bool {
                 }
             }
             Value::Okay => Ok(true),
+            Value::Data(ref bytes) => {
+                match try!(from_utf8(bytes)).parse::<bool>() {
+                    Ok(rv) => Ok(rv),
+                    Err(_) => invalid_type_error!(v,
+                        "Could not convert from string.")
+                }
+            },
             _ => invalid_type_error!(v,
                 "Response type not bool compatible."),
         }

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -294,6 +294,20 @@ fn test_json() {
 }
 
 #[test]
+fn test_bool() {
+    let ctx = TestContext::new();
+    let con = ctx.connection();
+
+    redis::cmd("SET").arg("true").arg(true).execute(&con);
+    redis::cmd("SET").arg("false").arg(false).execute(&con);
+
+    let true_val : bool = redis::cmd("GET").arg("true").query(&con).unwrap();
+    let false_val : bool = redis::cmd("GET").arg("false").query(&con).unwrap();
+    assert_eq!(true_val, true);
+    assert_eq!(false_val, false);
+}
+
+#[test]
 fn test_scanning() {
     let ctx = TestContext::new();
     let con = ctx.connection();


### PR DESCRIPTION
The `ToRedisArgs` will convert bool value to the string "true" or "false".
But the `FromRedisValue` for bool type won't convert them back to bool value.

This patch makes `FromRedisValue` convert `Value::Data` of bool to the corresponding bool value.
