### PR TITLE
Add an async interface using futures-rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 
 script:
   - make test
+  - cargo check --benches
 
 notifications:
   email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ build = "build.rs"
 [features]
 with-rustc-json = ["rustc-serialize"]
 with-unix-sockets = ["unix_socket"]
+# with-async-unix-sockets = ["tokio-uds"]
 with-system-unix-sockets = []
 
 [dependencies]
@@ -26,11 +27,21 @@ sha1 = ">= 0.2, < 0.7"
 url = "1.2"
 rustc-serialize = { version = "0.3.16", optional = true }
 unix_socket = { version = "0.5.0", optional = true }
+net2 = "0.2"
+combine = "3.0.0"
+futures = "0.1"
+tokio-reactor = "0.1"
+tokio-tcp = "0.1"
+tokio-io = "0.1"
+# tokio-uds = { git = "https://github.com/Marwes/tokio-uds", branch = "only_tokio_upgrade", optional = true }
 
 [dev-dependencies]
 rand = "0.4"
 net2 = "0.2"
 bencher = "0.1"
+partial-io = { version = "0.3", features = ["tokio", "quickcheck"] }
+quickcheck = "0.6"
+tokio = "0.1"
 
 [[bench]]
 name = "bench_basic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ build = "build.rs"
 
 [features]
 with-rustc-json = ["rustc-serialize"]
-with-unix-sockets = ["unix_socket"]
-# with-async-unix-sockets = ["tokio-uds"]
+with-unix-sockets = ["unix_socket", "tokio-uds"]
 with-system-unix-sockets = []
 
 [dependencies]
@@ -33,7 +32,7 @@ futures = "0.1"
 tokio-reactor = "0.1"
 tokio-tcp = "0.1"
 tokio-io = "0.1"
-# tokio-uds = { git = "https://github.com/Marwes/tokio-uds", branch = "only_tokio_upgrade", optional = true }
+tokio-uds = { version = "0.2", optional = true }
 
 [dev-dependencies]
 rand = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,8 @@ sha1 = ">= 0.2, < 0.7"
 url = "1.2"
 rustc-serialize = { version = "0.3.16", optional = true }
 unix_socket = { version = "0.5.0", optional = true }
-net2 = "0.2"
 combine = "3.0.0"
 futures = "0.1"
