### PR TITLE
Fix the compilation, test on windows and add Appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+os: Visual Studio 2015
+
+environment:
+  REDISRS_SERVER_TYPE: tcp
+  RUST_BACKTRACE: 1
+  matrix:
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+    - channel: stable
+      target: x86_64-pc-windows-gnu
+install:
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %channel% --default-host %target%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -vV
+  - cargo -vV
+  - cmd: nuget install redis-64 -excludeversion
+  - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\redis-64\tools\
+
+build: false
+
+test_script:
+  - cargo test --verbose %cargoflags%

--- a/src/types.rs
+++ b/src/types.rs
@@ -310,12 +310,12 @@ impl RedisError {
         }
     }
 
-    /// Returns true if error was caused by a broken pipe.
-    pub fn is_broken_pipe(&self) -> bool {
+    /// Returns true if error was caused by a dropped connection.
+    pub fn is_connection_dropped(&self) -> bool {
         match self.repr {
             ErrorRepr::IoError(ref err) => {
                 match err.kind() {
-                    io::ErrorKind::BrokenPipe => true,
+                    io::ErrorKind::BrokenPipe | io::ErrorKind::ConnectionReset => true,
                     _ => false,
                 }
             }

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -836,6 +836,7 @@ fn test_redis_server_down() {
     ctx.stop_server();
 
     let ping = redis::cmd("PING").query::<String>(&con);
-    assert_eq!(con.is_open(), false);
+
     assert_eq!(ping.is_err(), true);
+    assert_eq!(con.is_open(), false);
 }


### PR DESCRIPTION
###  Fix the build on windows 

`UnixStream` is not available on windows

On windows a dropped connection to redis (or a killed redis server) will
result in a `ConnectionReset` error which is triggered when trying to
write to the connection opposed to unix which fails when trying to read
data from it.

------------------------------------------------
### Add appveyor config 

The configuration is based on the sample from [here][1]. Since Appveyor
does not run jobs in parallel it is currently only running the tests
against stable rust to avoid slowing down the builds too much.

[1]: https://github.com/starkat99/appveyor-rust

Apart from setting up an Appveyor account I had to configure a webhook for `push` and `pull request` events. The webhook url can be found in the appveyor project settings. This is the output for the latest build of my fork: https://ci.appveyor.com/project/dsanderOauthDummy/redis-rs/build/1.0.26
