### PR TITLE
Fix seriously performance problem for SharedConnection 

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -145,7 +145,7 @@ impl Encoder for ValueCodec {
     type Item = Vec<u8>;
     type Error = RedisError;
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        dst.extend(item);
+        dst.extend_from_slice(item.as_ref());
         Ok(())
     }
 }


### PR DESCRIPTION
In following case, command sending is **1,000ms** over consuming.

- When using SharedConnection
- When sending few megabytes large object via SET

The cause is that `BytesMut.extend` is expanding by the iterator.
( For example, 1MB data is executed 1,000,000 times loop and too many allocations. 🤔  )

Instead, using `Bytes.extend_from_slice` will really improve performance.

Examples below:

```rust
    let mut buf = Vec::new();
    File::open("/path/to/large/file")
        .unwrap()
        .read_to_end(&mut buf).unwrap();
    let bytes = Bytes::from(buf);

    let client = redis::Client::open("redis://127.0.0.1:6379").unwrap();

    let instant = Instant::now();
    let f = client.get_shared_async_connection()
        .and_then(move |conn| {
            redis::cmd("SET")
                .arg("aaa")
                .arg(bytes.as_ref())
                .query_async(conn)
        })
        .map(move |(_, _): (_, String)| {
            println!("!!!!!!!!!!!!! Time spending {}ms", instant.elapsed().as_millis());
        })
        .map_err(|err| {
            panic!("Error: {}", err)
        });

    tokio::run(f);
```

Result in case for 9MB:
- Before: 890ms〜 on my machine.
- After: 10ms〜



