### PR TITLE
Fix get_payload_bytes returning channel

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -541,7 +541,7 @@ impl Msg {
     /// as an alternative to the `get_payload` function if you are interested
     /// in the raw bytes in it.
     pub fn get_payload_bytes(&self) -> &[u8] {
-        match self.channel {
+        match self.payload {
             Value::Data(ref bytes) => bytes,
             _ => b"",
         }


### PR DESCRIPTION
get_payload_bytes was previously returning the raw channel bytes instead
of the raw payload bytes. This has been corrected.