### PR TITLE
Fix SINTERSTORE wrapper name

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -487,7 +487,7 @@ implement_commands! {
     }
 
     /// Intersect multiple sets and store the resulting set in a key.
-    fn sdinterstore<K: ToRedisArgs>(dstkey: K, keys: K) {
+    fn sinterstore<K: ToRedisArgs>(dstkey: K, keys: K) {
         cmd("SINTERSTORE").arg(dstkey).arg(keys)
     }
 


### PR DESCRIPTION
The wrapper for `SINTERSTORE` was incorrectly `sdinterstore`, probably a copy-paste mishap since the previous ones in the series are `sdiff...`