### PR TITLE
Cut further done on dependencies (make script optional)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ url = "2.1"
 sha1 = { version = ">= 0.2, < 0.7", optional = true }
 
 # Dependency that is shared with tokio.  If we manage to make tokio optional we
-# could also kll this.
+# could also remove this.
 bytes = "0.5"
 
 # These are needed for parsing at the moment 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,28 +15,51 @@ edition = "2018"
 all-features = true
 
 [dependencies]
+# These two are generally really common simple dependencies so it does not seem
+# much of a point to optimize these, but these could in theory be removed for
+# an indirection through std::Formatter.
 dtoa = "0.4"
 itoa = "0.4.3"
+
+# This is a dependency that already exists in url
 percent-encoding = "2.1"
-sha1 = ">= 0.2, < 0.7"
+
+# We need this for redis url parsing
 url = "2.1"
-combine = "3.8.1"
+
+# We need this for script support
+sha1 = { version = ">= 0.2, < 0.7", optional = true }
+
+# Dependency that is shared with tokio.  If we manage to make tokio optional we
+# could also kll this.
 bytes = "0.5"
+
+# These are needed for parsing at the moment 
+combine = "3.8.1"
 futures-util = { version = "0.3.0", features = ["sink"], default-features = false }
-futures-executor = "0.3.0"
+futures-executor = { version = "0.3.0", default-features = false }
+
+# Only needed for AIO
 pin-project-lite = { version = "0.1", optional = true }
-tokio-util = { version = "0.2", features = ["codec"] }
-tokio = "0.2"
-crc16 = { version = "0.4.0", optional = true }
-rand = { version = "0.7.0", optional = true }
+tokio-util = { version = "0.2", features = ["codec"], optional = true }
+
+# Only needed for the r2d2 feature
 r2d2 = { version = "0.8.8", optional = true }
 
+# Only needed for cluster
+crc16 = { version = "0.4.0", optional = true }
+rand = { version = "0.7.0", optional = true }
+
+# Unfortunately currently a necessary dependency
+tokio = "0.2"
+
 [features]
