### PR TITLE
Fix "Trait object without an explicit dyn is deprecated" warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ redis = "0.11.0"
 Documentation on the library can be found at
 [docs.rs/redis](https://docs.rs/redis).
 
-**Note: redis-rs requires at least [Rust 1.26](https://blog.rust-lang.org/2018/05/10/Rust-1.26.html).**
+**Note: redis-rs requires at least [Rust 1.27](https://blog.rust-lang.org/2018/06/21/Rust-1.27.html).**
 
 ## Basic Operation
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -274,9 +274,11 @@ impl ActualConnection {
 
     pub fn read_response(&mut self) -> RedisResult<Value> {
         let result = Parser::new(match *self {
-            ActualConnection::Tcp(TcpConnection { ref mut reader, .. }) => reader as &mut BufRead,
+            ActualConnection::Tcp(TcpConnection { ref mut reader, .. }) => {
+                reader as &mut dyn BufRead
+            }
             #[cfg(unix)]
-            ActualConnection::Unix(UnixConnection { ref mut sock, .. }) => sock as &mut BufRead,
+            ActualConnection::Unix(UnixConnection { ref mut sock, .. }) => sock as &mut dyn BufRead,
         })
         .parse_value();
         // shutdown connection on protocol error

--- a/src/script.rs
+++ b/src/script.rs
@@ -77,7 +77,7 @@ impl Script {
 
     /// Invokes the script directly without arguments.
     #[inline]
-    pub fn invoke<T: FromRedisValue>(&self, con: &mut ConnectionLike) -> RedisResult<T> {
+    pub fn invoke<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
         ScriptInvocation {
             script: self,
             args: vec![],
@@ -123,7 +123,7 @@ impl<'a> ScriptInvocation<'a> {
 
     /// Invokes the script and returns the result.
     #[inline]
-    pub fn invoke<T: FromRedisValue>(&self, con: &mut ConnectionLike) -> RedisResult<T> {
+    pub fn invoke<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
         loop {
             match cmd("EVALSHA")
                 .arg(self.script.hash.as_bytes())

--- a/src/types.rs
+++ b/src/types.rs
@@ -208,9 +208,9 @@ impl error::Error for RedisError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match self.repr {
-            ErrorRepr::IoError(ref err) => Some(err as &error::Error),
+            ErrorRepr::IoError(ref err) => Some(err as &dyn error::Error),
             _ => None,
         }
     }
@@ -344,7 +344,7 @@ pub fn make_extension_error(code: &str, detail: Option<&str>) -> RedisError {
 /// Library generic result type.
 pub type RedisResult<T> = Result<T, RedisError>;
 
-pub type RedisFuture<T> = Box<Future<Item = T, Error = RedisError> + Send>;
+pub type RedisFuture<T> = Box<dyn Future<Item = T, Error = RedisError> + Send>;
 
 /// An info dictionary type.
 #[derive(Debug)]

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -27,7 +27,7 @@ impl ::quickcheck::Arbitrary for ArbitraryValue {
         let size = g.size();
         ArbitraryValue(arbitrary_value(g, size))
     }
-    fn shrink(&self) -> Box<Iterator<Item = Self>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         match self.0 {
             Value::Nil | Value::Okay => Box::new(None.into_iter()),
             Value::Int(i) => Box::new(i.shrink().map(Value::Int).map(ArbitraryValue)),

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -104,7 +104,10 @@ fn test_pipeline_transaction() {
     .unwrap();
 }
 
-fn test_cmd(con: &SharedConnection, i: i32) -> Box<Future<Item = (), Error = RedisError> + Send> {
+fn test_cmd(
+    con: &SharedConnection,
+    i: i32,
+) -> Box<dyn Future<Item = (), Error = RedisError> + Send> {
     let key = format!("key{}", i);
     let key_2 = key.clone();
     let key2 = format!("key{}_2", i);
@@ -133,7 +136,7 @@ fn test_cmd(con: &SharedConnection, i: i32) -> Box<Future<Item = (), Error = Red
     )
 }
 
-fn test_error(con: &SharedConnection) -> Box<Future<Item = (), Error = RedisError> + Send> {
+fn test_error(con: &SharedConnection) -> Box<dyn Future<Item = (), Error = RedisError> + Send> {
     Box::new(
         redis::cmd("SET")
             .query_async(con.clone())

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -766,7 +766,7 @@ fn test_invalid_protocol() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
 
-    let child = thread::spawn(move || -> Result<(), Box<Error + Send + Sync>> {
+    let child = thread::spawn(move || -> Result<(), Box<dyn Error + Send + Sync>> {
         let mut stream = BufReader::new(listener.incoming().next().unwrap()?);
         // read the request and respond with garbage
         let _: redis::Value = Parser::new(&mut stream).parse_value()?;


### PR DESCRIPTION
A recent-ish version of Rust nightly deprecated bare trait objects. This PR adds `dyn` to all trait objects in order to get rid of the warning.