### PR TITLE
Add Cmd::get, Cmd::set and remove PipelineCommands

### DIFF
--- a/benches/bench_basic.rs
+++ b/benches/bench_basic.rs
@@ -13,7 +13,7 @@ use tokio::runtime::current_thread::Runtime;
 
 use criterion::{Bencher, Benchmark, Criterion, Throughput};
 
-use redis::{PipelineCommands, Value};
+use redis::Value;
 
 fn get_client() -> redis::Client {
     redis::Client::open("redis://127.0.0.1:6379").unwrap()

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,4 @@
-use redis;
-use redis::{transaction, Commands, PipelineCommands};
+use redis::{self, transaction, Commands};
 use std::error::Error;
 
 use std::collections::HashMap;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,7 +49,7 @@ macro_rules! implement_commands {
                 #[inline]
                 fn $name<$($tyargs: $ty,)* RV: FromRedisValue>(
                     &mut self $(, $argname: $argty)*) -> RedisResult<RV>
-                    { ($body).query(self) }
+                    { Cmd::$name($($argname),*).query(self) }
             )*
 
             /// Incrementally iterate the keys space.
@@ -119,6 +119,15 @@ macro_rules! implement_commands {
                 c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
                 c.iter(self)
             }
+        }
+
+        impl Cmd {
+            $(
+                $(#[$attr])*
+                pub fn $name<$($tyargs: $ty),*>($($argname: $argty),*) -> Self {
+                    ::std::mem::replace($body, Cmd::new())
+                }
+            )*
         }
 
         /// Implements common redis commands for pipelines.  Unlike the regular

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -133,16 +133,13 @@ macro_rules! implement_commands {
         /// Implements common redis commands for pipelines.  Unlike the regular
         /// commands trait, this returns the pipeline rather than a result
         /// directly.  Other than that it works the same however.
-        pub trait PipelineCommands {
-            #[doc(hidden)]
-            fn perform(&mut self, con: Cmd) -> &mut Self;
-
+        impl Pipeline {
             $(
                 $(#[$attr])*
                 #[inline]
-                fn $name<$($tyargs: $ty),*>(
+                pub fn $name<$($tyargs: $ty),*>(
                     &mut self $(, $argname: $argty)*) -> &mut Self
-                    { self.perform(::std::mem::replace($body, Cmd::new())) }
+                    { self.add_command(::std::mem::replace($body, Cmd::new())) }
             )*
         }
     )
@@ -1066,11 +1063,5 @@ impl PubSubCommands for Connection {
                 ControlFlow::Break(value) => return Ok(value),
             }
         };
-    }
-}
-
-impl PipelineCommands for Pipeline {
-    fn perform(&mut self, cmd: Cmd) -> &mut Pipeline {
-        self.add_command(cmd)
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -728,7 +728,7 @@ impl Msg {
 /// Example:
 ///
 /// ```rust,no_run
-/// use redis::{Commands, PipelineCommands};
+/// use redis::Commands;
 /// # fn do_something() -> redis::RedisResult<()> {
 /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 /// # let mut con = client.get_connection().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,12 +205,10 @@
 //! # Ok(()) }
 //! ```
 //!
-//! You can also use high-level commands on pipelines through the
-//! `PipelineCommands` trait:
+//! You can also use high-level commands on pipelines:
 //!
 //! ```rust,no_run
 //! # fn do_something() -> redis::RedisResult<()> {
-//! use redis::PipelineCommands;
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let mut con = client.get_connection().unwrap();
 //! let (k1, k2) : (i32, i32) = redis::pipe()
@@ -230,7 +228,7 @@
 //!
 //! ```rust,no_run
 //! # fn do_something() -> redis::RedisResult<()> {
-//! use redis::{Commands, PipelineCommands};
+//! use redis::Commands;
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let mut con = client.get_connection().unwrap();
 //! let key = "the_key";
@@ -351,7 +349,7 @@
 // public api
 pub use crate::client::Client;
 pub use crate::cmd::{cmd, pack_command, pipe, Cmd, Iter, Pipeline};
-pub use crate::commands::{Commands, ControlFlow, PipelineCommands, PubSubCommands};
+pub use crate::commands::{Commands, ControlFlow, PubSubCommands};
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
     IntoConnectionInfo, Msg, PubSub,

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::let_unit_value)]
 use redis;
 
-use redis::{Commands, ControlFlow, PipelineCommands, PubSubCommands};
+use redis::{Commands, ControlFlow, PubSubCommands};
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::collections::{HashMap, HashSet};


### PR DESCRIPTION
0b314e2 

It is currently possible to call `set`,`get` etc on a connection and
run the query directly but it isn't possible to create a `Cmd` struct
without running the query (except for `Pipeline`).

This adds this capability with just some small tweaks to the macro
allowing `Cmd::set("abc", 123)` to be used etc.


af5fc36

A simple `impl Pipeline` block will do the trick here.

BREAKING CHANGE

Remove any imports of PipelineCommands