### PR TITLE
perf: Optimize the command encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ with-unix-sockets = ["unix_socket", "tokio-uds"]
 with-system-unix-sockets = []
 
 [dependencies]
+dtoa = "0.4"
+itoa = "0.4.3"
 sha1 = ">= 0.2, < 0.7"
 url = "1.2"
 rustc-serialize = { version = "0.3.16", optional = true }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -450,6 +450,10 @@ impl Pipeline {
         Value::Bulk(rv)
     }
 
+    pub fn get_packed_pipeline(&self, atomic: bool) -> Vec<u8> {
+        encode_pipeline(&self.commands, atomic)
+    }
+
     fn execute_pipelined(&self, con: &ConnectionLike) -> RedisResult<Value> {
         Ok(self.make_pipeline_results(con.req_packed_commands(
             &encode_pipeline(&self.commands, false),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let con = client.get_connection().unwrap();
 //! let mut iter : redis::Iter<isize> = redis::cmd("SSCAN").arg("my_set")
-//!     .cursor_arg(0).iter(&con)?;
+//!     .cursor_arg(0).clone().iter(&con)?;
 //! for x in iter {
 //!     // do something with the item
 //! }
@@ -360,6 +360,8 @@
 #[macro_use]
 extern crate combine;
 extern crate bytes;
+extern crate dtoa;
+extern crate itoa;
 extern crate sha1;
 extern crate url;
 #[macro_use]

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -205,6 +205,7 @@ fn test_scanning() {
     let iter = redis::cmd("SSCAN")
         .arg("foo")
         .cursor_arg(0)
+        .clone()
         .iter(&con)
         .unwrap();
 


### PR DESCRIPTION
Not as important as `IO` latency but can still be a decent throughput improvement.

(Lots of variance in the benchmarks but there is still some clear improvements)
```
encode/pipeline         time:   [727.07 us 731.89 us 737.21 us]
                        change: [-59.635% -58.716% -57.668%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
encode/pipeline_nested  time:   [246.61 us 249.05 us 251.81 us]
                        change: [-71.597% -70.950% -70.333%] (p = 0.00 < 0.05)
                        Performance has improved.
encode/integer          time:   [693.79 us 698.95 us 703.98 us]
                        change: [-63.633% -63.125% -62.651%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
encode/small            time:   [1.1458 us 1.1580 us 1.1701 us]
                        change: [-40.826% -39.741% -38.664%] (p = 0.00 < 0.05)
                        Performance has improved.
```

I could probably refactor to remove these breaking changes but for the moment...

BREAKING CHANGE

`ToRedisArgs` has been changed to take take an instance of `RedisWrite`  instead of `Vec<Vec<u8>>`. Use the `write_arg` method instead of `Vec::push`.

`impl Iterator` is used which requires 1.26

`iter` now takes `self` by value instead of cloning `self` inside the method.