### PR TITLE
Allow running SharedConnection with any other runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,17 @@ url = "1.2"
 combine = "3.8.1"
 bytes = "0.4"
 futures = "0.1"
-tokio-executor = "0.1"
+tokio-executor = { version = "0.1", optional = true }
 tokio-tcp = "0.1"
 tokio-io = "0.1"
 tokio-codec = "0.1"
 tokio-sync = "0.1"
 
 [features]
-default = [ "geospatial" ]
+default = [ "executor", "geospatial" ]
 
 geospatial = []
+executor = ["tokio-executor"]
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = { version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tokio-sync = "0.1"
 default = [ "executor", "geospatial" ]
 
 geospatial = []
-executor = ["tokio-executor"]
+executor = [ "tokio-executor" ]
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = { version = "0.2" }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,4 +20,4 @@ install:
 build: false
 
 test_script:
-  - cargo test --verbose --no-default-features %cargoflags%
+  - cargo test --verbose --no-default-features --features executor %cargoflags%

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,6 +51,7 @@ impl Client {
         ::aio::connect(self.connection_info.clone())
     }
 
+    #[cfg(feature = "executor")]
     pub fn get_shared_async_connection(
         &self,
     ) -> impl Future<Item = ::aio::SharedConnection, Error = RedisError> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 use futures::Future;
 
 use connection::{connect, Connection, ConnectionInfo, ConnectionLike, IntoConnectionInfo};
+use futures::future::Executor;
 use types::{RedisError, RedisResult, Value};
 
 /// The client type.
@@ -53,8 +54,20 @@ impl Client {
     pub fn get_shared_async_connection(
         &self,
     ) -> impl Future<Item = ::aio::SharedConnection, Error = RedisError> {
+        let executor = tokio_executor::DefaultExecutor::current();
         self.get_async_connection()
-            .and_then(move |con| ::aio::SharedConnection::new(con))
+            .and_then(move |con| ::aio::SharedConnection::new(con, executor))
+    }
+
+    pub fn get_shared_async_connection_with_executor<E>(
+        &self,
+        executor: E,
+    ) -> impl Future<Item = ::aio::SharedConnection, Error = RedisError>
+    where
+        E: Executor<Box<dyn Future<Item = (), Error = ()> + Send>>,
+    {
+        self.get_async_connection()
+            .and_then(move |con| ::aio::SharedConnection::new(con, executor))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,6 @@ extern crate sha1;
 extern crate url;
 #[macro_use]
 extern crate futures;
-extern crate tokio_executor;
 #[macro_use]
 extern crate tokio_io;
 extern crate tokio_codec;


### PR DESCRIPTION
Currently, SharedConnection only works on tokio 0.1 runtime.
Because it depends on `tokio_executor::spawn` (with tokio 0.1.x).
( https://github.com/mitsuhiko/redis-rs/blob/master/src/aio.rs#L437

I want to use SharedConnection with `async/await` in tokio 0.3.

In this PR, for that purpose, make it can be specified Executor from outside without depending on a specific Executor.
( This way is also adopted for [hyper](https://github.com/hyperium/hyper/blob/c71abe5c208de4f1a488cad5f3c68509e7a89266/src/server/conn.rs#L313) , [rusoto](https://github.com/rusoto/rusoto/pull/1472), and more.

For example, 0.3 Executor will work with 0.1 adapter as below:

```rust
let client = redis::Client::open("redis://127.0.0.1:6379").unwrap();
let executor = DefaultExecutor::current(); // This is tokio 0.3 Executor
let executor = Executor03As01::new(DefaultExecutor::current()); // This is tokio 0.1 compatible  Executor
let conn = client.get_shared_async_connection_with_executor(executor).compat().await?; // Works with await 
```

Compatibility layers is:

```rust
use std::sync::Mutex;
use futures01::future::{Executor as Executor01, ExecuteError as ExecuteError01};
use futures01::Future as Future01;
use futures::compat::Future01CompatExt;
use futures::FutureExt;
use tokio_executor::Executor;

pub struct Executor03As01<Ex> {
    inner: Mutex<Ex>,
}

impl<Ex> Executor03As01<Ex> {
    pub fn new(inner: Ex) -> Self {
        Executor03As01 { inner: Mutex::new(inner) }
    }
}

impl<Ex, Fut> Executor01<Fut> for Executor03As01<Ex>
    where
        Ex: Executor,
        Fut: Future01<Item = (), Error = ()> + Send + 'static,
{
    fn execute(&self, future: Fut) -> Result<(), ExecuteError01<Fut>> {
        let mut future = future.compat().map(|_| ());
        let mut pin = Box::pin(future);

        let mut guard = self.inner.lock().unwrap();
        (&mut guard).spawn(pin).expect("unable to spawn future from Compat executor");
        Ok(())
    }
}
```