### PR TITLE
feat: Let async dependencies like tokio be avoided in sync code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 sudo: false
 language: rust
-cache: cargo
+
+# Prevents cargo's cache from growing to large, see https://levans.fr/rust_travis_cache.html
+# Need to cache the whole `.cargo` directory to keep .crates.toml for
+# cargo-update to work
+cache:
+  directories:
+    - /home/travis/.cargo
+
+# But don't cache the cargo registry
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ sha1 = { version = ">= 0.2, < 0.7", optional = true }
 # could also remove this.
 bytes = "0.5"
 
-# These are needed for parsing at the moment 
-combine = "3.8.1"
+# These are needed for parsing at the moment
+combine = "4.0.1"
 futures-util = { version = "0.3.0", features = ["sink"], default-features = false }
 futures-executor = "0.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,14 @@ url = "2.1"
 # We need this for script support
 sha1 = { version = ">= 0.2, < 0.7", optional = true }
 
-bytes = "0.5"
-combine = "4.0.1"
+combine = { version = "4.0.1", default-features = false }
 
 # Only needed for AIO
-futures-util = { version = "0.3.0", features = ["sink"], default-features = false, optional = true }
+bytes = { version = "0.5", optional = true }
+futures-util = { version = "0.3.0", default-features = false, optional = true }
 pin-project-lite = { version = "0.1", optional = true }
