### PR TITLE
Fix docs typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 //! The URL format is `redis://[:<passwd>@]<hostname>[:port][/<db>]`
 //!
-//! In case the create is compiled with Unix socket support you can also
+//! In case the crate is compiled with Unix socket support you can also
 //! use a unix URL in this format:
 //!
 //! `redis+unix:///[:<passwd>@]<path>[?db=<db>]`


### PR DESCRIPTION
I'm assuming `crate` was meant, instead of `create` :)