### PR TITLE
Make FromRedisValue impl for HashMap/HashSet generic over hash builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tokio-uds = { version = "0.2", optional = true }
 [dev-dependencies]
 rand = "0.4"
 net2 = "0.2"
+fnv = "1.0.5"
 bencher = "0.1"
 partial-io = { version = "0.3", features = ["tokio", "quickcheck"] }
 quickcheck = "0.6"

--- a/src/types.rs
+++ b/src/types.rs
@@ -883,11 +883,12 @@ where
     }
 }
 
-impl<T: FromRedisValue + Eq + Hash> FromRedisValue for HashSet<T> {
-    fn from_redis_value(v: &Value) -> RedisResult<HashSet<T>> {
+impl<T: FromRedisValue + Eq + Hash, S: BuildHasher + Default> FromRedisValue for HashSet<T, S> {
+    fn from_redis_value(v: &Value) -> RedisResult<HashSet<T, S>> {
         match *v {
             Value::Bulk(ref items) => {
-                let mut rv = HashSet::new();
+                let s = S::default();
+                let mut rv = HashSet::with_hasher(s);
                 for item in items.iter() {
                     rv.insert(try!(from_redis_value(item)));
                 }

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -1,3 +1,4 @@
+extern crate fnv;
 extern crate redis;
 
 
@@ -72,6 +73,44 @@ fn test_vec() {
                                                                Value::Data("3".into())]));
 
     assert_eq!(v, Ok(vec![1i32, 2, 3]));
+}
+
+#[test]
+fn test_hashmap() {
+    use fnv::FnvHasher;
+    use std::collections::HashMap;
+    use std::hash::BuildHasherDefault;
+    use redis::{FromRedisValue, Value};
+
+    type Hm = HashMap<String, i32>;
+
+    let v: Result<Hm, _> = FromRedisValue::from_redis_value(&Value::Bulk(vec![Value::Data("a".into()),
+                                                                              Value::Data("1".into()),
+                                                                              Value::Data("b".into()),
+                                                                              Value::Data("2".into()),
+                                                                              Value::Data("c".into()),
+                                                                              Value::Data("3".into())]));
+    let mut e: Hm = HashMap::new();
+    e.insert("a".into(), 1);
+    e.insert("b".into(), 2);
+    e.insert("c".into(), 3);
+    assert_eq!(v, Ok(e));
+
+    type Hasher = BuildHasherDefault<FnvHasher>;
+    type HmHasher = HashMap<String, i32, Hasher>;
+    let v: Result<HmHasher, _> = FromRedisValue::from_redis_value(&Value::Bulk(vec![Value::Data("a".into()),
+                                                                                    Value::Data("1".into()),
+                                                                                    Value::Data("b".into()),
+                                                                                    Value::Data("2".into()),
+                                                                                    Value::Data("c".into()),
+                                                                                    Value::Data("3".into())]));
+
+    let fnv = Hasher::default();
+    let mut e: HmHasher = HashMap::with_hasher(fnv);
+    e.insert("a".into(), 1);
+    e.insert("b".into(), 2);
+    e.insert("c".into(), 3);
+    assert_eq!(v, Ok(e));
 }
 
 #[test]


### PR DESCRIPTION
This allows use of (for example) the FnvHashMap/FnvHashSet provided by [fnv](https://crates.io/crates/fnv) when getting maps/sets back from Redis.

Let me know if you'd like me to squash!