### PR TITLE
Fix the command verb being sent to redis for zremrangebyrank

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -670,7 +670,7 @@ implement_commands! {
 
     /// Remove all members in a sorted set within the given indexes.
     fn zrembyrank<K: ToRedisArgs>(key: K, start: isize, stop: isize) {
-        cmd("ZREMBYRANK").arg(key).arg(start).arg(stop)
+        cmd("ZREMRANGEBYRANK").arg(key).arg(start).arg(stop)
     }
 
     /// Remove all members in a sorted set within the given scores.


### PR DESCRIPTION
This doesn't seem to be version specific (the command hasn't changed since 2.0.0) and the documentation is available [here][1]. It looks like this was just an oversight or a copy paste issue. 

Right now attempting to use the command gives the following error:

```
An error was signalled by the server: unknown command `ZREMBYRANK`
```

[1]: https://redis.io/commands/zremrangebyrank