-tokio-util = { version = "0.2", features = ["codec"], optional = true }
-tokio = { version = "0.2", features = ["io-util"], optional = true }
+tokio-util = { version = "0.2", optional = true }
+tokio = { version = "0.2", optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.8", optional = true }
@@ -48,7 +48,7 @@ rand = { version = "0.7.0", optional = true }
 
 [features]
 default = ["geospatial", "aio", "script"]
-aio = ["pin-project-lite", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util"]
+aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/std", "combine/tokio-02"]
 tokio-rt-core = ["aio", "tokio/rt-core"]
 geospatial = []
 cluster = ["crc16", "rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,14 @@ url = "2.1"
 # We need this for script support
 sha1 = { version = ">= 0.2, < 0.7", optional = true }
 
-# Dependency that is shared with tokio.  If we manage to make tokio optional we
-# could also remove this.
 bytes = "0.5"
-
-# These are needed for parsing at the moment
 combine = "4.0.1"
-futures-util = { version = "0.3.0", features = ["sink"], default-features = false }
-futures-executor = "0.3.0"
 
 # Only needed for AIO
+futures-util = { version = "0.3.0", features = ["sink"], default-features = false, optional = true }
 pin-project-lite = { version = "0.1", optional = true }
 tokio-util = { version = "0.2", features = ["codec"], optional = true }
+tokio = { version = "0.2", features = ["io-util"], optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.8", optional = true }
@@ -49,9 +45,6 @@ r2d2 = { version = "0.8.8", optional = true }
 # Only needed for cluster
 crc16 = { version = "0.4.0", optional = true }
 rand = { version = "0.7.0", optional = true }
-
-# Unfortunately currently a necessary dependency
-tokio = "0.2"
 
 [features]
 default = ["geospatial", "aio", "script"]
@@ -71,6 +64,7 @@ criterion = "0.3"
 partial-io = { version = "0.3", features = ["tokio", "quickcheck"] }
 quickcheck = "0.6"
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
+# End of dev-dependencies
 
 [[test]]
 name = "test_async"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ url = "2.1"
 # We need this for script support
 sha1 = { version = ">= 0.2, < 0.7", optional = true }
 
-combine = { version = "4.0.1", default-features = false }
+combine = { version = "4.0.1", default-features = false, features = ["std"] }
 
 # Only needed for AIO
 bytes = { version = "0.5", optional = true }
@@ -48,7 +48,7 @@ rand = { version = "0.7.0", optional = true }
 
 [features]
 default = ["geospatial", "aio", "script"]
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/std", "combine/tokio-02"]
+aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
 tokio-rt-core = ["aio", "tokio/rt-core"]
 geospatial = []
 cluster = ["crc16", "rand"]

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -180,16 +180,14 @@ async fn connect_simple(connection_info: &ConnectionInfo) -> RedisResult<ActualC
             };
 
             TcpStream::connect(&socket_addr)
-                .map_ok(|con| ActualConnection::Tcp(BufReader::new(BufWriter::new(con))))
-                .await?
+                .await
+                .map(|con| ActualConnection::Tcp(BufReader::new(BufWriter::new(con))))?
         }
 
         #[cfg(unix)]
-        ConnectionAddr::Unix(ref path) => {
-            UnixStream::connect(path)
-                .map_ok(|stream| ActualConnection::Unix(BufReader::new(BufWriter::new(stream))))
-                .await?
-        }
+        ConnectionAddr::Unix(ref path) => UnixStream::connect(path)
+            .await
+            .map(|stream| ActualConnection::Unix(BufReader::new(BufWriter::new(stream))))?,
 
         #[cfg(not(unix))]
         ConnectionAddr::Unix(_) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -87,8 +87,7 @@ impl Client {
         crate::aio::MultiplexedConnection,
         impl std::future::Future<Output = ()>,
     )> {
-        let con = self.get_async_connection().await?;
-        Ok(crate::aio::MultiplexedConnection::new(con))
+        crate::aio::MultiplexedConnection::new(&self.connection_info).await
     }
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -160,7 +160,6 @@ where
     Ok(())
 }
 
-#[cfg(feature = "aio")]
 fn encode_pipeline(cmds: &[Cmd], atomic: bool) -> Vec<u8> {
     let mut rv = vec![];
     write_pipeline(&mut rv, cmds, atomic);
@@ -543,6 +542,7 @@ impl Pipeline {
         encode_pipeline(&self.commands, self.transaction_mode)
     }
 
+    #[cfg(feature = "aio")]
     pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
         write_pipeline(out, &self.commands, self.transaction_mode)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,8 +355,8 @@ pub use crate::connection::{
 };
 #[cfg(feature = "aio")]
 pub use crate::parser::parse_redis_value_async;
-#[cfg(feature = "script")]
 pub use crate::parser::{parse_redis_value, Parser};
+#[cfg(feature = "script")]
 pub use crate::script::{Script, ScriptInvocation};
 
 #[cfg(feature = "aio")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,14 +353,11 @@ pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
     IntoConnectionInfo, Msg, PubSub,
 };
-#[cfg(feature = "aio")]
-pub use crate::parser::parse_redis_value_async;
 pub use crate::parser::{parse_redis_value, Parser};
 #[cfg(feature = "script")]
+#[cfg_attr(docsrs, doc(cfg(feature = "script")))]
 pub use crate::script::{Script, ScriptInvocation};
 
-#[cfg(feature = "aio")]
-pub use crate::types::RedisFuture;
 pub use crate::types::{
     // utility functions
     from_redis_value,
@@ -386,11 +383,13 @@ pub use crate::types::{
 };
 
 #[cfg(feature = "aio")]
-pub use crate::commands::AsyncCommands;
+#[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
+pub use crate::{commands::AsyncCommands, parser::parse_redis_value_async, types::RedisFuture};
 
 mod macros;
 
 #[cfg(feature = "aio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub mod aio;
 
 #[cfg(feature = "geospatial")]
@@ -398,9 +397,11 @@ pub mod aio;
 pub mod geo;
 
 #[cfg(feature = "cluster")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cluster")))]
 pub mod cluster;
 
 #[cfg(feature = "r2d2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "r2d2")))]
 mod r2d2;
 
 mod client;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,11 +11,11 @@ use tokio::io::AsyncRead;
 use tokio_util::codec::{Decoder, Encoder};
 
 use combine::{
+    any,
     error::StreamError,
     opaque,
     parser::{
-        byte::{byte, crlf, take_until_bytes},
-        choice::choice,
+        byte::{crlf, take_until_bytes},
         combinator::{any_send_partial_state, AnySendPartialState},
         range::{recognize, take},
     },
@@ -65,90 +65,93 @@ where
     I::Error: combine::ParseError<u8, &'a [u8], I::Position>,
 {
     opaque!({
-        let line = || {
-            recognize(take_until_bytes(&b"\r\n"[..]).with(take(2).map(|_| ()))).and_then(
-                |line: &[u8]| {
-                    str::from_utf8(&line[..line.len() - 2]).map_err(StreamErrorFor::<I>::other)
-                },
+        any_send_partial_state(any().then_partial(move |&mut b| {
+            let line = || {
+                recognize(take_until_bytes(&b"\r\n"[..]).with(take(2).map(|_| ()))).and_then(
+                    |line: &[u8]| {
+                        str::from_utf8(&line[..line.len() - 2]).map_err(StreamErrorFor::<I>::other)
+                    },
+                )
+            };
+
+            let status = || {
+                line().map(|line| {
+                    if line == "OK" {
+                        Value::Okay
+                    } else {
+                        Value::Status(line.into())
+                    }
+                })
+            };
+
+            let int = || {
+                line().and_then(|line| match line.trim().parse::<i64>() {
+                    Err(_) => Err(StreamErrorFor::<I>::message_static_message(
+                        "Expected integer, got garbage",
+                    )),
+                    Ok(value) => Ok(value),
+                })
+            };
+
+            let data = || {
+                int().then_partial(move |size| {
+                    if *size < 0 {
+                        combine::value(Value::Nil).left()
+                    } else {
+                        take(*size as usize)
+                            .map(|bs: &[u8]| Value::Data(bs.to_vec()))
+                            .skip(crlf())
+                            .right()
+                    }
+                })
+            };
+
+            let bulk = || {
+                int().then_partial(|&mut length| {
+                    if length < 0 {
+                        combine::value(Value::Nil).map(Ok).left()
+                    } else {
+                        let length = length as usize;
+                        combine::count_min_max(length, length, value())
+                            .map(|result: ResultExtend<_, _>| result.0.map(Value::Bulk))
+                            .right()
+                    }
+                })
+            };
+
+            let error = || {
+                line().map(|line: &str| {
+                    let desc = "An error was signalled by the server";
+                    let mut pieces = line.splitn(2, ' ');
+                    let kind = match pieces.next().unwrap() {
+                        "ERR" => ErrorKind::ResponseError,
+                        "EXECABORT" => ErrorKind::ExecAbortError,
+                        "LOADING" => ErrorKind::BusyLoadingError,
+                        "NOSCRIPT" => ErrorKind::NoScriptError,
+                        "MOVED" => ErrorKind::Moved,
+                        "ASK" => ErrorKind::Ask,
+                        "TRYAGAIN" => ErrorKind::TryAgain,
+                        "CLUSTERDOWN" => ErrorKind::ClusterDown,
+                        "CROSSSLOT" => ErrorKind::CrossSlot,
+                        "MASTERDOWN" => ErrorKind::MasterDown,
+                        code => return make_extension_error(code, pieces.next()),
+                    };
+                    match pieces.next() {
+                        Some(detail) => RedisError::from((kind, desc, detail.to_string())),
+                        None => RedisError::from((kind, desc)),
+                    }
+                })
+            };
+
+            combine::dispatch!(b;
+                b'+' => status().map(Ok),
+                b':' => int().map(|i| Ok(Value::Int(i))),
+                b'$' => data().map(Ok),
+                b'*' => bulk(),
+                b'-' => error().map(Err),
+                b => combine::unexpected_any(combine::error::Token(b))
             )
-        };
-
-        let status = || {
-            line().map(|line| {
-                if line == "OK" {
-                    Value::Okay
-                } else {
-                    Value::Status(line.into())
-                }
-            })
-        };
-
-        let int = || {
-            line().and_then(|line| match line.trim().parse::<i64>() {
-                Err(_) => Err(StreamErrorFor::<I>::message_static_message(
-                    "Expected integer, got garbage",
-                )),
-                Ok(value) => Ok(value),
-            })
-        };
-
-        let data = || {
-            int().then_partial(move |size| {
-                if *size < 0 {
-                    combine::value(Value::Nil).left()
-                } else {
-                    take(*size as usize)
-                        .map(|bs: &[u8]| Value::Data(bs.to_vec()))
-                        .skip(crlf())
-                        .right()
-                }
-            })
-        };
-
-        let bulk = || {
-            int().then_partial(|&mut length| {
-                if length < 0 {
-                    combine::value(Value::Nil).map(Ok).left()
-                } else {
-                    let length = length as usize;
-                    combine::count_min_max(length, length, value())
-                        .map(|result: ResultExtend<_, _>| result.0.map(Value::Bulk))
-                        .right()
-                }
-            })
-        };
-
-        let error = || {
-            line().map(|line: &str| {
-                let desc = "An error was signalled by the server";
-                let mut pieces = line.splitn(2, ' ');
-                let kind = match pieces.next().unwrap() {
-                    "ERR" => ErrorKind::ResponseError,
-                    "EXECABORT" => ErrorKind::ExecAbortError,
-                    "LOADING" => ErrorKind::BusyLoadingError,
-                    "NOSCRIPT" => ErrorKind::NoScriptError,
-                    "MOVED" => ErrorKind::Moved,
-                    "ASK" => ErrorKind::Ask,
-                    "TRYAGAIN" => ErrorKind::TryAgain,
-                    "CLUSTERDOWN" => ErrorKind::ClusterDown,
-                    "CROSSSLOT" => ErrorKind::CrossSlot,
-                    "MASTERDOWN" => ErrorKind::MasterDown,
-                    code => return make_extension_error(code, pieces.next()),
-                };
-                match pieces.next() {
-                    Some(detail) => RedisError::from((kind, desc, detail.to_string())),
-                    None => RedisError::from((kind, desc)),
-                }
-            })
-        };
-
-        any_send_partial_state(choice((
-            byte(b'+').with(status().map(Ok)),
-            byte(b':').with(int().map(Value::Int).map(Ok)),
-            byte(b'$').with(data().map(Ok)),
-            byte(b'*').with(bulk()),
-            byte(b'-').with(error().map(Err)),
-        )))
+        }))
     })
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -229,6 +229,7 @@ mod aio_support {
 }
 
 #[cfg(feature = "aio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub use self::aio_support::*;
 
 /// The internal redis response parser.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -237,6 +237,12 @@ pub struct Parser {
     decoder: combine::stream::decoder::Decoder<AnySendPartialState, PointerOffset<[u8]>>,
 }
 
+impl Default for Parser {
+    fn default() -> Self {
+        Parser::new()
+    }
+}
+
 /// The parser can be used to parse redis responses into values.  Generally
 /// you normally do not use this directly as it's already done for you by
 /// the client but in some more complex situations it might be useful to be

--- a/src/types.rs
+++ b/src/types.rs
@@ -423,6 +423,7 @@ pub fn make_extension_error(code: &str, detail: Option<&str>) -> RedisError {
 pub type RedisResult<T> = Result<T, RedisError>;
 
 /// Library generic future type.
+#[cfg(feature = "aio")]
 pub type RedisFuture<'a, T> = futures_util::future::BoxFuture<'a, RedisResult<T>>;
 
 /// An info dictionary type.

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -759,10 +759,10 @@ fn test_invalid_protocol() {
     let child = thread::spawn(move || -> Result<(), Box<dyn Error + Send + Sync>> {
         let mut stream = BufReader::new(listener.incoming().next().unwrap()?);
         // read the request and respond with garbage
-        let _: redis::Value = Parser::new(&mut stream).parse_value()?;
+        let _: redis::Value = Parser::new().parse_value(&mut stream)?;
         stream.get_mut().write_all(b"garbage ---!#!#\r\n\r\n\n\r")?;
         // block until the stream is shutdown by the client
-        let _: RedisResult<redis::Value> = Parser::new(&mut stream).parse_value();
+        let _: RedisResult<redis::Value> = Parser::new().parse_value(&mut stream);
         Ok(())
     });
     sleep(Duration::from_millis(100));


### PR DESCRIPTION
Updates to `combine-4` which pulls the decoding logic into combine itself, allowing redis to only call a pair of macros (for sync and async code respectively). The buffering has been moved into the `Decoder` struct provided by `combine` which avoids some unnecessary copying that the previous implementation did and the `BufReader` were therefore removed.

BREAKING CHANGE

The `Parser` type now only persists the buffer and takes the `Read` instance in `parse_value`