-tokio-reactor = "0.1"
 tokio-tcp = "0.1"
 tokio-io = "0.1"
 tokio-uds = { version = "0.2", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	@REDISRS_SERVER_TYPE=tcp RUST_TEST_THREADS=1 cargo test --features="with-rustc-json"
 	@echo "Testing Connection Type UNIX"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix cargo test --features="with-rustc-json"
+	@REDISRS_SERVER_TYPE=unix cargo test --features="with-rustc-json" --test parser --test test_basic --test test_types
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="

--- a/src/async.rs
+++ b/src/async.rs
@@ -1,0 +1,290 @@
+use std::fmt::Arguments;
+use std::io::{self, BufReader, Read, Write};
+use std::mem;
+use std::net::{SocketAddr, ToSocketAddrs};
+
+use net2::TcpBuilder;
+
+#[cfg(feature = "with-async-unix-sockets")]
+use tokio_uds::UnixStream;
+
+use tokio_io::{self, AsyncWrite};
+use tokio_reactor;
+use tokio_tcp::TcpStream;
+
+use futures::future::Either;
+use futures::{future, Async, Future, Poll};
+
+use cmd::cmd;
+use types::{ErrorKind, RedisError, RedisFuture, Value};
+
+use connection::{ConnectionAddr, ConnectionInfo};
+
+enum ActualConnection {
+    Tcp(BufReader<TcpStream>),
+    #[cfg(feature = "with-async-unix-sockets")]
+    Unix(BufReader<UnixStream>),
+}
+
+struct WriteWrapper<T>(BufReader<T>);
+
+impl<T> Write for WriteWrapper<T>
+where
+    T: Read + Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.get_mut().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.get_mut().flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.get_mut().write_all(buf)
+    }
+    fn write_fmt(&mut self, fmt: Arguments) -> io::Result<()> {
+        self.0.get_mut().write_fmt(fmt)
+    }
+}
+
+impl<T> AsyncWrite for WriteWrapper<T>
+where
+    T: Read + AsyncWrite,
+{
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        self.0.get_mut().shutdown()
+    }
+}
+
+/// Represents a stateful redis TCP connection.
+pub struct Connection {
+    con: ActualConnection,
+    db: i64,
+}
+
+macro_rules! with_connection {
+    ($con:expr, $f:expr) => {
+        match $con {
+            #[cfg(not(feature = "with-async-unix-sockets"))]
+            ActualConnection::Tcp(con) => {
+                $f(con).map(|(con, value)| (ActualConnection::Tcp(con), value))
+            }
+
+            #[cfg(feature = "with-async-unix-sockets")]
+            ActualConnection::Tcp(con) => {
+                Either::A($f(con).map(|(con, value)| (ActualConnection::Tcp(con), value)))
+            }
+            #[cfg(feature = "with-async-unix-sockets")]
+            ActualConnection::Unix(con) => {
+                Either::B($f(con).map(|(con, value)| (ActualConnection::Unix(con), value)))
+            }
+        }
+    };
+}
+
+macro_rules! with_write_connection {
+    ($con:expr, $f:expr) => {
+        match $con {
+            #[cfg(not(feature = "with-async-unix-sockets"))]
+            ActualConnection::Tcp(con) => {
+                $f(WriteWrapper(con)).map(|(con, value)| (ActualConnection::Tcp(con.0), value))
+            }
+
+            #[cfg(feature = "with-async-unix-sockets")]
+            ActualConnection::Tcp(con) => Either::A(
+                $f(WriteWrapper(con)).map(|(con, value)| (ActualConnection::Tcp(con.0), value)),
+            ),
+            #[cfg(feature = "with-async-unix-sockets")]
+            ActualConnection::Unix(con) => Either::B(
+                $f(WriteWrapper(con))
+                    .map(|(con, value)| (ActualConnection::Unix(con.0), value)),
+            ),
+        }
+    };
+}
+
+impl Connection {
+    pub fn read_response(self) -> RedisFuture<(Self, Value)> {
+        let db = self.db;
+        Box::new(
+            with_connection!(self.con, ::parser::parse_async).then(move |result| {
+                match result {
+                    Ok((con, value)) => Ok((Connection { con: con, db }, value)),
+                    Err(err) => {
+                        // TODO Do we need to shutdown here as we do in the sync version?
+                        Err(err)
+                    }
+                }
+            }),
+        )
+    }
+}
+
+pub fn connect(
+    connection_info: ConnectionInfo,
+    handle: &tokio_reactor::Handle,
+) -> RedisFuture<Connection> {
+    let connection = match *connection_info.addr {
+        ConnectionAddr::Tcp(ref host, port) => {
+            let socket_addr = match (&host[..], port).to_socket_addrs() {
+                Ok(mut socket_addrs) => match socket_addrs.next() {
+                    Some(socket_addr) => socket_addr,
+                    None => {
+                        return Box::new(future::err(RedisError::from((
+                            ErrorKind::InvalidClientConfig,
+                            "No address found for host",
+                        ))))
+                    }
+                },
+                Err(err) => return Box::new(future::err(err.into())),
+            };
+
+            let stream_result = (|| -> io::Result<_> {
+                let builder = match socket_addr {
+                    SocketAddr::V4(_) => TcpBuilder::new_v4()?,
+                    SocketAddr::V6(_) => TcpBuilder::new_v6()?,
+                };
+                Ok(builder.to_tcp_stream()?)
+            })();
+            let stream = match stream_result {
+                Ok(stream) => stream,
+                Err(err) => return Box::new(future::err(err.into())),
+            };
+            Either::A(
+                TcpStream::connect_std(stream, &socket_addr, handle)
+                    .from_err()
+                    .map(|con| ActualConnection::Tcp(BufReader::new(con))),
+            )
+        }
+        #[cfg(feature = "with-async-unix-sockets")]
+        ConnectionAddr::Unix(ref path) => {
+            let result = UnixStream::connect(path)
+                .map(|stream| ActualConnection::Unix(BufReader::new(stream)));
+            Either::B(future::result(result))
+        }
+        #[cfg(not(feature = "with-async-unix-sockets"))]
+        ConnectionAddr::Unix(_) => Either::B(future::err(RedisError::from((
+            ErrorKind::InvalidClientConfig,
+            "Cannot connect to unix sockets \
+             on this platform",
+        )))),
+    };
+
+    Box::new(connection.from_err().and_then(move |con| {
+        let rv = Connection {
+            con,
+            db: connection_info.db,
+        };
+
+        let login = match connection_info.passwd {
+            Some(ref passwd) => {
+                Either::A(cmd("AUTH").arg(&**passwd).query_async::<_, Value>(rv).then(
+                    |x| match x {
+                        Ok((rv, Value::Okay)) => Ok(rv),
+                        _ => {
+                            fail!((
+                                ErrorKind::AuthenticationFailed,
+                                "Password authentication failed"
+                            ));
+                        }
+                    },
+                ))
+            }
+            None => Either::B(future::ok(rv)),
+        };
+
+        login.and_then(move |rv| {
+            if connection_info.db != 0 {
+                Either::A(
+                    cmd("SELECT")
+                        .arg(connection_info.db)
+                        .query_async::<_, Value>(rv)
+                        .then(|result| match result {
+                            Ok((rv, Value::Okay)) => Ok(rv),
+                            _ => fail!((
+                                ErrorKind::ResponseError,
+                                "Redis server refused to switch database"
+                            )),
+                        }),
+                )
+            } else {
+                Either::B(future::ok(rv))
+            }
+        })
+    }))
+}
+
+pub trait ConnectionLike: Sized {
+    /// Sends an already encoded (packed) command into the TCP socket and
+    /// reads the single response from it.
+    fn req_packed_command(self, cmd: Vec<u8>) -> RedisFuture<(Self, Value)>;
+
+    /// Sends multiple already encoded (packed) command into the TCP socket
+    /// and reads `count` responses from it.  This is used to implement
+    /// pipelining.
+    fn req_packed_commands(
+        self,
+        cmd: Vec<u8>,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<(Self, Vec<Value>)>;
+
+    /// Returns the database this connection is bound to.  Note that this
+    /// information might be unreliable because it's initially cached and
+    /// also might be incorrect if the connection like object is not
+    /// actually connected.
+    fn get_db(&self) -> i64;
+}
+
+impl ConnectionLike for Connection {
+    fn req_packed_command(self, cmd: Vec<u8>) -> RedisFuture<(Self, Value)> {
+        let db = self.db;
+        Box::new(
+            with_write_connection!(self.con, |con| tokio_io::io::write_all(con, cmd))
+                .from_err()
+                .and_then(move |(con, _)| Connection { con, db }.read_response()),
+        )
+    }
+
+    fn req_packed_commands(
+        self,
+        cmd: Vec<u8>,
+        offset: usize,
+        count: usize,
+    ) -> RedisFuture<(Self, Vec<Value>)> {
+        let db = self.db;
+        Box::new(
+            with_write_connection!(self.con, |con| tokio_io::io::write_all(con, cmd))
+                .from_err()
+                .and_then(move |(con, _)| {
+                    let mut con = Some(Connection { con, db });
+                    let mut rv = vec![];
+                    let mut future = None;
+                    let mut idx = 0;
+                    future::poll_fn(move || {
+                        while idx < offset + count {
+                            if future.is_none() {
+                                future = Some(con.take().unwrap().read_response());
+                            }
+                            let (con2, item) = try_ready!(future.as_mut().unwrap().poll());
+                            con = Some(con2);
+                            future = None;
+
+                            if idx >= offset {
+                                rv.push(item);
+                            }
+                            idx += 1;
+                        }
+                        Ok(Async::Ready((
+                            con.take().unwrap(),
+                            mem::replace(&mut rv, Vec::new()),
+                        )))
+                    })
+                }),
+        )
+    }
+
+    fn get_db(&self) -> i64 {
+        self.db
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
-use connection::{ConnectionInfo, IntoConnectionInfo, Connection, connect, ConnectionLike};
-use types::{RedisResult, Value};
+use connection::{connect, Connection, ConnectionInfo, ConnectionLike, IntoConnectionInfo};
+use types::{RedisFuture, RedisResult, Value};
 
+use tokio_reactor;
 
 /// The client type.
 #[derive(Debug, Clone)]
@@ -29,7 +30,9 @@ impl Client {
     /// actually open a connection yet but it does perform some basic
     /// checks on the URL that might make the operation fail.
     pub fn open<T: IntoConnectionInfo>(params: T) -> RedisResult<Client> {
-        Ok(Client { connection_info: try!(params.into_connection_info()) })
+        Ok(Client {
+            connection_info: try!(params.into_connection_info()),
+        })
     }
 
     /// Instructs the client to actually connect to redis and returns a
@@ -40,6 +43,17 @@ impl Client {
     pub fn get_connection(&self) -> RedisResult<Connection> {
         Ok(try!(connect(&self.connection_info)))
     }
+
+    pub fn get_async_connection(&self) -> RedisFuture<::async::Connection> {
+        self.get_async_connection_handle(&tokio_reactor::Handle::current())
+    }
+
+    pub fn get_async_connection_handle(
+        &self,
+        handle: &tokio_reactor::Handle,
+    ) -> RedisFuture<::async::Connection> {
+        ::async::connect(self.connection_info.clone(), handle)
+    }
 }
 
 impl ConnectionLike for Client {
@@ -47,11 +61,12 @@ impl ConnectionLike for Client {
         try!(self.get_connection()).req_packed_command(cmd)
     }
 
-    fn req_packed_commands(&self,
-                           cmd: &[u8],
-                           offset: usize,
-                           count: usize)
-                           -> RedisResult<Vec<Value>> {
+    fn req_packed_commands(
+        &self,
+        cmd: &[u8],
+        offset: usize,
+        count: usize,
+    ) -> RedisResult<Vec<Value>> {
         try!(self.get_connection()).req_packed_commands(cmd, offset, count)
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,8 +1,6 @@
 use connection::{connect, Connection, ConnectionInfo, ConnectionLike, IntoConnectionInfo};
 use types::{RedisFuture, RedisResult, Value};
 
-use tokio_reactor;
-
 /// The client type.
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -45,14 +43,7 @@ impl Client {
     }
 
     pub fn get_async_connection(&self) -> RedisFuture<::async::Connection> {
-        self.get_async_connection_handle(&tokio_reactor::Handle::current())
-    }
-
-    pub fn get_async_connection_handle(
-        &self,
-        handle: &tokio_reactor::Handle,
-    ) -> RedisFuture<::async::Connection> {
-        ::async::connect(self.connection_info.clone(), handle)
+        ::async::connect(self.connection_info.clone())
     }
 }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -165,7 +165,7 @@ struct TcpConnection {
     open: bool,
 }
 
-#[cfg(any(feature="with-unix-sockets", feature="with-system-unix-sockets"))]
+#[cfg(any(feature = "with-unix-sockets", feature = "with-system-unix-sockets"))]
 struct UnixConnection {
     sock: BufReader<UnixStream>,
     open: bool,
@@ -232,7 +232,11 @@ impl ActualConnection {
     pub fn send_bytes(&mut self, bytes: &[u8]) -> RedisResult<Value> {
         match *self {
             ActualConnection::Tcp(ref mut connection) => {
-                let res = connection.reader.get_mut().write_all(bytes).map_err(|e| RedisError::from(e));
+                let res = connection
+                    .reader
+                    .get_mut()
+                    .write_all(bytes)
+                    .map_err(|e| RedisError::from(e));
                 match res {
                     Err(e) => {
                         if e.is_connection_dropped() {
@@ -240,7 +244,7 @@ impl ActualConnection {
                         }
                         Err(e)
                     }
-                    Ok(_) => Ok(Value::Okay)
+                    Ok(_) => Ok(Value::Okay),
                 }
             }
             #[cfg(any(feature = "with-unix-sockets", feature = "with-system-unix-sockets"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -376,7 +376,7 @@ extern crate tokio_tcp;
 
 #[cfg(feature = "with-rustc-json")]
 pub extern crate rustc_serialize as serialize;
-#[cfg(feature = "with-async-unix-sockets")]
+#[cfg(feature = "with-unix-sockets")]
 extern crate tokio_uds;
 #[cfg(feature = "with-unix-sockets")]
 extern crate unix_socket;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,7 @@
 //!
 //! Because redis inherently is mostly type-less and the protocol is not
 //! exactly friendly to developers, this library provides flexible support
-//! for casting values to the intended results.  This is driven through the
-//! `FromRedisValue` and `ToRedisArgs` traits.
+//! for casting values to the intended results.  This is driven through the `FromRedisValue` and `ToRedisArgs` traits.
 //!
 //! The `arg` method of the command will accept a wide range of types through
 //! the `ToRedisArgs` trait and the `query` method of a command can convert the
@@ -302,6 +301,56 @@
 //! # Ok(()) }
 //! ```
 //!
+//! # Async
+//!
+//! In addition to the synchronous interface that's been explained above there also exists an
+//! asynchronous interface based on [`futures`][] and [`tokio`][].
+//!
+//! This interface exists under the `async` module and largely mirrors the synchronous with a few
+//! concessions to make it fit the constraints of `futures`.
+//!
+//! ```rust,no_run
+//! extern crate redis;
+//! extern crate futures;
+//! extern crate tokio;
+//!
+//! use tokio::executor::current_thread::block_on_all;
+//!
+//! use futures::Future;
+//!
+//! # fn main() {
+//! let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+//! let connect = client.get_async_connection();
+//!
+//! block_on_all(connect.and_then(|con| {
+//!     redis::cmd("SET")
+//!         .arg("key1")
+//!         .arg(b"foo")
+//!         // `query_async` acts in the same way as `query` but requires the connection to be
+//!         // taken by value as the method returns a `Future` instead of `Result`.
+//!         // This connection will be returned after the future has been completed allowing it to
+//!         // be used again.
+//!         .query_async(con)
+//!         .and_then(|(con, ())| {
+//!             redis::cmd("SET").arg(&["key2", "bar"]).query_async(con)
+//!         })
+//!         .and_then(|(con, ())| {
+//!             redis::cmd("MGET")
+//!                 .arg(&["key1", "key2"])
+//!                 .query_async(con)
+//!                 .map(|t| t.1)
+//!         })
+//!         .then(|result| {
+//!             assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
+//!             result
+//!         })
+//! })).unwrap();
+//! # }
+//! ```
+//!
+//! [`futures`]:https://crates.io/crates/futures
+//! [`tokio`]:https://tokio.rs
+//!
 //! ## Breaking Changes
 //!
 //! In Rust 0.5.0 the semi-internal `ConnectionInfo` struct had to be
@@ -311,56 +360,70 @@
 
 #![deny(non_camel_case_types)]
 
-extern crate url;
+#[macro_use]
+extern crate combine;
 extern crate sha1;
+extern crate url;
 
-#[cfg(feature="with-rustc-json")]
+extern crate net2;
+
+#[macro_use]
+extern crate futures;
+#[macro_use]
+extern crate tokio_io;
+extern crate tokio_reactor;
+extern crate tokio_tcp;
+
+#[cfg(feature = "with-rustc-json")]
 pub extern crate rustc_serialize as serialize;
-#[cfg(feature="with-unix-sockets")]
+#[cfg(feature = "with-async-unix-sockets")]
+extern crate tokio_uds;
+#[cfg(feature = "with-unix-sockets")]
 extern crate unix_socket;
 
 #[doc(hidden)]
-#[cfg(feature="with-rustc-json")]
+#[cfg(feature = "with-rustc-json")]
 pub use serialize::json::Json;
 
 // public api
-pub use parser::{parse_redis_value, Parser};
 pub use client::Client;
+pub use cmd::{cmd, pack_command, pipe, Cmd, Iter, Pipeline};
+pub use commands::{Commands, ControlFlow, PipelineCommands, PubSubCommands};
+pub use connection::{parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo,
+                     ConnectionLike, IntoConnectionInfo, Msg, PubSub};
+pub use parser::{parse_async, parse_redis_value, Parser};
 pub use script::{Script, ScriptInvocation};
-pub use connection::{Connection, ConnectionLike, ConnectionInfo, ConnectionAddr,
-                     IntoConnectionInfo, PubSub, Msg, transaction, parse_redis_url};
-pub use cmd::{cmd, Cmd, pipe, Pipeline, Iter, pack_command};
-pub use commands::{Commands, PipelineCommands, PubSubCommands, ControlFlow};
 
-pub use types::{
-    /* low level values */
-    Value,
+pub use types::{// utility functions
+                from_redis_value,
 
-    /* error and result types */
-    RedisError,
-    RedisResult,
+                // error kinds
+                ErrorKind,
 
-    /* error kinds */
-    ErrorKind,
+                // conversion traits
+                FromRedisValue,
 
-    /* utility types */
-    InfoDict,
-    NumericBehavior,
+                // utility types
+                InfoDict,
+                NumericBehavior,
 
-    /* conversion traits */
-    FromRedisValue,
-    ToRedisArgs,
+                // error and result types
+                RedisError,
+                RedisFuture,
+                RedisResult,
+                ToRedisArgs,
 
-    /* utility functions */
-    from_redis_value,
-};
+                // low level values
+                Value};
 
 mod macros;
 
-mod parser;
+pub mod async;
+
 mod client;
-mod connection;
-mod types;
-mod script;
 mod cmd;
 mod commands;
+mod connection;
+mod parser;
+mod script;
+mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,13 +365,10 @@ extern crate combine;
 extern crate sha1;
 extern crate url;
 
-extern crate net2;
-
 #[macro_use]
 extern crate futures;
 #[macro_use]
 extern crate tokio_io;
-extern crate tokio_reactor;
 extern crate tokio_tcp;
 
 #[cfg(feature = "with-rustc-json")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,16 +1,18 @@
 #![macro_use]
 
 macro_rules! fail {
-    ($expr:expr) => (
+    ($expr:expr) => {
         return Err(::std::convert::From::from($expr));
-    )
+    };
 }
 
 macro_rules! unwrap_or {
-    ($expr:expr, $or:expr) => (
+    ($expr:expr, $or:expr) => {
         match $expr {
             Some(x) => x,
-            None => { $or; }
+            None => {
+                $or;
+            }
         }
-    )
+    };
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,234 @@
-use std::io::{Read, BufReader};
+use std::io::{BufRead, BufReader};
+use std::str;
 
-use types::{RedisResult, Value, ErrorKind, make_extension_error};
+use types::{make_extension_error, ErrorKind, RedisError, RedisResult, Value};
 
+use futures::{Async, Future, Poll};
+use tokio_io::AsyncRead;
+
+use combine;
+use combine::byte::{byte, crlf, newline};
+use combine::combinator::{any_partial_state, AnyPartialState};
+#[allow(unused_imports)] // See https://github.com/rust-lang/rust/issues/43970
+use combine::error::StreamError;
+use combine::parser::choice::choice;
+use combine::range::{recognize, take, take_until_range};
+use combine::stream::{RangeStream, StreamErrorFor};
+
+struct ResultExtend<T, E>(Result<T, E>);
+
+impl<T, E> Default for ResultExtend<T, E>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        ResultExtend(Ok(T::default()))
+    }
+}
+
+impl<T, U, E> Extend<Result<U, E>> for ResultExtend<T, E>
+where
+    T: Extend<U>,
+{
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = Result<U, E>>,
+    {
+        let mut returned_err = None;
+        match self.0 {
+            Ok(ref mut elems) => elems.extend(iter.into_iter().scan((), |_, item| match item {
+                Ok(item) => Some(item),
+                Err(err) => {
+                    returned_err = Some(err);
+                    None
+                }
+            })),
+            Err(_) => (),
+        }
+        if let Some(err) = returned_err {
+            self.0 = Err(err);
+        }
+    }
+}
+
+parser!{
+    type PartialState = AnyPartialState;
+    fn value['a, I]()(I) -> RedisResult<Value>
+        where [I: RangeStream<Item = u8, Range = &'a [u8]> ]
+    {
+        let end_of_line: fn () -> _ = || crlf().or(newline());
+        let line = || recognize(take_until_range(&b"\r\n"[..]).with(end_of_line()))
+            .and_then(|line: &[u8]| {
+                str::from_utf8(line)
+                    .map(|line| line.trim_right_matches(|c: char| c == '\r' || c == '\n'))
+                    .map_err(StreamErrorFor::<I>::other)
+            });
+
+        let status = || line().map(|line| {
+            if line == "OK" {
+                Value::Okay
+            } else {
+                Value::Status(line.into())
+            }
+        });
+
+        let int = || line().and_then(|line| {
+            match line.trim().parse::<i64>() {
+                Err(_) => Err(StreamErrorFor::<I>::message_static_message("Expected integer, got garbage")),
+                Ok(value) => Ok(value),
+            }
+        });
+
+        let data = || int().then_partial(move |size| {
+            if *size < 0 {
+                combine::value(Value::Nil).left()
+            } else {
+                take(*size as usize)
+                    .map(|bs: &[u8]| Value::Data(bs.to_vec()))
+                    .skip(end_of_line())
+                    .right()
+            }
+        });
+
+        let bulk = || {
+            int().then_partial(|&mut length| {
+                if length < 0 {
+                    combine::value(Value::Nil).map(Ok).left()
+                } else {
+                    let length = length as usize;
+                    combine::count_min_max(length, length, value()).map(|result: ResultExtend<_, _>| {
+                        result.0.map(Value::Bulk)
+                    }).right()
+                }
+            })
+        };
+
+        let error = || {
+            line()
+                .map(|line: &str| {
+                    let desc = "An error was signalled by the server";
+                    let mut pieces = line.splitn(2, ' ');
+                    let kind = match pieces.next().unwrap() {
+                        "ERR" => ErrorKind::ResponseError,
+                        "EXECABORT" => ErrorKind::ExecAbortError,
+                        "LOADING" => ErrorKind::BusyLoadingError,
+                        "NOSCRIPT" => ErrorKind::NoScriptError,
+                        code => {
+                            return make_extension_error(code, pieces.next())
+                        }
+                    };
+                    match pieces.next() {
+                        Some(detail) => RedisError::from((kind, desc, detail.to_string())),
+                        None => RedisError::from((kind, desc)),
+                    }
+                })
+        };
+
+        any_partial_state(choice((
+           byte(b'+').with(status().map(Ok)),
+           byte(b':').with(int().map(Value::Int).map(Ok)),
+           byte(b'$').with(data().map(Ok)),
+           byte(b'*').with(bulk()),
+           byte(b'-').with(error().map(Err))
+        )))
+    }
+}
+
+pub struct ValueFuture<R> {
+    reader: Option<R>,
+    state: AnyPartialState,
+    // Intermediate storage for data we know that we need to parse a value but we haven't been able
+    // to parse completely yet
+    remaining: Vec<u8>,
+}
+
+impl<R> Future for ValueFuture<R>
+where
+    R: BufRead,
+{
+    type Item = (R, Value);
+    type Error = RedisError;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            assert!(
+                self.reader.is_some(),
+                "ValueFuture: poll called on completed future"
+            );
+            let remaining_data = self.remaining.len();
+
+            let (opt, mut removed) = {
+                let buffer = try_nb!(self.reader.as_mut().unwrap().fill_buf());
+                if buffer.len() == 0 {
+                    fail!((ErrorKind::ResponseError, "Could not read enough bytes"))
+                }
+                let buffer = if !self.remaining.is_empty() {
+                    self.remaining.extend(buffer);
+                    &self.remaining[..]
+                } else {
+                    buffer
+                };
+                let stream = combine::easy::Stream(combine::stream::PartialStream(buffer));
+                match combine::stream::decode(value(), stream, &mut self.state) {
+                    Ok(x) => x,
+                    Err(err) => {
+                        let err = err.map_position(|pos| pos.translate_position(buffer))
+                            .map_range(|range| format!("{:?}", range))
+                            .to_string();
+                        return Err(RedisError::from((
+                            ErrorKind::ResponseError,
+                            "parse error",
+                            err,
+                        )));
+                    }
+                }
+            };
+
+            if !self.remaining.is_empty() {
+                // Remove the data we have parsed and adjust `removed` to be the amount of data we
+                // consumed from `self.reader`
+                self.remaining.drain(..removed);
+                if removed >= remaining_data {
+                    removed = removed - remaining_data;
+                } else {
+                    removed = 0;
+                }
+            }
+
+            match opt {
+                Some(value) => {
+                    self.reader.as_mut().unwrap().consume(removed);
+                    let reader = self.reader.take().unwrap();
+                    return Ok(Async::Ready((reader, value?)));
+                }
+                None => {
+                    // We have not enough data to produce a Value but we know that all the data of
+                    // the current buffer are necessary. Consume all the buffered data to ensure
+                    // that the next iteration actually reads more data.
+                    let buffer_len = {
+                        let buffer = try!(self.reader.as_mut().unwrap().fill_buf());
+                        if remaining_data == 0 {
+                            self.remaining.extend(&buffer[removed..]);
+                        }
+                        buffer.len()
+                    };
+                    self.reader.as_mut().unwrap().consume(buffer_len);
+                }
+            }
+        }
+    }
+}
+
+pub fn parse_async<R>(reader: R) -> ValueFuture<R>
+where
+    R: AsyncRead + BufRead,
+{
+    ValueFuture {
+        reader: Some(reader),
+        state: Default::default(),
+        remaining: Vec::new(),
+    }
+}
 
 /// The internal redis response parser.
 pub struct Parser<T> {
@@ -12,7 +239,7 @@ pub struct Parser<T> {
 /// you normally do not use this directly as it's already done for you by
 /// the client but in some more complex situations it might be useful to be
 /// able to parse the redis responses.
-impl<'a, T: Read> Parser<T> {
+impl<'a, T: BufRead> Parser<T> {
     /// Creates a new parser that parses the data behind the reader.  More
     /// than one value can be behind the reader in which case the parser can
     /// be invoked multiple times.  In other words: the stream does not have
@@ -23,162 +250,18 @@ impl<'a, T: Read> Parser<T> {
 
     // public api
 
-    /// parses a single value out of the stream.  If there are multiple
-    /// values you can call this multiple times.  If the reader is not yet
-    /// ready this will block.
     pub fn parse_value(&mut self) -> RedisResult<Value> {
-        let b = try!(self.read_byte());
-        match b as char {
-            '+' => self.parse_status(),
-            ':' => self.parse_int(),
-            '$' => self.parse_data(),
-            '*' => self.parse_bulk(),
-            '-' => self.parse_error(),
-            _ => fail!((ErrorKind::ResponseError, "Invalid response when parsing value")),
-        }
-    }
-
-    // internal helpers
-
-    #[inline]
-    fn expect_char(&mut self, refchar: char) -> RedisResult<()> {
-        if try!(self.read_byte()) as char == refchar {
-            Ok(())
-        } else {
-            fail!((ErrorKind::ResponseError, "Invalid byte in response"));
-        }
-    }
-
-    #[inline]
-    fn expect_newline(&mut self) -> RedisResult<()> {
-        match try!(self.read_byte()) as char {
-            '\n' => Ok(()),
-            '\r' => self.expect_char('\n'),
-            _ => fail!((ErrorKind::ResponseError, "Invalid byte in response")),
-        }
-    }
-
-    fn read_line(&mut self) -> RedisResult<Vec<u8>> {
-        let mut rv = vec![];
-
-        loop {
-            let b = try!(self.read_byte());
-            match b as char {
-                '\n' => {
-                    break;
-                }
-                '\r' => {
-                    try!(self.expect_char('\n'));
-                    break;
-                }
-                _ => rv.push(b),
-            };
-        }
-
-        Ok(rv)
-    }
-
-    fn read_string_line(&mut self) -> RedisResult<String> {
-        match String::from_utf8(try!(self.read_line())) {
-            Err(_) => fail!((ErrorKind::ResponseError, "Expected valid string, got garbage")),
-            Ok(value) => Ok(value),
-        }
-    }
-
-    fn read_byte(&mut self) -> RedisResult<u8> {
-        let buf: &mut [u8; 1] = &mut [0];
-        let nread = try!(self.reader.read(buf));
-
-        if nread < 1 {
-            fail!((ErrorKind::ResponseError, "Could not read enough bytes"))
-        } else {
-            Ok(buf[0])
-        }
-    }
-
-    fn read(&mut self, bytes: usize) -> RedisResult<Vec<u8>> {
-        let mut rv = vec![0; bytes];
-        let mut i = 0;
-        while i < bytes {
-            let res_nread = {
-                let ref mut buf = &mut rv[i..];
-                self.reader.read(buf)
-            };
-            match res_nread {
-                Ok(nread) if nread > 0 => i += nread,
-                Ok(_) => fail!((ErrorKind::ResponseError, "Could not read enough bytes")),
-                Err(e) => return Err(From::from(e)),
-            }
-        }
-        Ok(rv)
-    }
-
-    fn read_int_line(&mut self) -> RedisResult<i64> {
-        let line = try!(self.read_string_line());
-        match line.trim().parse::<i64>() {
-            Err(_) => fail!((ErrorKind::ResponseError, "Expected integer, got garbage")),
-            Ok(value) => Ok(value),
-        }
-    }
-
-    fn parse_status(&mut self) -> RedisResult<Value> {
-        let line = try!(self.read_string_line());
-        if line == "OK" {
-            Ok(Value::Okay)
-        } else {
-            Ok(Value::Status(line))
-        }
-    }
-
-    fn parse_int(&mut self) -> RedisResult<Value> {
-        Ok(Value::Int(try!(self.read_int_line())))
-    }
-
-    fn parse_data(&mut self) -> RedisResult<Value> {
-        let length = try!(self.read_int_line());
-        if length < 0 {
-            Ok(Value::Nil)
-        } else {
-            let data = try!(self.read(length as usize));
-            try!(self.expect_newline());
-            Ok(Value::Data(data))
-        }
-    }
-
-    fn parse_bulk(&mut self) -> RedisResult<Value> {
-        let length = try!(self.read_int_line());
-        if length < 0 {
-            Ok(Value::Nil)
-        } else {
-            let mut rv = vec![];
-            rv.reserve(length as usize);
-            for _ in 0..length {
-                rv.push(try!(self.parse_value()));
-            }
-            Ok(Value::Bulk(rv))
-        }
-    }
-
-    fn parse_error(&mut self) -> RedisResult<Value> {
-        let desc = "An error was signalled by the server";
-        let line = try!(self.read_string_line());
-        let mut pieces = line.splitn(2, ' ');
-        let kind = match pieces.next().unwrap() {
-            "ERR" => ErrorKind::ResponseError,
-            "EXECABORT" => ErrorKind::ExecAbortError,
-            "LOADING" => ErrorKind::BusyLoadingError,
-            "NOSCRIPT" => ErrorKind::NoScriptError,
-            code => {
-                fail!(make_extension_error(code, pieces.next()));
-            }
+        let mut parser = ValueFuture {
+            reader: Some(&mut self.reader),
+            state: AnyPartialState::default(),
+            remaining: Vec::new(),
         };
-        match pieces.next() {
-            Some(detail) => fail!((kind, desc, detail.to_string())),
-            None => fail!((kind, desc)),
+        match parser.poll()? {
+            Async::NotReady => panic!("Blocking read received WouldBlock error"),
+            Async::Ready((_, value)) => return Ok(value),
         }
     }
 }
-
 
 /// Parses bytes into a redis value.
 ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, BufReader};
+use std::io::{self, BufRead, BufReader};
 use std::str;
 
 use types::{make_extension_error, ErrorKind, RedisError, RedisResult, Value};
@@ -257,8 +257,8 @@ impl<'a, T: BufRead> Parser<T> {
             remaining: Vec::new(),
         };
         match parser.poll()? {
-            Async::NotReady => panic!("Blocking read received WouldBlock error"),
-            Async::Ready((_, value)) => return Ok(value),
+            Async::NotReady => Err(io::Error::from(io::ErrorKind::WouldBlock).into()),
+            Async::Ready((_, value)) => Ok(value),
         }
     }
 }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,0 +1,128 @@
+extern crate redis;
+
+extern crate futures;
+extern crate partial_io;
+#[macro_use]
+extern crate quickcheck;
+extern crate tokio;
+
+use std::io::{self, BufReader};
+
+use partial_io::{GenWouldBlock, PartialAsyncRead, PartialWithErrors};
+
+use tokio::executor::current_thread::block_on_all;
+
+use futures::Future;
+
+use redis::Value;
+
+#[derive(Clone, Debug)]
+struct ArbitraryValue(Value);
+impl ::quickcheck::Arbitrary for ArbitraryValue {
+    fn arbitrary<G: ::quickcheck::Gen>(g: &mut G) -> Self {
+        let size = g.size();
+        ArbitraryValue(arbitrary_value(g, size))
+    }
+    fn shrink(&self) -> Box<Iterator<Item = Self>> {
+        match self.0 {
+            Value::Nil | Value::Okay => Box::new(None.into_iter()),
+            Value::Int(i) => Box::new(i.shrink().map(Value::Int).map(ArbitraryValue)),
+            Value::Data(ref xs) => Box::new(xs.shrink().map(Value::Data).map(ArbitraryValue)),
+            Value::Bulk(ref xs) => {
+                let ys = xs.iter()
+                    .map(|x| ArbitraryValue(x.clone()))
+                    .collect::<Vec<_>>();
+                Box::new(
+                    ys.shrink()
+                        .map(|xs| xs.into_iter().map(|x| x.0).collect())
+                        .map(Value::Bulk)
+                        .map(ArbitraryValue),
+                )
+            }
+            Value::Status(ref status) => {
+                Box::new(status.shrink().map(Value::Status).map(ArbitraryValue))
+            }
+        }
+    }
+}
+
+fn arbitrary_value<G: ::quickcheck::Gen>(g: &mut G, recursive_size: usize) -> Value {
+    use quickcheck::Arbitrary;
+    if recursive_size == 0 {
+        Value::Nil
+    } else {
+        match g.gen_range(0, 6) {
+            0 => Value::Nil,
+            1 => Value::Int(Arbitrary::arbitrary(g)),
+            2 => Value::Data(Arbitrary::arbitrary(g)),
+            3 => {
+                let size = {
+                    let s = g.size();
+                    g.gen_range(0, s)
+                };
+                Value::Bulk(
+                    (0..size)
+                        .map(|_| arbitrary_value(g, recursive_size / size))
+                        .collect(),
+                )
+            }
+            4 => {
+                let size = {
+                    let s = g.size();
+                    g.gen_range(0, s)
+                };
+                let status = g.gen_ascii_chars().take(size).collect();
+                if status == "OK" {
+                    Value::Okay
+                } else {
+                    Value::Status(status)
+                }
+            }
+            5 => Value::Okay,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn encode_value<W>(value: &Value, writer: &mut W) -> io::Result<()>
+where
+    W: io::Write,
+{
+    match *value {
+        Value::Nil => write!(writer, "$-1\r\n"),
+        Value::Int(val) => write!(writer, ":{}\r\n", val),
+        Value::Data(ref val) => {
+            try!(write!(writer, "${}\r\n", val.len()));
+            try!(writer.write_all(val));
+            writer.write_all(b"\r\n")
+        }
+        Value::Bulk(ref values) => {
+            try!(write!(writer, "*{}\r\n", values.len()));
+            for val in values.iter() {
+                try!(encode_value(val, writer));
+            }
+            Ok(())
+        }
+        Value::Okay => write!(writer, "+OK\r\n"),
+        Value::Status(ref s) => write!(writer, "+{}\r\n", s),
+    }
+}
+
+quickcheck!{
+    fn partial_io_parse(input: ArbitraryValue, seq: PartialWithErrors<GenWouldBlock>) -> () {
+        let mut encoded_input = Vec::new();
+        encode_value(&input.0, &mut encoded_input).unwrap();
+
+        let mut reader = &encoded_input[..];
+        let partial_reader = PartialAsyncRead::new(&mut reader, seq);
+
+        let result = block_on_all(redis::parse_async(BufReader::new(partial_reader))
+            .map(|t| t.1));
+        assert!(result.as_ref().is_ok(), "{}", result.unwrap_err());
+        assert_eq!(
+            result.unwrap(),
+            input.0,
+        );
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,159 @@
+#![allow(dead_code)]
+
+extern crate net2;
+extern crate rand;
+
+use redis::{self, RedisFuture};
+
+use std::env;
+use std::fs;
+use std::process;
+use std::thread::sleep;
+use std::time::Duration;
+
+use std::path::PathBuf;
+
+#[derive(PartialEq)]
+enum ServerType {
+    Tcp,
+    Unix,
+}
+
+pub struct RedisServer {
+    pub process: process::Child,
+    addr: redis::ConnectionAddr,
+}
+
+impl ServerType {
+    fn get_intended() -> ServerType {
+        match env::var("REDISRS_SERVER_TYPE")
+            .ok()
+            .as_ref()
+            .map(|x| &x[..])
+        {
+            Some("tcp") => ServerType::Tcp,
+            Some("unix") => ServerType::Unix,
+            val => {
+                panic!("Unknown server type {:?}", val);
+            }
+        }
+    }
+}
+
+impl RedisServer {
+    pub fn new() -> RedisServer {
+        let server_type = ServerType::get_intended();
+        let mut cmd = process::Command::new("redis-server");
+        cmd.stdout(process::Stdio::null())
+            .stderr(process::Stdio::null());
+
+        let addr = match server_type {
+            ServerType::Tcp => {
+                // this is technically a race but we can't do better with
+                // the tools that redis gives us :(
+                let listener = net2::TcpBuilder::new_v4()
+                    .unwrap()
+                    .reuse_address(true)
+                    .unwrap()
+                    .bind("127.0.0.1:0")
+                    .unwrap()
+                    .listen(1)
+                    .unwrap();
+                let server_port = listener.local_addr().unwrap().port();
+                cmd.arg("--port")
+                    .arg(server_port.to_string())
+                    .arg("--bind")
+                    .arg("127.0.0.1");
+                redis::ConnectionAddr::Tcp("127.0.0.1".to_string(), server_port)
+            }
+            ServerType::Unix => {
+                let (a, b) = rand::random::<(u64, u64)>();
+                let path = format!("/tmp/redis-rs-test-{}-{}.sock", a, b);
+                cmd.arg("--port").arg("0").arg("--unixsocket").arg(&path);
+                redis::ConnectionAddr::Unix(PathBuf::from(&path))
+            }
+        };
+
+        let process = cmd.spawn().unwrap();
+        RedisServer {
+            process: process,
+            addr: addr,
+        }
+    }
+
+    pub fn wait(&mut self) {
+        self.process.wait().unwrap();
+    }
+
+    pub fn get_client_addr(&self) -> &redis::ConnectionAddr {
+        &self.addr
+    }
+
+    pub fn stop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
+        match *self.get_client_addr() {
+            redis::ConnectionAddr::Unix(ref path) => {
+                fs::remove_file(&path).ok();
+            }
+            _ => {}
+        }
+    }
+}
+
+impl Drop for RedisServer {
+    fn drop(&mut self) {
+        self.stop()
+    }
+}
+
+pub struct TestContext {
+    pub server: RedisServer,
+    pub client: redis::Client,
+}
+
+impl TestContext {
+    pub fn new() -> TestContext {
+        let server = RedisServer::new();
+
+        let client = redis::Client::open(redis::ConnectionInfo {
+            addr: Box::new(server.get_client_addr().clone()),
+            db: 0,
+            passwd: None,
+        }).unwrap();
+        let con;
+
+        let millisecond = Duration::from_millis(1);
+        loop {
+            match client.get_connection() {
+                Err(err) => if err.is_connection_refusal() {
+                    sleep(millisecond);
+                } else {
+                    panic!("Could not connect: {}", err);
+                },
+                Ok(x) => {
+                    con = x;
+                    break;
+                }
+            }
+        }
+        redis::cmd("FLUSHDB").execute(&con);
+
+        TestContext {
+            server: server,
+            client: client,
+        }
+    }
+
+    pub fn connection(&self) -> redis::Connection {
+        self.client.get_connection().unwrap()
+    }
+
+    pub fn async_connection(&self) -> RedisFuture<redis::async::Connection> {
+        self.client.get_async_connection()
+    }
+
+    pub fn stop_server(&mut self) {
+        self.server.stop();
+    }
+}

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -1,0 +1,62 @@
+#![cfg(not(any(feature = "with-unix-sockets", feature = "with-system-unix-sockets")))]
+extern crate redis;
+
+extern crate futures;
+extern crate tokio;
+
+use futures::Future;
+
+use support::*;
+
+use tokio::executor::current_thread::block_on_all;
+
+mod support;
+
+#[test]
+fn test_args() {
+    let ctx = TestContext::new();
+    let connect = ctx.async_connection();
+
+    block_on_all(connect.and_then(|con| {
+        redis::cmd("SET")
+            .arg("key1")
+            .arg(b"foo")
+            .query_async(con)
+            .and_then(|(con, ())| redis::cmd("SET").arg(&["key2", "bar"]).query_async(con))
+            .and_then(|(con, ())| {
+                redis::cmd("MGET")
+                    .arg(&["key1", "key2"])
+                    .query_async(con)
+                    .map(|t| t.1)
+            })
+            .then(|result| {
+                assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
+                result
+            })
+    })).unwrap();
+}
+
+#[test]
+fn test_pipeline_transaction() {
+    let ctx = TestContext::new();
+    block_on_all(ctx.async_connection().and_then(|con| {
+        let mut pipe = redis::pipe();
+        pipe.atomic()
+            .cmd("SET")
+            .arg("key_1")
+            .arg(42)
+            .ignore()
+            .cmd("SET")
+            .arg("key_2")
+            .arg(43)
+            .ignore()
+            .cmd("MGET")
+            .arg(&["key_1", "key_2"]);
+        pipe.query_async(con)
+            .and_then(|(_con, ((k1, k2),)): (_, ((i32, i32),))| {
+                assert_eq!(k1, 42);
+                assert_eq!(k2, 43);
+                Ok(())
+            })
+    })).unwrap();
+}

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -1,4 +1,3 @@
-#![cfg(not(any(feature = "with-unix-sockets", feature = "with-system-unix-sockets")))]
 extern crate redis;
 
 extern crate futures;


### PR DESCRIPTION
This adds support for communicating with redis instances asynchronously using futures and tokio. Putting this up now to show the changes and additions I have done so far.

Since the current response parser is tied to reading synchronously from a `Read` instance I rewrote it using https://github.com/Marwes/combine. I choose combine since I know it (obviously) and I wanted to try the state machine support I have been working on [in tandem](https://github.com/Marwes/combine/pull/128) with this PR (this PR is what made me come up with the idea). Though I am a bit biased I do think it should be a good fit after I have worked out the bugs so I hope the change is acceptable. (I did see the Nom parser in https://github.com/mitsuhiko/redis-rs/pull/129 but didn't use it as I'd still need to code the state machine manually whereas combine creates it automatically).

`query(_async)` is currently the only added API and there is also a bunch of cleanup to be done.

Closes #103 