### PR TITLE
Use the bencher library to let benchmarks build on stable 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,9 @@ unix_socket = { version = "0.5.0", optional = true }
 [dev-dependencies]
 rand = "0.3"
 net2 = "0.2"
+bencher = "0.1"
+
+[[bench]]
+name = "bench_basic"
+harness = false
+

--- a/benches/bench_basic.rs
+++ b/benches/bench_basic.rs
@@ -1,14 +1,13 @@
-#![feature(test)]
-extern crate test;
 extern crate redis;
+#[macro_use]
+extern crate bencher;
 
-use test::Bencher;
+use bencher::Bencher;
 
 fn get_client() -> redis::Client {
     redis::Client::open("redis://127.0.0.1:6379").unwrap()
 }
 
-#[bench]
 fn bench_simple_getsetdel(b: &mut Bencher) {
     let client = get_client();
     let con = client.get_connection().unwrap();
@@ -21,7 +20,6 @@ fn bench_simple_getsetdel(b: &mut Bencher) {
     });
 }
 
-#[bench]
 fn bench_simple_getsetdel_pipeline(b: &mut Bencher) {
     let client = get_client();
     let con = client.get_connection().unwrap();
@@ -43,7 +41,6 @@ fn bench_simple_getsetdel_pipeline(b: &mut Bencher) {
     });
 }
 
-#[bench]
 fn bench_simple_getsetdel_pipeline_precreated(b: &mut Bencher) {
     let client = get_client();
     let con = client.get_connection().unwrap();
@@ -63,3 +60,12 @@ fn bench_simple_getsetdel_pipeline_precreated(b: &mut Bencher) {
         let _: (usize,) = pipe.query(&con).unwrap();
     });
 }
+
+
+benchmark_group!(
+    bench,
+    bench_simple_getsetdel,
+    bench_simple_getsetdel_pipeline,
+    bench_simple_getsetdel_pipeline_precreated
+);
+benchmark_main!(bench);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,11 +1,5 @@
 #![macro_use]
 
-macro_rules! ensure {
-    ($expr:expr, $err_result:expr) => (
-        if !($expr) { return $err_result; }
-    )
-}
-
 macro_rules! fail {
     ($expr:expr) => (
         return Err(::std::convert::From::from($expr));


### PR DESCRIPTION
https://github.com/bluss/bencher/ is just a port of the builtin benchmark library which can be used on stable rust.