### PR TITLE
Allow a more efficient pattern of Pipeline memory allocation

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -502,7 +502,7 @@ impl Pipeline {
         )
     }
 
-    /// Clear the internal data strcture of `Pipeline`, allowing it to be reused.
+    /// Clear the internal data structure of `Pipeline`, allowing it to be reused.
     #[inline]
     pub fn clear(&mut self) {
         self.commands.clear();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -358,8 +358,7 @@ impl Pipeline {
         Self::with_capacity(0)
     }
 
-    /// Creates an empty pipeline with pre-allocated capacity.  For consistency with the `cmd`
-    /// api a `pipe` function is provided as alias.
+    /// Creates an empty pipeline with pre-allocated capacity.
     pub fn with_capacity(capacity: usize) -> Pipeline {
         Pipeline {
             commands: Vec::with_capacity(capacity),
@@ -487,8 +486,9 @@ impl Pipeline {
     ///     .cmd("GET").arg("key_2").query(&con).unwrap();
     /// ```
     ///
-    /// NOTE: In order to clear (and reuse) the `Pipeline` object after calling `query()`, one must
-    ///       explicitly call `clear()`.
+    /// NOTE: A Pipeline object may be reused after `query()` with all the commands as were inserted
+    ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
+    ///       it is necessary to call the `clear()` before inserting new commands.
     #[inline]
     pub fn query<T: FromRedisValue>(&self, con: &ConnectionLike) -> RedisResult<T> {
         from_redis_value(
@@ -502,7 +502,10 @@ impl Pipeline {
         )
     }
 
-    /// Clear the internal data structure of `Pipeline`, allowing it to be reused.
+    /// Clear a Pipeline object internal data structure.
+    ///
+    /// This allows reusing a Pipeline object as a clear object while performing a minimal amount of
+    /// memory released/reallocated.
     #[inline]
     pub fn clear(&mut self) {
         self.commands.clear();
@@ -570,8 +573,9 @@ impl Pipeline {
     /// let _ : () = redis::pipe().cmd("PING").query(&con).unwrap();
     /// ```
     ///
-    /// NOTE: In order to clear (and reuse) the `Pipeline` object after calling `execute()`, one
-    ///       must explicitly call `clear()`.
+    /// NOTE: A Pipeline object may be reused after `query()` with all the commands as were inserted
+    ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
+    ///       it is necessary to call the `clear()` before inserting new commands.
     #[inline]
     pub fn execute(&self, con: &ConnectionLike) {
         let _: () = self.query(con).unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -486,6 +486,9 @@ impl Pipeline {
     ///     .cmd("GET").arg("key_1")
     ///     .cmd("GET").arg("key_2").query(&con).unwrap();
     /// ```
+    ///
+    /// NOTE: In order to clear (and reuse) the `Pipeline` object after calling `query()`, one must
+    ///       explicitly call `clear()`.
     #[inline]
     pub fn query<T: FromRedisValue>(&self, con: &ConnectionLike) -> RedisResult<T> {
         from_redis_value(
@@ -499,13 +502,10 @@ impl Pipeline {
         )
     }
 
-    /// Like ``query()`` but clears the pooled commands from memory.  This allows reusal of a Pipeline
-    /// object with minimal re-allocation of memory.
+    /// Clear the internal data strcture of `Pipeline`, allowing it to be reused.
     #[inline]
-    pub fn query_clear<T: FromRedisValue>(&mut self, con: &ConnectionLike) -> RedisResult<T> {
-        let res = self.query(con);
+    pub fn clear(&mut self) {
         self.commands.clear();
-        res
     }
 
     fn execute_pipelined_async<C>(self, con: C) -> RedisFuture<(C, Value)>
@@ -569,6 +569,9 @@ impl Pipeline {
     /// # let con = client.get_connection().unwrap();
     /// let _ : () = redis::pipe().cmd("PING").query(&con).unwrap();
     /// ```
+    ///
+    /// NOTE: In order to clear (and reuse) the `Pipeline` object after calling `execute()`, one
+    ///       must explicitly call `clear()`.
     #[inline]
     pub fn execute(&self, con: &ConnectionLike) {
         let _: () = self.query(con).unwrap();

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -300,6 +300,80 @@ fn test_pipeline_transaction() {
 }
 
 #[test]
+fn test_pipeline_reuse_query() {
+    let ctx = TestContext::new();
+    let con = ctx.connection();
+
+    let mut pl = redis::pipe();
+
+    let ((k1,),): ((i32,),) = pl
+        .cmd("SET")
+        .arg("pkey_1")
+        .arg(42)
+        .ignore()
+        .cmd("MGET")
+        .arg(&["pkey_1"])
+        .query(&con)
+        .unwrap();
+
+    assert_eq!(k1, 42);
+
+    redis::cmd("DEL").arg("pkey_1").execute(&con);
+
+    // The internal commands vector of the pipeline still contains the previous commands.
+    let ((k1,), (k2, k3)): ((i32,), (i32, i32)) = pl
+        .cmd("SET")
+        .arg("pkey_2")
+        .arg(43)
+        .ignore()
+        .cmd("MGET")
+        .arg(&["pkey_1"])
+        .arg(&["pkey_2"])
+        .query(&con)
+        .unwrap();
+
+    assert_eq!(k1, 42);
+    assert_eq!(k2, 42);
+    assert_eq!(k3, 43);
+}
+
+#[test]
+fn test_pipeline_reuse_query_clear() {
+    let ctx = TestContext::new();
+    let con = ctx.connection();
+
+    let mut pl = redis::pipe();
+
+    let ((k1,),): ((i32,),) = pl
+        .cmd("SET")
+        .arg("pkey_1")
+        .arg(44)
+        .ignore()
+        .cmd("MGET")
+        .arg(&["pkey_1"])
+        .query_clear(&con)
+        .unwrap();
+
+    assert_eq!(k1, 44);
+
+    redis::cmd("DEL").arg("pkey_1").execute(&con);
+
+    let ((k1, k2),): ((bool, i32),) = pl
+        .cmd("SET")
+        .arg("pkey_2")
+        .arg(45)
+        .ignore()
+        .cmd("MGET")
+        .arg(&["pkey_1"])
+        .arg(&["pkey_2"])
+        .query_clear(&con)
+        .unwrap();
+
+    assert_eq!(k1, false);
+    assert_eq!(k2, 45);
+}
+
+#[test]
 fn test_real_transaction() {
     let ctx = TestContext::new();
     let con = ctx.connection();

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -351,8 +351,9 @@ fn test_pipeline_reuse_query_clear() {
         .ignore()
         .cmd("MGET")
         .arg(&["pkey_1"])
-        .query_clear(&con)
+        .query(&con)
         .unwrap();
+    pl.clear();
 
     assert_eq!(k1, 44);
 
@@ -366,8 +367,9 @@ fn test_pipeline_reuse_query_clear() {
         .cmd("MGET")
         .arg(&["pkey_1"])
         .arg(&["pkey_2"])
-        .query_clear(&con)
+        .query(&con)
         .unwrap();
+    pl.clear();
 
     assert_eq!(k1, false);
     assert_eq!(k2, 45);


### PR DESCRIPTION
This change allows a performance sensitive tight loop to reuse a
Pipeline object instead of allocating a new one each time.

 - `with_capacity` allows to preallocate the internal `commands` vector
   to the specified capacity.
 - `Pipeline.query_clear()` clears the internal `commands` vector from
   values after the query (but keeps the allocated capacity).
 - The unitests show the expected behaviour of `query` vs `query_clear`.