### PR TITLE
Do not require transaction to use FromRedisValue

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -745,7 +745,7 @@ impl Msg {
 pub fn transaction<
     C: ConnectionLike,
     K: ToRedisArgs,
-    T: FromRedisValue,
+    T,
     F: FnMut(&mut C, &mut Pipeline) -> RedisResult<Option<T>>,
 >(
     con: &mut C,


### PR DESCRIPTION
`redis::transaction` takes a closure that returns a value, and it returns that value itself if the value is Option::Some. There is no use of FromRedisValue in `transaction`, so it's not clear why this trait bound is required. It seems perfectly valid to return something that will never be serialized/deserialized with redis, such as a struct containing metrics about the statements run in the transaction.