### PR TITLE
 perf(parser): Use more performant operations for line parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sha1 = ">= 0.2, < 0.7"
 url = "1.2"
 rustc-serialize = { version = "0.3.16", optional = true }
 unix_socket = { version = "0.5.0", optional = true }
-combine = "3.8.0"
+combine = "3.8.1"
 bytes = "0.4"
 futures = "0.1"
 tokio-executor = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ sha1 = ">= 0.2, < 0.7"
 url = "1.2"
 rustc-serialize = { version = "0.3.16", optional = true }
 unix_socket = { version = "0.5.0", optional = true }
-combine = "3.2.0"
+combine = "3.8.0"
 bytes = "0.4"
 futures = "0.1"
 tokio-executor = "0.1"


### PR DESCRIPTION
`take_until_bytes` uses `memchr` to find the next end of line + some
minor changes to use the fact that we know that `line` contains `\r\n`
at the end.

```
decode                  time:   [2.1868 us 2.2129 us 2.2494 us]
                        change: [-30.297% -29.538% -28.706%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```