### PR TITLE
add GETRANGE to Commands trait

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -166,6 +166,18 @@ implement_commands! {
         cmd("GETSET").arg(key).arg(value)
     }
 
+    /// Get a range of bytes/substring from the value of a key. Negative values provide an offset from the end of the value.
+    /// NOTE: in redis <= 2.0 this command was SUBSTR
+    fn getrange<K: ToRedisArgs>(key: K, from: isize, to: isize) {
+        cmd("GETRANGE").arg(key).arg(from).arg(to)
+    }
+
+    /// Get a range of bytes/substring from the value of a key. Negative values provide an offset from the end of the value.
+    /// NOTE: this command was renamed to GETRANGE in redis >= 2.0
+    fn substr<K: ToRedisArgs>(key: K, from: isize, to: isize) {
+        cmd("SUBSTR").arg(key).arg(from).arg(to)
+    }
+
     /// Delete one or more keys.
     fn del<K: ToRedisArgs>(key: K) {
         cmd("DEL").arg(key)


### PR DESCRIPTION
Adds [GETRANGE](https://redis.io/commands/getrange) and SUBSTR (for redis versions <= 2.0)