### PR TITLE
fix: Use write_all to guarantee that all bytes gets written 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: rust
+cache: cargo
 rust:
   - stable
   - beta

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp cargo test --features="with-rustc-json"
+	@REDISRS_SERVER_TYPE=tcp RUST_TEST_THREADS=1 cargo test --features="with-rustc-json"
 	@echo "Testing Connection Type UNIX"
 	@echo "===================================================================="
 	@REDISRS_SERVER_TYPE=unix cargo test --features="with-rustc-json"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -209,7 +209,7 @@ impl ActualConnection {
             #[cfg(any(feature="with-unix-sockets", feature="with-system-unix-sockets"))]
             ActualConnection::Unix(ref mut sock) => &mut *sock as &mut Write,
         };
-        try!(w.write(bytes));
+        try!(w.write_all(bytes));
         Ok(Value::Okay)
     }
 


### PR DESCRIPTION
Based on #147 to avoid the test flakiness.

Closes #147 