-default = ["geospatial", "aio"]
-aio = ["pin-project-lite", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util"]
+default = ["geospatial", "aio", "script"]
+aio = ["pin-project-lite", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util"]
 tokio-rt-core = ["aio", "tokio/rt-core"]
 geospatial = []
 cluster = ["crc16", "rand"]
+script = ["sha1"]
 
 [dev-dependencies]
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ bytes = "0.5"
 # These are needed for parsing at the moment 
 combine = "3.8.1"
 futures-util = { version = "0.3.0", features = ["sink"], default-features = false }
-futures-executor = { version = "0.3.0", default-features = false }
+futures-executor = "0.3.0"
 
 # Only needed for AIO
 pin-project-lite = { version = "0.1", optional = true }

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -16,8 +16,10 @@ use tokio::{
 };
 use tokio_util::codec::Decoder;
 
+#[cfg(unix)]
+use futures_util::future::Either;
 use futures_util::{
-    future::{Either, Future, FutureExt, TryFutureExt},
+    future::{Future, FutureExt, TryFutureExt},
     ready,
     sink::Sink,
     stream::{Stream, StreamExt},

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -270,7 +270,7 @@ impl ActualConnection {
                 open: true,
             }),
             #[cfg(not(unix))]
-            ConnectionAddr::Unix(ref path) => {
+            ConnectionAddr::Unix(ref _path) => {
                 fail!((
                     ErrorKind::InvalidClientConfig,
                     "Cannot connect to unix sockets \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,25 +274,27 @@
 //! # }
 //! ```
 //!
-//! # Scripts
-//!
-//! Lua scripts are supported through the `Script` type in a convenient
-//! way (it does not support pipelining currently).  It will automatically
-//! load the script if it does not exist and invoke it.
-//!
-//! Example:
-//!
-//! ```rust,no_run
-//! # fn do_something() -> redis::RedisResult<()> {
-//! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-//! # let mut con = client.get_connection().unwrap();
-//! let script = redis::Script::new(r"
-//!     return tonumber(ARGV[1]) + tonumber(ARGV[2]);
-//! ");
-//! let result : isize = script.arg(1).arg(2).invoke(&mut con)?;
-//! assert_eq!(result, 3);
-//! # Ok(()) }
-//! ```
+#![cfg_attr(feature = "script", doc = r##"
+# Scripts
+
+Lua scripts are supported through the `Script` type in a convenient
+way (it does not support pipelining currently).  It will automatically
+load the script if it does not exist and invoke it.
+
+Example:
+
+```rust,no_run
+# fn do_something() -> redis::RedisResult<()> {
+# let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+# let mut con = client.get_connection().unwrap();
+let script = redis::Script::new(r"
+    return tonumber(ARGV[1]) + tonumber(ARGV[2]);
+");
+let result : isize = script.arg(1).arg(2).invoke(&mut con)?;
+assert_eq!(result, 3);
+# Ok(()) }
+```
+"##)]
 //!
 //! # Async
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,9 @@
 //! # }
 //! ```
 //!
-#![cfg_attr(feature = "script", doc = r##"
+#![cfg_attr(
+    feature = "script",
+    doc = r##"
 # Scripts
 
 Lua scripts are supported through the `Script` type in a convenient
@@ -294,7 +296,8 @@ let result : isize = script.arg(1).arg(2).invoke(&mut con)?;
 assert_eq!(result, 3);
 # Ok(()) }
 ```
-"##)]
+"##
+)]
 //!
 //! # Async
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,15 @@
 //!
 //! ## Optional Features
 //!
-//! There are currently two features defined that can enable additional
-//! functionality if so desired.
+//! There are a few features defined that can enable additional functionality
+//! if so desired.  Some of them are turned on by default.
+//!
+//! * `aio`: enables async IO support (enabled by default)
+//! * `geospatial`: enables geospatial support (enabled by default)
+//! * `script`: enables script support (enabled by default)
+//! * `r2d2`: enables r2d2 connection pool support (optional)
+//! * `cluster`: enables redis cluster support (optional)
+//! * `tokio-rt-core`: enables support for tokio-rt (optional)
 //!
 //! ## Connection Parameters
 //!
@@ -339,6 +346,8 @@ pub use crate::connection::{
     IntoConnectionInfo, Msg, PubSub,
 };
 pub use crate::parser::{parse_redis_value, parse_redis_value_async, Parser};
+
+#[cfg(feature = "script")]
 pub use crate::script::{Script, ScriptInvocation};
 
 pub use crate::types::{

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "script")]
 use sha1::Sha1;
 
 use crate::cmd::cmd;

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -236,6 +236,7 @@ fn test_transaction_multiplexed_connection() {
 }
 
 #[test]
+#[cfg(feature = "script")]
 fn test_script() {
     // Note this test runs both scripts twice to test when they have already been loaded
     // into Redis and when they need to be loaded in

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -6,7 +6,7 @@ use futures::{future, prelude::*};
 
 use crate::support::*;
 
-use redis::{aio::MultiplexedConnection, RedisError, RedisResult};
+use redis::{aio::MultiplexedConnection, RedisResult};
 
 mod support;
 
@@ -238,6 +238,8 @@ fn test_transaction_multiplexed_connection() {
 #[test]
 #[cfg(feature = "script")]
 fn test_script() {
+    use redis::RedisError;
+
     // Note this test runs both scripts twice to test when they have already been loaded
     // into Redis and when they need to be loaded in
     let script1 = redis::Script::new("return redis.call('SET', KEYS[1], ARGV[1])");
@@ -268,6 +270,7 @@ fn test_script() {
 }
 
 #[test]
+#[cfg(feature = "script")]
 fn test_script_returning_complex_type() {
     let ctx = TestContext::new();
     block_on_all(async {

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -568,6 +568,7 @@ fn scoped_pubsub() {
 }
 
 #[test]
+#[cfg(feature = "script")]
 fn test_script() {
     let ctx = TestContext::new();
     let mut con = ctx.connection();

--- a/tests/test_cluster.rs
+++ b/tests/test_cluster.rs
@@ -43,6 +43,7 @@ fn test_cluster_eval() {
 }
 
 #[test]
+#[cfg(feature = "script")]
 fn test_cluster_script() {
     let cluster = TestClusterContext::new(3, 0);
     let mut con = cluster.connection();


### PR DESCRIPTION
This cuts down the default dependencies:

```
redis v0.15.2-alpha.0
├── bytes v0.5.3
├── combine v3.8.1
│   ├── ascii v0.9.3
│   ├── byteorder v1.3.2
│   ├── either v1.5.2
│   ├── memchr v2.2.1
│   └── unreachable v1.0.0
│       └── void v1.0.2
├── dtoa v0.4.4
├── futures-executor v0.3.1
│   ├── futures-core v0.3.1
│   ├── futures-task v0.3.1
│   └── futures-util v0.3.1
│       ├── futures-core v0.3.1 (*)
│       ├── futures-sink v0.3.1
│       ├── futures-task v0.3.1 (*)
│       └── pin-utils v0.1.0-alpha.4
├── futures-util v0.3.1 (*)
├── itoa v0.4.4
├── percent-encoding v2.1.0
├── tokio v0.2.9
│   ├── bytes v0.5.3 (*)
│   └── pin-project-lite v0.1.2
└── url v2.1.0
    ├── idna v0.2.0
    │   ├── matches v0.1.8
    │   ├── unicode-bidi v0.3.4
    │   │   └── matches v0.1.8 (*)
    │   └── unicode-normalization v0.1.8
    │       └── smallvec v0.6.10
    ├── matches v0.1.8 (*)
    └── percent-encoding v2.1.0 (*)
```

Refs #257 