### PR TITLE
Expose connection status in `is_open` method.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -154,13 +154,13 @@ impl IntoConnectionInfo for url::Url {
 }
 
 struct TcpConnection {
-    pub reader: BufReader<TcpStream>,
-    pub open: bool
+    reader: BufReader<TcpStream>,
+    open: bool
 }
 
 struct UnixConnection {
-    pub sock: UnixStream,
-    pub open: bool
+    sock: UnixStream,
+    open: bool
 }
 
 enum ActualConnection {
@@ -241,7 +241,7 @@ impl ActualConnection {
         let result = Parser::new(match *self {
                 ActualConnection::Tcp(TcpConnection{ ref mut reader, .. }) => reader as &mut Read,
                 #[cfg(any(feature="with-unix-sockets", feature="with-system-unix-sockets"))]
-            ActualConnection::Unix(UnixConnection { ref mut sock, .. }) => sock as &mut Read,
+                ActualConnection::Unix(UnixConnection { ref mut sock, .. }) => sock as &mut Read,
             })
             .parse_value();
         // shutdown connection on protocol error
@@ -476,8 +476,11 @@ impl Connection {
 
     /// Returns the connection status.
     ///
-    /// The connection is open until any `read_response` call failed to
-    /// parse a command.
+    /// The connection is open until any `read_response` call recieved an
+    /// invalid response from the server (most likely a closed or dropped
+    /// connection, otherwise a Redis protocol error). When using unix
+    /// sockets the connection is open until writing a command failed with a
+    /// `BrokenPipe` error.
     pub fn is_open(&self) -> bool {
         self.con.borrow().is_open()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -310,6 +310,19 @@ impl RedisError {
         }
     }
 
+    /// Returns true if error was caused by a broken pipe.
+    pub fn is_broken_pipe(&self) -> bool {
+        match self.repr {
+            ErrorRepr::IoError(ref err) => {
+                match err.kind() {
+                    io::ErrorKind::BrokenPipe => true,
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
     /// Returns the extension error code
     pub fn extension_error_code(&self) -> Option<&str> {
         match self.repr {


### PR DESCRIPTION
The `is_open` method can be used in `r2d2::ManageConnection#has_broken`
to determine if the connection was closed or failed for an other reason.

Before `r2d2-redis` had no way to check if the connection broke during
the time a request was made. This meant the only way to handle
connection errors (either a problem with the network or redis server) was
to use `test_on_check_out(true)` which run the `is_valid` check before
a connection is checked out of the pool.

While this works it has an impact on the throughput because every
checkout makes a request to redis to check the connection status.

Exposing the connection status allows the user to optimize for the
"golden path" and only mark connections (and thus removing them from the
pool) if something went wrong.

As far as I know the only way to check the status of a connection is to
either read or write to it, writing arbitrary data would mess with a
working connections and trying to read data could block. That is why I
opted to only update the status when parsing a response failed with
a `ResponseError`. Not sure why but this also works when the server
closed the connection while writing to a TCP socket (verified manually
with toxiproxy).

---------

Make ActualConnection enum variants hold a Tcp/UnixConnection struct

Allows to deconstruct the struct and only use the fields that are
required.