### PR TITLE
Update .gitignore to remove redundant target path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ lib
 target
 .rust
 Cargo.lock
-target


### PR DESCRIPTION
Just getting started with Rust and was looking at some popular libraries and noticed this redundant path. 