### PR TITLE
Implement flexible PubSub API

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,4 @@
-use connection::{ConnectionInfo, IntoConnectionInfo, Connection, connect, PubSub, connect_pubsub,
-                 ConnectionLike};
+use connection::{ConnectionInfo, IntoConnectionInfo, Connection, connect, ConnectionLike};
 use types::{RedisResult, Value};
 
 
@@ -40,15 +39,6 @@ impl Client {
     /// errors.
     pub fn get_connection(&self) -> RedisResult<Connection> {
         Ok(try!(connect(&self.connection_info)))
-    }
-
-    /// Returns a PubSub connection.  A pubsub connection can be used to
-    /// listen to messages coming in through the redis publish/subscribe
-    /// system.
-    ///
-    /// Note that redis' pubsub operates across all databases.
-    pub fn get_pubsub(&self) -> RedisResult<PubSub> {
-        Ok(try!(connect_pubsub(&self.connection_info)))
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 use types::{FromRedisValue, ToRedisArgs, RedisResult, NumericBehavior};
 use client::Client;
-use connection::{Connection, ConnectionLike};
+use connection::{Connection, ConnectionLike, Msg};
 use cmd::{cmd, Cmd, Pipeline, Iter};
 
 
@@ -734,8 +734,99 @@ implement_commands! {
     }
 }
 
+/// Allows pubsub callbacks to stop receiving messages.
+///
+/// Arbitraty data may be returned from `Break`.
+pub enum ControlFlow<U> {
+    Continue,
+    Break(U),
+}
+
+/// The PubSub trait allows subscribing to one or more items
+/// and receiving a callback whenever a message arrives.
+///
+/// Each method handles subscribing to the list of keys, waiting for
+/// messages, and unsubscribing from the same list of keys once
+/// a ControlFlow::Break is encountered.
+///
+/// Once (p)subscribe returns Ok(U), the connection is again safe to use
+/// for calling other methods.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # fn do_something() -> redis::RedisResult<()> {
+/// use redis::{PubSubCommands, ControlFlow};
+/// let client = redis::Client::open("redis://127.0.0.1/")?;
+/// let mut con = client.get_connection()?;
+/// let mut count = 0;
+/// con.subscribe(&["foo"], |msg| {
+///     // do something with message
+///     assert_eq!(msg.get_channel(), Ok(String::from("foo")));
+///
+///     // incerement messages seen counter
+///     count += 1;
+///     match count {
+///         // stop after receiving 10 messages
+///         10 => ControlFlow::Break(()),
+///         _ => ControlFlow::Continue,
+///     }
+/// });
+/// # Ok(()) }
+/// ```
+//
+// In the future, it would be nice to implement Try such that `?` will work
+// within the closure.
+pub trait PubSubCommands {
+    /// Subscribe to a list of channels using SUBSCRIBE and run the provided
+    /// closure for each message received.
+    fn subscribe<'a, C, F, U>(&mut self, _: C, _: F) -> RedisResult<U>
+        where F: FnMut(Msg) -> ControlFlow<U>,
+              C: ToRedisArgs;
+
+    /// Subscribe to a list of channels using PSUBSCRIBE and run the provided
+    /// closure for each message received.
+    fn psubscribe<'a, P, F, U>(&mut self, _: P, _: F) -> RedisResult<U>
+        where F: FnMut(Msg) -> ControlFlow<U>,
+              P: ToRedisArgs;
+}
+
 impl Commands for Connection {}
 impl Commands for Client {}
+
+impl PubSubCommands for Connection {
+    fn subscribe<'a, C, F, U>(&mut self, channels: C, mut func: F) -> RedisResult<U>
+        where F: FnMut(Msg) -> ControlFlow<U>,
+              C: ToRedisArgs
+    {
+        let mut pubsub = self.as_pubsub();
+        pubsub.subscribe(channels)?;
+
+        loop {
+            let msg = pubsub.get_message()?;
+            match func(msg) {
+                ControlFlow::Continue => continue,
+                ControlFlow::Break(value) => return Ok(value),
+            }
+        }
+    }
+
+    fn psubscribe<'a, P, F, U>(&mut self, patterns: P, mut func: F) -> RedisResult<U>
+        where F: FnMut(Msg) -> ControlFlow<U>,
+              P: ToRedisArgs
+    {
+        let mut pubsub = self.as_pubsub();
+        pubsub.psubscribe(patterns)?;
+
+        loop {
+            let msg = pubsub.get_message()?;
+            match func(msg) {
+                ControlFlow::Continue => continue,
+                ControlFlow::Break(value) => return Ok(value),
+            }
+        }
+    }
+}
 
 impl PipelineCommands for Pipeline {
     fn perform(&mut self, cmd: &Cmd) -> &mut Pipeline {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -736,17 +736,17 @@ implement_commands! {
 
 /// Allows pubsub callbacks to stop receiving messages.
 ///
-/// Arbitraty data may be returned from `Break`.
+/// Arbitrary data may be returned from `Break`.
 pub enum ControlFlow<U> {
     Continue,
     Break(U),
 }
 
-/// The PubSub trait allows subscribing to one or more items
+/// The PubSub trait allows subscribing to one or more channels
 /// and receiving a callback whenever a message arrives.
 ///
 /// Each method handles subscribing to the list of keys, waiting for
-/// messages, and unsubscribing from the same list of keys once
+/// messages, and unsubscribing from the same list of channels once
 /// a ControlFlow::Break is encountered.
 ///
 /// Once (p)subscribe returns Ok(U), the connection is again safe to use
@@ -764,7 +764,7 @@ pub enum ControlFlow<U> {
 ///     // do something with message
 ///     assert_eq!(msg.get_channel(), Ok(String::from("foo")));
 ///
-///     // incerement messages seen counter
+///     // increment messages seen counter
 ///     count += 1;
 ///     match count {
 ///         // stop after receiving 10 messages
@@ -774,9 +774,8 @@ pub enum ControlFlow<U> {
 /// });
 /// # Ok(()) }
 /// ```
-//
-// In the future, it would be nice to implement Try such that `?` will work
-// within the closure.
+// TODO In the future, it would be nice to implement Try such that `?` will work
+//      within the closure.
 pub trait PubSubCommands: Sized {
     /// Subscribe to a list of channels using SUBSCRIBE and run the provided
     /// closure for each message received.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -780,12 +780,20 @@ pub enum ControlFlow<U> {
 pub trait PubSubCommands {
     /// Subscribe to a list of channels using SUBSCRIBE and run the provided
     /// closure for each message received.
+    ///
+    /// For every `Msg` passed to the provided closure, either
+    /// `ControlFlow::Break` or `ControlFlow::Continue` must be returned. This
+    /// method will not return until `ControlFlow::Break` is observed.
     fn subscribe<'a, C, F, U>(&mut self, _: C, _: F) -> RedisResult<U>
         where F: FnMut(Msg) -> ControlFlow<U>,
               C: ToRedisArgs;
 
     /// Subscribe to a list of channels using PSUBSCRIBE and run the provided
     /// closure for each message received.
+    ///
+    /// For every `Msg` passed to the provided closure, either
+    /// `ControlFlow::Break` or `ControlFlow::Continue` must be returned. This
+    /// method will not return until `ControlFlow::Break` is observed.
     fn psubscribe<'a, P, F, U>(&mut self, _: P, _: F) -> RedisResult<U>
         where F: FnMut(Msg) -> ControlFlow<U>,
               P: ToRedisArgs;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -426,25 +426,25 @@ impl ConnectionLike for Connection {
 impl<'a> PubSub<'a> {
     /// Subscribes to a new channel.
     pub fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        let _: () = try!(cmd("SUBSCRIBE").arg(channel).query(self.con));
+        let _: () = cmd("SUBSCRIBE").arg(channel).query(self.con)?;
         Ok(())
     }
 
     /// Subscribes to a new channel with a pattern.
     pub fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        let _: () = try!(cmd("PSUBSCRIBE").arg(pchannel).query(self.con));
+        let _: () = cmd("PSUBSCRIBE").arg(pchannel).query(self.con)?;
         Ok(())
     }
 
     /// Unsubscribes from a channel.
     pub fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        let _: () = try!(cmd("UNSUBSCRIBE").arg(channel).query(self.con));
+        let _: () = cmd("UNSUBSCRIBE").arg(channel).query(self.con)?;
         Ok(())
     }
 
     /// Unsubscribes from a channel with a pattern.
     pub fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        let _: () = try!(cmd("PUNSUBSCRIBE").arg(pchannel).query(self.con));
+        let _: () = cmd("PUNSUBSCRIBE").arg(pchannel).query(self.con)?;
         Ok(())
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -500,7 +500,7 @@ impl ConnectionLike for Connection {
 /// # }
 /// ```
 impl<'a> PubSub<'a> {
-    pub fn new(con: &'a mut Connection) -> Self {
+    fn new(con: &'a mut Connection) -> Self {
         Self { con }
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::io::{Read, BufReader, Write};
 use std::net::{self, TcpStream};
 use std::str::from_utf8;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::time::Duration;
 
 use url;
@@ -164,11 +164,17 @@ enum ActualConnection {
 pub struct Connection {
     con: RefCell<ActualConnection>,
     db: i64,
+
+    /// Flag indicating whether the connection was left in the PubSub state after dropping `PubSub`.
+    ///
+    /// This flag is checked when attempting to send a command, and if it's raised, we attempt to
+    /// exit the pubsub state before executing the new request.
+    pubsub: Cell<bool>,
 }
 
 /// Represents a pubsub connection.
-pub struct PubSub {
-    con: Connection,
+pub struct PubSub<'a> {
+    con: &'a mut Connection,
 }
 
 /// Represents a pubsub message.
@@ -268,6 +274,7 @@ pub fn connect(connection_info: &ConnectionInfo) -> RedisResult<Connection> {
     let rv = Connection {
         con: RefCell::new(con),
         db: connection_info.db,
+        pubsub: Cell::new(false),
     };
 
     match connection_info.passwd {
@@ -365,13 +372,81 @@ impl Connection {
         self.con.borrow().set_read_timeout(dur)
     }
 
-    pub fn pubsub(self) -> PubSub {
+    pub fn as_pubsub<'a>(&'a mut self) -> PubSub<'a> {
+        // NOTE: The pubsub flag is intentionally not raised at this time since running commands
+        // within the pubsub state should not try and exit from the pubsub state.
         PubSub::new(self)
+    }
+
+    fn exit_pubsub(&self) -> RedisResult<()> {
+        let res = self.clear_active_subscriptions();
+        if res.is_ok() {
+            self.pubsub.set(false);
+        } else {
+            // Raise the pubsub flag to indicate the connection is "stuck" in that state.
+            self.pubsub.set(true);
+        }
+
+        res
+    }
+
+    /// Get the inner connection out of a PubSub
+    ///
+    /// Any active subscriptions are unsubscribed. In the event of an error, the connection is
+    /// dropped.
+    fn clear_active_subscriptions(&self) -> RedisResult<()> {
+        // Responses to unsubscribe commands return in a 3-tuple with values
+        // ("unsubscribe" or "punsubscribe", name of subscription removed, count of remaining subs).
+        // The "count of remaining subs" includes both pattern subscriptions and non pattern
+        // subscriptions. Thus, to accurately drain all unsubscribe messages received from the
+        // server, both commands need to be executed at once.
+        {
+            // Prepare both unsubscribe commands
+            let unsubscribe = cmd("UNSUBSCRIBE").get_packed_command();
+            let punsubscribe = cmd("PUNSUBSCRIBE").get_packed_command();
+
+            // Grab a reference to the underlying connection so that we may send
+            // the commands without immediately blocking for a response.
+            let mut con = self.con.borrow_mut();
+
+            // Execute commands
+            con.send_bytes(&unsubscribe)?;
+            con.send_bytes(&punsubscribe)?;
+        }
+
+        // Receive responses
+        //
+        // There will be at minimum two responses - 1 for each of punsubscribe and unsubscribe
+        // commands. There may be more responses if there are active subscriptions. In this case,
+        // messages are received until the _subscription count_ in the responses reach zero.
+        let mut received_unsub = false;
+        let mut received_punsub = false;
+        loop {
+            let res: (Vec<u8>, (), isize) = from_redis_value(&self.recv_response()?)?;
+
+            match res.0.first().map(|v| *v) {
+                Some(b'u') => received_unsub = true,
+                Some(b'p') => received_punsub = true,
+                _ => (),
+            }
+
+            if received_unsub && received_punsub && res.2 == 0 {
+                break;
+            }
+        }
+
+        // Finally, the connection is back in its normal state since all subscriptions were
+        // cancelled *and* all unsubscribe messages were received.
+        Ok(())
     }
 }
 
 impl ConnectionLike for Connection {
     fn req_packed_command(&self, cmd: &[u8]) -> RedisResult<Value> {
+        if self.pubsub.get() {
+            self.exit_pubsub()?;
+        }
+
         let mut con = self.con.borrow_mut();
         try!(con.send_bytes(cmd));
         con.read_response()
@@ -382,6 +457,9 @@ impl ConnectionLike for Connection {
                            offset: usize,
                            count: usize)
                            -> RedisResult<Vec<Value>> {
+        if self.pubsub.get() {
+            self.exit_pubsub()?;
+        }
         let mut con = self.con.borrow_mut();
         try!(con.send_bytes(cmd));
         let mut rv = vec![];
@@ -410,7 +488,7 @@ impl ConnectionLike for Connection {
 /// # fn do_something() -> redis::RedisResult<()> {
 /// let client = try!(redis::Client::open("redis://127.0.0.1/"));
 /// let mut con = client.get_connection()?;
-/// let mut pubsub = con.pubsub();
+/// let mut pubsub = con.as_pubsub();
 /// try!(pubsub.subscribe("channel_1"));
 /// try!(pubsub.subscribe("channel_2"));
 ///
@@ -421,32 +499,32 @@ impl ConnectionLike for Connection {
 /// }
 /// # }
 /// ```
-impl PubSub {
-    pub fn new(con: Connection) -> Self {
+impl<'a> PubSub<'a> {
+    pub fn new(con: &'a mut Connection) -> Self {
         Self { con }
     }
 
     /// Subscribes to a new channel.
     pub fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        let _: () = cmd("SUBSCRIBE").arg(channel).query(&self.con)?;
+        let _: () = cmd("SUBSCRIBE").arg(channel).query(self.con)?;
         Ok(())
     }
 
     /// Subscribes to a new channel with a pattern.
     pub fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        let _: () = cmd("PSUBSCRIBE").arg(pchannel).query(&self.con)?;
+        let _: () = cmd("PSUBSCRIBE").arg(pchannel).query(self.con)?;
         Ok(())
     }
 
     /// Unsubscribes from a channel.
     pub fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        let _: () = cmd("UNSUBSCRIBE").arg(channel).query(&self.con)?;
+        let _: () = cmd("UNSUBSCRIBE").arg(channel).query(self.con)?;
         Ok(())
     }
 
     /// Unsubscribes from a channel with a pattern.
     pub fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        let _: () = cmd("PUNSUBSCRIBE").arg(pchannel).query(&self.con)?;
+        let _: () = cmd("PUNSUBSCRIBE").arg(pchannel).query(self.con)?;
         Ok(())
     }
 
@@ -492,55 +570,11 @@ impl PubSub {
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> RedisResult<()> {
         self.con.set_read_timeout(dur)
     }
+}
 
-    /// Get the inner connection out of a PubSub
-    ///
-    /// Any active subscriptions are unsubscribed. In the event of an error, the connection is
-    /// dropped.
-    pub fn into_inner(self) -> RedisResult<Connection> {
-        // Responses to unsubscribe commands return in a 3-tuple with values
-        // ("unsubscribe" or "punsubscribe", name of subscription removed, count of remaining subs).
-        // The "count of remaining subs" includes both pattern subscriptions and non pattern
-        // subscriptions. Thus, to accurately drain all unsubscribe messages received from the
-        // server, both commands need to be executed at once.
-        {
-            // Prepare both unsubscribe commands
-            let unsubscribe = cmd("UNSUBSCRIBE").get_packed_command();
-            let punsubscribe = cmd("PUNSUBSCRIBE").get_packed_command();
-
-            // Grab a reference to the underlying connection so that we may send
-            // the commands without immediately blocking for a response.
-            let mut con = self.con.con.borrow_mut();
-
-            // Execute commands
-            con.send_bytes(&unsubscribe)?;
-            con.send_bytes(&punsubscribe)?;
-        }
-
-        // Receive responses
-        //
-        // There will be at minimum two responses - 1 for each of punsubscribe and unsubscribe
-        // commands. There may be more responses if there are active subscriptions. In this case,
-        // messages are received until the _subscription count_ in the responses reach zero.
-        let mut received_unsub = false;
-        let mut received_punsub = false;
-        loop {
-            let res: (Vec<u8>, (), isize) = from_redis_value(&self.con.recv_response()?)?;
-
-            match res.0.first().map(|v| *v) {
-                Some(b'u') => received_unsub = true,
-                Some(b'p') => received_punsub = true,
-                _ => (),
-            }
-
-            if received_unsub && received_punsub && res.2 == 0 {
-                break;
-            }
-        }
-
-        // Finally, the connection is back in its normal state since all subscriptions were
-        // cancelled *and* all unsubscribe messages were received.
-        Ok(self.con)
+impl<'a> Drop for PubSub<'a> {
+    fn drop(&mut self) {
+        let _ = self.con.exit_pubsub();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@
 //! # fn do_something() -> redis::RedisResult<()> {
 //! let client = try!(redis::Client::open("redis://127.0.0.1/"));
 //! let mut con = try!(client.get_connection());
-//! let mut pubsub = con.as_pubsub();
+//! let mut pubsub = con.pubsub();
 //! try!(pubsub.subscribe("channel_1"));
 //! try!(pubsub.subscribe("channel_2"));
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@
 //! # fn do_something() -> redis::RedisResult<()> {
 //! let client = try!(redis::Client::open("redis://127.0.0.1/"));
 //! let mut con = try!(client.get_connection());
-//! let mut pubsub = con.pubsub();
+//! let mut pubsub = con.as_pubsub();
 //! try!(pubsub.subscribe("channel_1"));
 //! try!(pubsub.subscribe("channel_2"));
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,8 @@
 //! ```rust,no_run
 //! # fn do_something() -> redis::RedisResult<()> {
 //! let client = try!(redis::Client::open("redis://127.0.0.1/"));
-//! let mut pubsub = try!(client.get_pubsub());
+//! let mut con = try!(client.get_connection());
+//! let mut pubsub = con.as_pubsub();
 //! try!(pubsub.subscribe("channel_1"));
 //! try!(pubsub.subscribe("channel_2"));
 //!
@@ -329,7 +330,7 @@ pub use script::{Script, ScriptInvocation};
 pub use connection::{Connection, ConnectionLike, ConnectionInfo, ConnectionAddr,
                      IntoConnectionInfo, PubSub, Msg, transaction, parse_redis_url};
 pub use cmd::{cmd, Cmd, pipe, Pipeline, Iter, pack_command};
-pub use commands::{Commands, PipelineCommands};
+pub use commands::{Commands, PipelineCommands, PubSubCommands, ControlFlow};
 
 pub use types::{
     /* low level values */


### PR DESCRIPTION
Originally, pubsub support as only available only by creating a client
and then asking for a pubsub API. The original `PubSub` type owned a
connection. This neatly avoided the issue that only certain commands are
available once calling subscribe or psubscribe; however, it's very
unfriendly to connection poolers such as r2d2

This commit makes it so that a borrowed connection may be used for
PubSub. Available commands are limited while in pubsub mode by borring
the connection mutably into a type that only exposes the allowed
commands. This API may be accessed by calling `as_pubsub` on a
`Connection`. To go back to being able to use *any* command, this
wrapper type may be dropped, and the connection should become usable
again for other purposes.

Additionally, convenience methods are added to `Connection`: `subscribe`
and `psubscribe`. They accept a `ToRedisArgs` and a closure which will
be called every time a message is received. The subscription status can
be managed via the return value of the closure which is either
`ControlFlow::Continue` or `ControlFlow::Break`.

This is a breaking change; the original PubSub type was removed in favor
of this more flexible API and to avoid code bloat by having multiple
implementations or additional abstractions to allow an implementation to
be shared.

Resolves #135.