### PR TITLE
Remove rustc-serialize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 build = "build.rs"
 
 [features]
-with-rustc-json = ["rustc-serialize"]
 with-unix-sockets = ["unix_socket", "tokio-uds"]
 with-system-unix-sockets = []
 
@@ -20,7 +19,6 @@ dtoa = "0.4"
 itoa = "0.4.3"
 sha1 = ">= 0.2, < 0.7"
 url = "1.2"
-rustc-serialize = { version = "0.3.16", optional = true }
 unix_socket = { version = "0.5.0", optional = true }
 combine = "3.8.1"
 bytes = "0.4"

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ test:
 	@echo "===================================================================="
 	@echo "Testing Connection Type TCP"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=tcp RUST_TEST_THREADS=1 cargo test --features="with-rustc-json"
+	@REDISRS_SERVER_TYPE=tcp RUST_TEST_THREADS=1 cargo test
 	@echo "Testing Connection Type UNIX"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix cargo test --features="with-rustc-json" --test parser --test test_basic --test test_types
+	@REDISRS_SERVER_TYPE=unix cargo test --test parser --test test_basic --test test_types
 	@echo "===================================================================="
 	@echo "Testing Connection Type UNIX SOCKETS"
 	@echo "===================================================================="
-	@REDISRS_SERVER_TYPE=unix cargo test --features="with-rustc-json with-unix-sockets"
+	@REDISRS_SERVER_TYPE=unix cargo test --features="with-unix-sockets"
 
 test-single: RUST_TEST_THREADS=1
 test-single: test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,6 @@
 //!   enabling the `with-unix-sockets` feature flag.  On rust 1.10 or later
 //!   this is not needed.
 //!
-//! `with-rustc-json`:
-//!   This feature flag enables the `rustc_serialize` JSON support.
-//!
 //! ## Connection Parameters
 //!
 //! redis-rs knows different ways to define where a connection should
@@ -373,16 +370,10 @@ extern crate tokio_codec;
 extern crate tokio_sync;
 extern crate tokio_tcp;
 
-#[cfg(feature = "with-rustc-json")]
-pub extern crate rustc_serialize as serialize;
 #[cfg(feature = "with-unix-sockets")]
 extern crate tokio_uds;
 #[cfg(feature = "with-unix-sockets")]
 extern crate unix_socket;
-
-#[doc(hidden)]
-#[cfg(feature = "with-rustc-json")]
-pub use serialize::json::Json;
 
 // public api
 pub use client::Client;

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -181,26 +181,6 @@ fn test_optionals() {
     assert_eq!(a, 0i32);
 }
 
-#[cfg(feature = "with-rustc-json")]
-#[test]
-fn test_json() {
-    use redis::Json;
-
-    let ctx = TestContext::new();
-    let mut con = ctx.connection();
-
-    redis::cmd("SET")
-        .arg("foo")
-        .arg("[1, 2, 3]")
-        .execute(&mut con);
-
-    let json: Json = redis::cmd("GET").arg("foo").query(&mut con).unwrap();
-    assert_eq!(
-        json,
-        Json::Array(vec![Json::U64(1), Json::U64(2), Json::U64(3)])
-    );
-}
-
 #[test]
 fn test_scanning() {
     let ctx = TestContext::new();


### PR DESCRIPTION
rustc-serialize is long deprecated.
JSON (de)serialization can be handled by the user outside of redis-rs