### PR TITLE
perf: Avoid allocating some redundant Vec's during encoding

### DIFF
--- a/benches/bench_basic.rs
+++ b/benches/bench_basic.rs
@@ -4,6 +4,8 @@ extern crate bencher;
 
 use bencher::Bencher;
 
+use redis::PipelineCommands;
+
 fn get_client() -> redis::Client {
     redis::Client::open("redis://127.0.0.1:6379").unwrap()
 }
@@ -61,11 +63,26 @@ fn bench_simple_getsetdel_pipeline_precreated(b: &mut Bencher) {
     });
 }
 
+fn bench_long_pipeline(b: &mut Bencher) {
+    let client = get_client();
+    let con = client.get_connection().unwrap();
+    let mut pipe = redis::pipe();
+
+    for _ in 0..1_000 {
+        pipe.set("foo", "bar").ignore();
+    }
+
+    b.iter(|| {
+        let _: () = pipe.query(&con).unwrap();
+    });
+}
+
 
 benchmark_group!(
     bench,
     bench_simple_getsetdel,
     bench_simple_getsetdel_pipeline,
-    bench_simple_getsetdel_pipeline_precreated
+    bench_simple_getsetdel_pipeline_precreated,
+    bench_long_pipeline
 );
 benchmark_main!(bench);

--- a/benches/bench_basic.rs
+++ b/benches/bench_basic.rs
@@ -88,12 +88,25 @@ fn bench_encode_pipeline(b: &mut Bencher) {
     });
 }
 
+fn bench_encode_pipeline_nested(b: &mut Bencher) {
+    b.iter(|| {
+        let mut pipe = redis::pipe();
+
+        for _ in 0..200 {
+            pipe.set("foo", ("bar", 123, b"1231279712", &["test", "test", "test"][..])).ignore();
+        }
+        pipe
+    });
+}
+
+
 benchmark_group!(
     bench,
     bench_simple_getsetdel,
     bench_simple_getsetdel_pipeline,
     bench_simple_getsetdel_pipeline_precreated,
     bench_long_pipeline,
-    bench_encode_pipeline
+    bench_encode_pipeline,
+    bench_encode_pipeline_nested
 );
 benchmark_main!(bench);

--- a/benches/bench_basic.rs
+++ b/benches/bench_basic.rs
@@ -77,12 +77,23 @@ fn bench_long_pipeline(b: &mut Bencher) {
     });
 }
 
+fn bench_encode_pipeline(b: &mut Bencher) {
+    b.iter(|| {
+        let mut pipe = redis::pipe();
+
+        for _ in 0..1_000 {
+            pipe.set("foo", "bar").ignore();
+        }
+        pipe
+    });
+}
 
 benchmark_group!(
     bench,
     bench_simple_getsetdel,
     bench_simple_getsetdel_pipeline,
     bench_simple_getsetdel_pipeline_precreated,
-    bench_long_pipeline
+    bench_long_pipeline,
+    bench_encode_pipeline
 );
 benchmark_main!(bench);

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -198,7 +198,9 @@ impl Cmd {
     /// ```
     #[inline]
     pub fn arg<T: ToRedisArgs>(&mut self, arg: T) -> &mut Cmd {
-        for item in arg.to_redis_args().into_iter() {
+        let mut out = Vec::new();
+        arg.write_redis_args(&mut out);
+        for item in out {
             self.args.push(Arg::Simple(item));
         }
         self

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -93,7 +93,9 @@ fn bulklen(len: usize) -> usize {
     return 1 + countdigits(len) + 2 + len + 2;
 }
 
-fn encode_command(args: &Vec<Arg>, cursor: u64) -> Vec<u8> {
+fn encode_command(args: &[Arg], cursor: u64) -> Vec<u8> {
+    use std::io::Write;
+
     let mut totlen = 1 + countdigits(args.len()) + 2;
     for item in args {
         totlen += bulklen(match *item {
@@ -104,17 +106,11 @@ fn encode_command(args: &Vec<Arg>, cursor: u64) -> Vec<u8> {
     }
 
     let mut cmd = Vec::with_capacity(totlen);
-    cmd.push('*' as u8);
-    cmd.extend(args.len().to_string().as_bytes());
-    cmd.push('\r' as u8);
-    cmd.push('\n' as u8);
+    write!(cmd, "*{}\r\n", args.len()).unwrap();
 
     {
         let mut encode = |item: &[u8]| {
-            cmd.push('$' as u8);
-            cmd.extend(item.len().to_string().as_bytes());
-            cmd.push('\r' as u8);
-            cmd.push('\n' as u8);
+            write!(cmd, "${}\r\n", item.len()).unwrap();
             cmd.extend(item.iter());
             cmd.push('\r' as u8);
             cmd.push('\n' as u8);
@@ -524,7 +520,7 @@ pub fn cmd<'a>(name: &'a str) -> Cmd {
 /// assert_eq!(cmd, b"*3\r\n$3\r\nSET\r\n$6\r\nmy_key\r\n$2\r\n42\r\n".to_vec());
 /// ```
 pub fn pack_command(args: &[Vec<u8>]) -> Vec<u8> {
-    encode_command(&args.iter().map(|x| Arg::Borrowed(x)).collect(), 0)
+    encode_command(&args.iter().map(|x| Arg::Borrowed(x)).collect::<Vec<_>>(), 0)
 }
 
 /// Shortcut for creating a new pipeline.

--- a/src/script.rs
+++ b/src/script.rs
@@ -103,7 +103,7 @@ impl<'a> ScriptInvocation<'a> {
     pub fn arg<'b, T: ToRedisArgs>(&'b mut self, arg: T) -> &'b mut ScriptInvocation<'a>
         where 'a: 'b
     {
-        self.args.extend(arg.to_redis_args().into_iter());
+        arg.write_redis_args(&mut self.args);
         self
     }
 
@@ -113,7 +113,7 @@ impl<'a> ScriptInvocation<'a> {
     pub fn key<'b, T: ToRedisArgs>(&'b mut self, key: T) -> &'b mut ScriptInvocation<'a>
         where 'a: 'b
     {
-        self.keys.extend(key.to_redis_args().into_iter());
+        key.write_redis_args(&mut self.keys);
         self
     }
 


### PR DESCRIPTION
A couple of small and simple performance improvements I could do easily while looking through the code. There is definitely more that could be done here towards avoiding allocations but I didn't want to get sidetracked any further and that will be easier to build on top of the `&mut Vec` style as well.

```
 name                                        before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 bench_encode_pipeline                       498,750         515,194              16,444    3.30%   x 0.97
 bench_encode_pipeline_nested                329,036         225,092            -103,944  -31.59%   x 1.46
 bench_long_pipeline                         1,819,621       1,697,848          -121,773   -6.69%   x 1.07
 bench_simple_getsetdel                      89,985          90,718                  733    0.81%   x 0.99
 bench_simple_getsetdel_pipeline             35,303          35,811                  508    1.44%   x 0.99
 bench_simple_getsetdel_pipeline_precreated  34,209          33,526                 -683   -2.00%   x 1.02
```