### PR TITLE
feat: Add ToRedisArgs for &T

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -740,12 +740,20 @@ impl<T: ToRedisArgs> ToRedisArgs for Option<T> {
     }
 }
 
-impl <T: ToRedisArgs> ToRedisArgs for &T {
+impl<T: ToRedisArgs> ToRedisArgs for &T {
+    fn to_redis_args(&self) -> Vec<Vec<u8>> {
+        ToRedisArgs::to_redis_args(*self)
+    }
+
     fn write_redis_args<W>(&self, out: &mut W)
     where
         W: ?Sized + RedisWrite,
     {
         ToRedisArgs::write_redis_args(*self, out)
+    }
+
+    fn describe_numeric_behavior(&self) -> NumericBehavior {
+        ToRedisArgs::describe_numeric_behavior(*self)
     }
 
     fn is_single_arg(&self) -> bool {

--- a/src/types.rs
+++ b/src/types.rs
@@ -680,15 +680,6 @@ impl ToRedisArgs for String {
     }
 }
 
-impl<'a> ToRedisArgs for &'a String {
-    fn write_redis_args<W>(&self, out: &mut W)
-    where
-        W: ?Sized + RedisWrite,
-    {
-        out.write_arg(self.as_bytes())
-    }
-}
-
 impl<'a> ToRedisArgs for &'a str {
     fn write_redis_args<W>(&self, out: &mut W)
     where
@@ -746,6 +737,19 @@ impl<T: ToRedisArgs> ToRedisArgs for Option<T> {
             Some(ref x) => x.is_single_arg(),
             None => false,
         }
+    }
+}
+
+impl <T: ToRedisArgs> ToRedisArgs for &T {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        ToRedisArgs::write_redis_args(*self, out)
+    }
+
+    fn is_single_arg(&self) -> bool {
+        ToRedisArgs::is_single_arg(*self)
     }
 }
 


### PR DESCRIPTION
This is purely for ergonomics. Having a variable `x: Vec<_>` and passing that variable as `&x` will infer `&Vec<_>` as type, so one currently has to write:

```
let x: Vec<_> =  ...;
client.get(&x[..])
```

With this change one can write:

```
client.get(&x)
```