### PR TITLE
Remove the need for RefCell by requiring `&mut ConnectionLike`

### DIFF
--- a/benches/bench_basic.rs
+++ b/benches/bench_basic.rs
@@ -22,13 +22,13 @@ fn get_client() -> redis::Client {
 
 fn bench_simple_getsetdel(b: &mut Bencher) {
     let client = get_client();
-    let con = client.get_connection().unwrap();
+    let mut con = client.get_connection().unwrap();
 
     b.iter(|| {
         let key = "test_key";
-        redis::cmd("SET").arg(key).arg(42).execute(&con);
-        let _: isize = redis::cmd("GET").arg(key).query(&con).unwrap();
-        redis::cmd("DEL").arg(key).execute(&con);
+        redis::cmd("SET").arg(key).arg(42).execute(&mut con);
+        let _: isize = redis::cmd("GET").arg(key).query(&mut con).unwrap();
+        redis::cmd("DEL").arg(key).execute(&mut con);
     });
 }
 
@@ -56,7 +56,7 @@ fn bench_simple_getsetdel_async(b: &mut Bencher) {
 
 fn bench_simple_getsetdel_pipeline(b: &mut Bencher) {
     let client = get_client();
-    let con = client.get_connection().unwrap();
+    let mut con = client.get_connection().unwrap();
 
     b.iter(|| {
         let key = "test_key";
@@ -70,14 +70,14 @@ fn bench_simple_getsetdel_pipeline(b: &mut Bencher) {
             .cmd("DEL")
             .arg(key)
             .ignore()
-            .query(&con)
+            .query(&mut con)
             .unwrap();
     });
 }
 
 fn bench_simple_getsetdel_pipeline_precreated(b: &mut Bencher) {
     let client = get_client();
-    let con = client.get_connection().unwrap();
+    let mut con = client.get_connection().unwrap();
     let key = "test_key";
     let mut pipe = redis::pipe();
     pipe.cmd("SET")
@@ -91,7 +91,7 @@ fn bench_simple_getsetdel_pipeline_precreated(b: &mut Bencher) {
         .ignore();
 
     b.iter(|| {
-        let _: (usize,) = pipe.query(&con).unwrap();
+        let _: (usize,) = pipe.query(&mut con).unwrap();
     });
 }
 
@@ -108,12 +108,12 @@ fn long_pipeline() -> redis::Pipeline {
 
 fn bench_long_pipeline(b: &mut Bencher) {
     let client = get_client();
-    let con = client.get_connection().unwrap();
+    let mut con = client.get_connection().unwrap();
 
     let pipe = long_pipeline();
 
     b.iter(|| {
-        let _: () = pipe.query(&con).unwrap();
+        let _: () = pipe.query(&mut con).unwrap();
     });
 }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 /// hashmap of tuples.  This is particularly useful for responses like
 /// CONFIG GET or all most H functions which will return responses in
 /// such list of implied tuples.
-fn do_print_max_entry_limits(con: &redis::Connection) -> redis::RedisResult<()> {
+fn do_print_max_entry_limits(con: &mut redis::Connection) -> redis::RedisResult<()> {
     // since rust cannot know what format we actually want we need to be
     // explicit here and define the type of our response.  In this case
     // String -> int fits all the items we query for.
@@ -42,7 +42,7 @@ fn do_print_max_entry_limits(con: &redis::Connection) -> redis::RedisResult<()> 
 /// This is a pretty stupid example that demonstrates how to create a large
 /// set through a pipeline and how to iterate over it through implied
 /// cursors.
-fn do_show_scanning(con: &redis::Connection) -> redis::RedisResult<()> {
+fn do_show_scanning(con: &mut redis::Connection) -> redis::RedisResult<()> {
     // This makes a large pipeline of commands.  Because the pipeline is
     // modified in place we can just ignore the return value upon the end
     // of each iteration.
@@ -71,7 +71,7 @@ fn do_show_scanning(con: &redis::Connection) -> redis::RedisResult<()> {
 }
 
 /// Demonstrates how to do an atomic increment in a very low level way.
-fn do_atomic_increment_lowlevel(con: &redis::Connection) -> redis::RedisResult<()> {
+fn do_atomic_increment_lowlevel(con: &mut redis::Connection) -> redis::RedisResult<()> {
     let key = "the_key";
     println!("Run low-level atomic increment:");
 
@@ -114,7 +114,7 @@ fn do_atomic_increment_lowlevel(con: &redis::Connection) -> redis::RedisResult<(
 }
 
 /// Demonstrates how to do an atomic increment with transaction support.
-fn do_atomic_increment(con: &redis::Connection) -> redis::RedisResult<()> {
+fn do_atomic_increment(con: &mut redis::Connection) -> redis::RedisResult<()> {
     let key = "the_key";
     println!("Run high-level atomic increment:");
 
@@ -122,7 +122,7 @@ fn do_atomic_increment(con: &redis::Connection) -> redis::RedisResult<()> {
     let _: () = con.set(key, 42)?;
 
     // run the transaction block.
-    let (new_val,): (isize,) = transaction(con, &[key], |pipe| {
+    let (new_val,): (isize,) = transaction(con, &[key], |con, pipe| {
         // load the old value, so we know what to increment.
         let val: isize = con.get(key)?;
         // increment
@@ -139,17 +139,17 @@ fn do_atomic_increment(con: &redis::Connection) -> redis::RedisResult<()> {
 fn do_redis_code() -> redis::RedisResult<()> {
     // general connection handling
     let client = redis::Client::open("redis://127.0.0.1/")?;
-    let con = client.get_connection()?;
+    let mut con = client.get_connection()?;
 
     // read some config and print it.
-    do_print_max_entry_limits(&con)?;
+    do_print_max_entry_limits(&mut con)?;
 
     // demonstrate how scanning works.
-    do_show_scanning(&con)?;
+    do_show_scanning(&mut con)?;
 
     // shows an atomic increment.
-    do_atomic_increment_lowlevel(&con)?;
-    do_atomic_increment(&con)?;
+    do_atomic_increment_lowlevel(&mut con)?;
+    do_atomic_increment(&mut con)?;
 
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -59,12 +59,12 @@ impl Client {
 }
 
 impl ConnectionLike for Client {
-    fn req_packed_command(&self, cmd: &[u8]) -> RedisResult<Value> {
+    fn req_packed_command(&mut self, cmd: &[u8]) -> RedisResult<Value> {
         self.get_connection()?.req_packed_command(cmd)
     }
 
     fn req_packed_commands(
-        &self,
+        &mut self,
         cmd: &[u8],
         offset: usize,
         count: usize,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,7 @@
 // can't use rustfmt here because it screws up the file.
 #![cfg_attr(rustfmt, rustfmt_skip)]
 use types::{FromRedisValue, ToRedisArgs, RedisResult, NumericBehavior};
-use client::Client;
-use connection::{Connection, ConnectionLike, Msg};
+use connection::{ConnectionLike, Msg, Connection};
 use cmd::{cmd, Cmd, Pipeline, Iter};
 
 
@@ -26,9 +25,9 @@ macro_rules! implement_commands {
         /// ```rust,no_run
         /// # fn do_something() -> redis::RedisResult<()> {
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
-        /// let con = client.get_connection()?;
-        /// redis::cmd("SET").arg("my_key").arg(42).execute(&con);
-        /// assert_eq!(redis::cmd("GET").arg("my_key").query(&con), Ok(42));
+        /// let mut con = client.get_connection()?;
+        /// redis::cmd("SET").arg("my_key").arg(42).execute(&mut con);
+        /// assert_eq!(redis::cmd("GET").arg("my_key").query(&mut con), Ok(42));
         /// # Ok(()) }
         /// ```
         ///
@@ -38,7 +37,7 @@ macro_rules! implement_commands {
         /// # fn do_something() -> redis::RedisResult<()> {
         /// use redis::Commands;
         /// let client = redis::Client::open("redis://127.0.0.1/")?;
-        /// let con = client.get_connection()?;
+        /// let mut con = client.get_connection()?;
         /// assert_eq!(con.get("my_key"), Ok(42));
         /// # Ok(()) }
         /// ```
@@ -47,25 +46,25 @@ macro_rules! implement_commands {
                 $(#[$attr])*
                 #[inline]
                 fn $name<$($tyargs: $ty,)* RV: FromRedisValue>(
-                    &self $(, $argname: $argty)*) -> RedisResult<RV>
+                    &mut self $(, $argname: $argty)*) -> RedisResult<RV>
                     { ($body).query(self) }
             )*
 
             /// Incrementally iterate the keys space.
             #[inline]
-            fn scan<RV: FromRedisValue>(&self) -> RedisResult<Iter<RV>> {
+            fn scan<RV: FromRedisValue>(&mut self) -> RedisResult<Iter<RV>> {
                 cmd("SCAN").cursor_arg(0).iter(self)
             }
 
             /// Incrementally iterate the keys space for keys matching a pattern.
             #[inline]
-            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&self, pattern: P) -> RedisResult<Iter<RV>> {
+            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisResult<Iter<RV>> {
                 cmd("SCAN").cursor_arg(0).arg("MATCH").arg(pattern).iter(self)
             }
 
             /// Incrementally iterate hash fields and associated values.
             #[inline]
-            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&self, key: K) -> RedisResult<Iter<RV>> {
+            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<RV>> {
                 cmd("HSCAN").arg(key).cursor_arg(0).iter(self)
             }
 
@@ -73,33 +72,33 @@ macro_rules! implement_commands {
             /// field names matching a pattern.
             #[inline]
             fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&self, key: K, pattern: P) -> RedisResult<Iter<RV>> {
+                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<RV>> {
                 cmd("HSCAN").arg(key).cursor_arg(0).arg("MATCH").arg(pattern).iter(self)
             }
 
             /// Incrementally iterate set elements.
             #[inline]
-            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&self, key: K) -> RedisResult<Iter<RV>> {
+            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<RV>> {
                 cmd("SSCAN").arg(key).cursor_arg(0).iter(self)
             }
 
             /// Incrementally iterate set elements for elements matching a pattern.
             #[inline]
             fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&self, key: K, pattern: P) -> RedisResult<Iter<RV>> {
+                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<RV>> {
                 cmd("SSCAN").arg(key).cursor_arg(0).arg("MATCH").arg(pattern).iter(self)
             }
 
             /// Incrementally iterate sorted set elements.
             #[inline]
-            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&self, key: K) -> RedisResult<Iter<RV>> {
+            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisResult<Iter<RV>> {
                 cmd("ZSCAN").arg(key).cursor_arg(0).iter(self)
             }
 
             /// Incrementally iterate sorted set elements for elements matching a pattern.
             #[inline]
             fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&self, key: K, pattern: P) -> RedisResult<Iter<RV>> {
+                    (&mut self, key: K, pattern: P) -> RedisResult<Iter<RV>> {
                 cmd("ZSCAN").arg(key).cursor_arg(0).arg("MATCH").arg(pattern).iter(self)
             }
         }
@@ -803,8 +802,7 @@ pub trait PubSubCommands: Sized {
               P: ToRedisArgs;
 }
 
-impl Commands for Connection {}
-impl Commands for Client {}
+impl<T> Commands for T where T: ConnectionLike {}
 
 impl PubSubCommands for Connection {
     fn subscribe<'a, C, F, U>(&mut self, channels: C, mut func: F) -> RedisResult<U>

--- a/src/script.rs
+++ b/src/script.rs
@@ -18,11 +18,11 @@ pub struct Script {
 ///
 /// ```rust,no_run
 /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-/// # let con = client.get_connection().unwrap();
+/// # let mut con = client.get_connection().unwrap();
 /// let script = redis::Script::new(r"
 ///     return tonumber(ARGV[1]) + tonumber(ARGV[2]);
 /// ");
-/// let result = script.arg(1).arg(2).invoke(&con);
+/// let result = script.arg(1).arg(2).invoke(&mut con);
 /// assert_eq!(result, Ok(3));
 /// ```
 impl Script {
@@ -75,7 +75,7 @@ impl Script {
 
     /// Invokes the script directly without arguments.
     #[inline]
-    pub fn invoke<T: FromRedisValue>(&self, con: &ConnectionLike) -> RedisResult<T> {
+    pub fn invoke<T: FromRedisValue>(&self, con: &mut ConnectionLike) -> RedisResult<T> {
         ScriptInvocation {
             script: self,
             args: vec![],
@@ -121,7 +121,7 @@ impl<'a> ScriptInvocation<'a> {
 
     /// Invokes the script and returns the result.
     #[inline]
-    pub fn invoke<T: FromRedisValue>(&self, con: &ConnectionLike) -> RedisResult<T> {
+    pub fn invoke<T: FromRedisValue>(&self, con: &mut ConnectionLike) -> RedisResult<T> {
         loop {
             match cmd("EVALSHA")
                 .arg(self.script.hash.as_bytes())

--- a/src/types.rs
+++ b/src/types.rs
@@ -369,8 +369,8 @@ pub struct InfoDict {
 /// ```rust,no_run
 /// # fn do_something() -> redis::RedisResult<()> {
 /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-/// # let con = client.get_connection().unwrap();
-/// let info : redis::InfoDict = redis::cmd("INFO").query(&con)?;
+/// # let mut con = client.get_connection().unwrap();
+/// let info : redis::InfoDict = redis::cmd("INFO").query(&mut con)?;
 /// let role : Option<String> = info.get("role");
 /// # Ok(()) }
 /// ```

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -128,7 +128,7 @@ impl TestContext {
             passwd: None,
         })
         .unwrap();
-        let con;
+        let mut con;
 
         let millisecond = Duration::from_millis(1);
         loop {
@@ -146,7 +146,7 @@ impl TestContext {
                 }
             }
         }
-        redis::cmd("FLUSHDB").execute(&con);
+        redis::cmd("FLUSHDB").execute(&mut con);
 
         TestContext {
             server: server,


### PR DESCRIPTION
There isn't anything in redis-rs that requires the `RefCell` so users can always replicate the earlier behavior by themselves wrapping the connection in a `RefCell`.

This might also protect against programmer errors when using `iter` to query as one should not issue another `query` while still using the iterator.

BREAKING CHANGE

Changes the signature of several functions that took a `&ConnectionLike` to take `&mut ConnectionLike`