### PR TITLE
doc: Document what `parse_async` returns with `impl Future`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -269,7 +269,7 @@ where
     }
 }
 
-pub fn parse_async<R>(reader: R) -> ValueFuture<R>
+pub fn parse_async<R>(reader: R) -> impl Future<Item = (R, Value), Error = RedisError>
 where
     R: AsyncRead + BufRead,
 {


### PR DESCRIPTION
`ValueFuture` is a hidden type so it isn't possible to see what it
returns. We can instead use `impl Future` to document that while keeping
it hidden.

cc #193