### PR TITLE
perf(async): Use tokio_sync's channels instead of futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio-executor = "0.1"
 tokio-tcp = "0.1"
 tokio-io = "0.1"
 tokio-codec = "0.1"
+tokio-sync = "0.1"
 tokio-uds = { version = "0.2", optional = true }
 
 [dev-dependencies]

--- a/src/async.rs
+++ b/src/async.rs
@@ -13,8 +13,8 @@ use tokio_io::{self, AsyncWrite};
 use tokio_tcp::TcpStream;
 
 use futures::future::Either;
-use futures::sync::{mpsc, oneshot};
 use futures::{future, stream, Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
+use tokio_sync::{mpsc, oneshot};
 
 use cmd::cmd;
 use types::{ErrorKind, RedisError, RedisFuture, Value};
@@ -394,6 +394,7 @@ where
         let (sender, receiver) = mpsc::channel(BUFFER_SIZE);
         tokio_executor::spawn(
             receiver
+                .map_err(|_| ())
                 .forward(PipelineSink {
                     sink_stream,
                     in_flight: VecDeque::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,7 @@ extern crate tokio_executor;
 #[macro_use]
 extern crate tokio_io;
 extern crate tokio_codec;
+extern crate tokio_sync;
 extern crate tokio_tcp;
 
 #[cfg(feature = "with-rustc-json")]


### PR DESCRIPTION
These are slightly faster than the ones from `futures` so since we
already use `tokio` there is no harm in using these types instead.

```
query/simple_getsetdel_async
                        time:   [150.96 us 154.48 us 158.39 us]
                        change: [-30.815% -29.179% -27.560%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

query_pipeline/shared_async_implicit_pipeline
                        time:   [5.5211 ms 5.5509 ms 5.5852 ms]
                        thrpt:  [179.04 Kelem/s 180.15 Kelem/s 181.12 Kelem/s]
                 change:
                        time:   [-11.816% -11.045% -10.262%] (p = 0.00 < 0.05)
                        thrpt:  [+11.436% +12.416% +13.400%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
query_pipeline/shared_async_long_pipeline
                        time:   [3.1803 ms 3.1931 ms 3.2065 ms]
                        thrpt:  [311.87 Kelem/s 313.17 Kelem/s 314.44 Kelem/s]
                 change:
                        time:   [-5.9922% -5.4092% -4.8482%] (p = 0.00 < 0.05)
                        thrpt:  [+5.0952% +5.7185% +6.3742%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```