### PR TITLE
Expose ValueFuture struct as public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@ pub use connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
     IntoConnectionInfo, Msg, PubSub,
 };
-pub use parser::{parse_async, parse_redis_value, Parser};
+pub use parser::{parse_async, parse_redis_value, Parser, ValueFuture};
 pub use script::{Script, ScriptInvocation};
 
 pub use types::{


### PR DESCRIPTION
Currently, `parse_async` returns `ValueFuture`, which is private, so this makes `parse_async` completely useless as far as I can see. Thus, either `ValueFuture` should be public or `parse_async` should be private, shouldn't they?

I use the parser to play around with Redis protocol, so it is quite useful to have `ValueFuture`.