### PR TITLE
Fix Script::invoke_async return type error

### DIFF
--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -254,3 +254,24 @@ fn test_script() {
     }))
     .unwrap();
 }
+
+#[test]
+fn test_script_returning_complex_type() {
+    let ctx = TestContext::new();
+    block_on_all(future::lazy(|| {
+        ctx.shared_async_connection().and_then(|con| {
+            redis::Script::new("return {1, ARGV[1], true}")
+                .arg("hello")
+                .invoke_async(con)
+                .and_then(
+                    |(_con, (i, s, b)): (SharedConnection, (i32, String, bool))| {
+                        assert_eq!(i, 1);
+                        assert_eq!(s, "hello");
+                        assert_eq!(b, true);
+                        Ok(())
+                    },
+                )
+        })
+    }))
+    .unwrap();
+}


### PR DESCRIPTION
Previously, invoking a script with a complex return type would cause the following error: `Response was of incompatible type: "Not a bulk response" (response was string data('"4b98bef92b171357ddc437b395c7c1a5145ca2bd"'))`

This was because the Future returned when loading the script into the DB returns the hash of the script, and thus the return type of String would not match the intended return type.

This commit adds an enum to account for the different Future return types.

Apologies for not catching this originally!