### PR TITLE
Add optional support for TLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: rust
 cache: cargo
+script:
+  - cargo build --verbose --all
+  - cargo build --verbose --all --features tls
+  - cargo test --verbose --all
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,17 @@ tokio-io = "0.1"
 tokio-codec = "0.1"
 tokio-sync = "0.1"
 
+## default-tls
+native-tls = { version = "0.2", optional = true }
+tokio-tls = { version = "0.2", optional = true }
+
 [features]
 default = [ "executor", "geospatial" ]
 
 geospatial = []
 executor = [ "tokio-executor" ]
+
+tls = ["native-tls", "tokio-tls"]
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = { version = "0.2" }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -2,7 +2,7 @@ use redis;
 
 use futures;
 
-use futures::{Future};
+use futures::Future;
 
 use tokio::runtime::current_thread::block_on_all;
 
@@ -26,7 +26,8 @@ fn do_redis_async_code(url: &str) -> redis::RedisResult<()> {
                 assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
                 result
             })
-    })).unwrap();
+    }))
+    .unwrap();
     Ok(())
 }
 

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,0 +1,49 @@
+use redis;
+
+use futures;
+
+use futures::{Future};
+
+use tokio::runtime::current_thread::block_on_all;
+
+fn do_redis_async_code(url: &str) -> redis::RedisResult<()> {
+    let client = redis::Client::open(url)?;
+    let connect = client.get_async_connection();
+
+    block_on_all(connect.and_then(|con| {
+        redis::cmd("SET")
+            .arg("key1")
+            .arg(b"foo")
+            .query_async(con)
+            .and_then(|(con, ())| redis::cmd("SET").arg(&["key2", "bar"]).query_async(con))
+            .and_then(|(con, ())| {
+                redis::cmd("MGET")
+                    .arg(&["key1", "key2"])
+                    .query_async(con)
+                    .map(|t| t.1)
+            })
+            .then(|result| {
+                assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
+                result
+            })
+    })).unwrap();
+    Ok(())
+}
+
+fn main() {
+    let url = if std::env::args().nth(1) == Some("--tls".into()) {
+        "redis+tls://127.0.0.1:6380/#insecure"
+    } else {
+        "redis://127.0.0.1:6379/"
+    };
+    // at this point the errors are fatal, let's just fail hard.
+    match do_redis_async_code(url) {
+        Err(err) => {
+            println!("Could not execute example:");
+            println!("  {:?}", err);
+        }
+        Ok(()) => {
+            println!("success!");
+        }
+    }
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,5 @@
 use redis;
 use redis::{transaction, Commands, PipelineCommands};
-use std::error::Error;
 
 use std::collections::HashMap;
 
@@ -136,9 +135,9 @@ fn do_atomic_increment(con: &mut redis::Connection) -> redis::RedisResult<()> {
 }
 
 /// Runs all the examples and propagates errors up.
-fn do_redis_code() -> redis::RedisResult<()> {
+fn do_redis_code(url: &str) -> redis::RedisResult<()> {
     // general connection handling
-    let client = redis::Client::open("redis://127.0.0.1/")?;
+    let client = redis::Client::open(url)?;
     let mut con = client.get_connection()?;
 
     // read some config and print it.
@@ -155,11 +154,16 @@ fn do_redis_code() -> redis::RedisResult<()> {
 }
 
 fn main() {
+    let url = if std::env::args().nth(1) == Some("--tls".into()) {
+        "redis+tls://127.0.0.1:6380/#insecure"
+    } else {
+        "redis://127.0.0.1:6379/"
+    };
     // at this point the errors are fatal, let's just fail hard.
-    match do_redis_code() {
+    match do_redis_code(url) {
         Err(err) => {
             println!("Could not execute example:");
-            println!("  {}: {}", err.category(), err.description());
+            println!("  {:?}", err);
         }
         Ok(()) => {}
     }

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -561,12 +561,6 @@ impl ConnectionLike for SharedConnection {
         offset: usize,
         count: usize,
     ) -> RedisFuture<(Self, Vec<Value>)> {
-        #[cfg(not(unix))]
-        let future = match self.pipeline {
-            ActualPipeline::Tcp(ref pipeline) => pipeline.send_recv_multiple(cmd, offset + count),
-        };
-
-        #[cfg(unix)]
         let future = self.pipeline.send_recv_multiple(cmd, offset + count);
         Box::new(
             future

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -149,7 +149,10 @@ pub fn connect(
                 #[cfg(feature = "tls")]
                 {
                     use std::convert::TryInto;
-                    let cx: native_tls::TlsConnector = tls.try_into().unwrap(); // TODO: fix unwrap
+                    let cx: native_tls::TlsConnector = match tls.try_into() {
+                        Ok(cx) => cx,
+                        Err(e) => return Either::A(future::err(e))
+                    };
                     let cx = tokio_tls::TlsConnector::from(cx);
                     CaseFuture::A(
                         TcpStream::connect(&socket_addr)
@@ -516,13 +519,6 @@ where
             })
     }
 }
-
-// #[derive(Clone)]
-// enum ActualPipeline {
-//     Tcp(Pipeline<Framed<TcpStream, ValueCodec>>),
-//     #[cfg(unix)]
-//     Unix(Pipeline<Framed<UnixStream, ValueCodec>>),
-// }
 
 /// A connection object bound to an executor.
 #[derive(Clone)]

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -146,6 +146,34 @@ pub fn connect(
                     .map(|con| ActualConnection::Tcp(BufReader::new(con))),
             )
         }
+        // ConnectionAddr::TcpTls(ref host, ref port) => {
+        //     use native_tls::TlsConnector;
+        //     let connector = TlsConnector::new().unwrap();
+        //     let socket_addr = match (&host[..], port).to_socket_addrs() {
+        //         Ok(mut socket_addrs) => match socket_addrs.next() {
+        //             Some(socket_addr) => socket_addr,
+        //             None => {
+        //                 return Either::A(future::err(RedisError::from((
+        //                     ErrorKind::InvalidClientConfig,
+        //                     "No address found for host",
+        //                 ))));
+        //             }
+        //         },
+        //         Err(err) => return Either::A(future::err(err.into())),
+        //     };
+        //     use native_tls::TlsConnector;
+        //     use tokio_tls;
+        //     let tls = TlsConnector::builder().build().unwrap();
+        //     let tls = tokio_tls::TlsConnector::from(cx);
+
+        //     Either::A(
+        //         TcpStream::connect(&addr).and_then(move |socket| {
+        //             tls.connect(&host, socket)
+        //         })
+        //         .from_err()
+        //         .map(|con| ActualConnection::Tcp(BufReader::new(con))),
+        //     )
+        // }
         #[cfg(unix)]
         ConnectionAddr::Unix(ref path) => Either::B(
             UnixStream::connect(path).map(|stream| ActualConnection::Unix(BufReader::new(stream))),

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -152,7 +152,7 @@ pub fn connect(
                     use std::convert::TryInto;
                     let cx: native_tls::TlsConnector = match tls.try_into() {
                         Ok(cx) => cx,
-                        Err(e) => return Either::A(future::err(e))
+                        Err(e) => return Either::A(future::err(e)),
                     };
                     let cx = tokio_tls::TlsConnector::from(cx);
                     CaseFuture::A(

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -224,10 +224,7 @@ fn url_to_tcp_connection_info(
 }
 
 #[cfg(unix)]
-fn url_to_unix_connection_info(
-    url: url::Url,
-    tls: Option<TlsConnectionInfo>,
-) -> RedisResult<ConnectionInfo> {
+fn url_to_unix_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
     Ok(ConnectionInfo {
         addr: Box::new(ConnectionAddr::Unix(unwrap_or!(
             url.to_file_path().ok(),
@@ -269,7 +266,7 @@ impl IntoConnectionInfo for url::Url {
                 };
                 url_to_tcp_connection_info(self, tls_connection_info)
             }
-            "unix" | "redis+unix" => url_to_unix_connection_info(self, None),
+            "unix" | "redis+unix" => url_to_unix_connection_info(self),
             _ => fail!((
                 ErrorKind::InvalidClientConfig,
                 "URL provided is not a redis URL"

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -120,6 +120,7 @@ impl TestContext {
             addr: Box::new(server.get_client_addr().clone()),
             db: 0,
             passwd: None,
+            tls: None,
         })
         .unwrap();
         let mut con;


### PR DESCRIPTION
Resolves issue #241 

I decided to go with dynamic dispatch, since static dispatch with one more feature flag was adding tons of duplicated code. I totally understand if this is not what you'd like to merge in the crate, and am totally willing to rework on this with some guidance.

I chose to use the `redis+tls` scheme, as it seems this is what some other libraries are using. Hostname verification can be disabled by adding `#insecure` to the URL.

I guess it would also be possible to add `stunnel` and a generate a self-signed certificate to test this in CI.