### PR TITLE
Expose RedisWrite

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,6 +413,7 @@ pub use types::{
     RedisError,
     RedisFuture,
     RedisResult,
+    RedisWrite,
     ToRedisArgs,
 
     // low level values


### PR DESCRIPTION
To implement `ToRedisArgs` outside this crate,  RedisWrite needs to be publicly exposed.