### PR TITLE
Connection manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,7 @@ futures = "0.3"
 criterion = "0.3"
 partial-io = { version = "0.3", features = ["tokio", "quickcheck"] }
 quickcheck = "0.6"
-tokio = { version = "0.2", features = ["rt-core", "macros"] }
-# End of dev-dependencies
+tokio = { version = "0.2", features = ["rt-core", "macros", "time"] }
 
 [[test]]
 name = "test_async"
@@ -86,3 +85,7 @@ required-features = ["tokio-rt-core"]
 [[example]]
 name = "async-await"
 required-features = ["aio"]
+
+[[example]]
+name = "async-connection-loss"
+required-features = ["tokio-rt-core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "0.2", optional = true }
 
 # Only needed for the connection manager
 arc-swap = { version = "0.4.4", optional = true }
+futures = { version = "0.3.3", optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.8", optional = true }
@@ -56,7 +57,7 @@ tokio-rt-core = ["aio", "tokio/rt-core"]
 geospatial = []
 cluster = ["crc16", "rand"]
 script = ["sha1"]
-connection-manager = ["tokio-rt-core", "arc-swap"]
+connection-manager = ["tokio-rt-core", "arc-swap", "futures"]
 
 [dev-dependencies]
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ pin-project-lite = { version = "0.1", optional = true }
 tokio-util = { version = "0.2", optional = true }
 tokio = { version = "0.2", optional = true }
 
+# Only needed for the connection manager
+# TODO: Add separate feature for this
+arc-swap = { version = "0.4.4", optional = true }
+
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.8", optional = true }
 
@@ -49,7 +53,7 @@ rand = { version = "0.7.0", optional = true }
 [features]
 default = ["geospatial", "aio", "script"]
 aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
-tokio-rt-core = ["aio", "tokio/rt-core"]
+tokio-rt-core = ["aio", "tokio/rt-core", "arc-swap"]
 geospatial = []
 cluster = ["crc16", "rand"]
 script = ["sha1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ tokio-util = { version = "0.2", optional = true }
 tokio = { version = "0.2", optional = true }
 
 # Only needed for the connection manager
-# TODO: Add separate feature for this
 arc-swap = { version = "0.4.4", optional = true }
 
 # Only needed for the r2d2 feature
@@ -53,10 +52,11 @@ rand = { version = "0.7.0", optional = true }
 [features]
 default = ["geospatial", "aio", "script"]
 aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
-tokio-rt-core = ["aio", "tokio/rt-core", "arc-swap"]
+tokio-rt-core = ["aio", "tokio/rt-core"]
 geospatial = []
 cluster = ["crc16", "rand"]
 script = ["sha1"]
+connection-manager = ["tokio-rt-core", "arc-swap"]
 
 [dev-dependencies]
 rand = "0.7"
@@ -92,4 +92,4 @@ required-features = ["aio"]
 
 [[example]]
 name = "async-connection-loss"
-required-features = ["tokio-rt-core"]
+required-features = ["connection-manager"]

--- a/examples/async-connection-loss.rs
+++ b/examples/async-connection-loss.rs
@@ -4,7 +4,7 @@
 //! - Async multiplexed connection
 //! - Async connection manager
 //!
-//! It will then send a PING every second and print the result.
+//! It will then send a PING every 100 ms and print the result.
 
 use std::env;
 use std::process;
@@ -20,12 +20,12 @@ enum Mode {
 }
 
 async fn run<C: ConnectionLike>(mut con: C) -> redis::RedisResult<()> {
-    let mut interval = interval(Duration::from_secs(1));
+    let mut interval = interval(Duration::from_millis(100));
     loop {
         interval.tick().await;
-        println!("PING");
+        println!("> PING");
         let result: redis::RedisResult<String> = redis::cmd("PING").query_async(&mut con).await;
-        println!("Query result: {:?}", result);
+        println!("< {:?}", result);
     }
 }
 

--- a/examples/async-connection-loss.rs
+++ b/examples/async-connection-loss.rs
@@ -31,7 +31,7 @@ async fn run<C: ConnectionLike>(mut con: C) -> redis::RedisResult<()> {
 
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
-    let mode = match env::args().skip(1).next().as_ref().map(String::as_str) {
+    let mode = match env::args().nth(1).as_ref().map(String::as_str) {
         Some("default") => {
             println!("Using default connection mode\n");
             Mode::Default

--- a/examples/async-connection-loss.rs
+++ b/examples/async-connection-loss.rs
@@ -1,0 +1,60 @@
+//! This example will connect to Redis in one of three modes:
+//!
+//! - Regular async connection
+//! - Async multiplexed connection
+//! - Async connection manager
+//!
+//! It will then send a PING every second and print the result.
+
+use std::env;
+use std::process;
+use std::time::Duration;
+
+use redis::aio::ConnectionLike;
+use tokio::time::interval;
+
+enum Mode {
+    Default,
+    Multiplexed,
+    Reconnect,
+}
+
+async fn run<C: ConnectionLike>(mut con: C) -> redis::RedisResult<()> {
+    let mut interval = interval(Duration::from_secs(1));
+    loop {
+        interval.tick().await;
+        println!("PING");
+        let result: redis::RedisResult<String> = redis::cmd("PING").query_async(&mut con).await;
+        println!("Query result: {:?}", result);
+    }
+}
+
+#[tokio::main]
+async fn main() -> redis::RedisResult<()> {
+    let mode = match env::args().skip(1).next().as_ref().map(String::as_str) {
+        Some("default") => {
+            println!("Using default connection mode\n");
+            Mode::Default
+        }
+        Some("multiplexed") => {
+            println!("Using multiplexed connection mode\n");
+            Mode::Multiplexed
+        }
+        Some("reconnect") => {
+            println!("Using reconnect manager mode\n");
+            Mode::Reconnect
+        }
+        Some(_) | None => {
+            println!("Usage: reconnect-manager (default|multiplexed|reconnect)");
+            process::exit(1);
+        }
+    };
+
+    let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    match mode {
+        Mode::Default => run(client.get_async_connection().await?).await?,
+        Mode::Multiplexed => run(client.get_multiplexed_tokio_connection().await?).await?,
+        Mode::Reconnect => run(client.get_tokio_connection_manager().await?).await?,
+    };
+    Ok(())
+}

--- a/examples/async-connection-loss.rs
+++ b/examples/async-connection-loss.rs
@@ -25,7 +25,7 @@ async fn run_single<C: ConnectionLike>(mut con: C) -> RedisResult<()> {
     let mut interval = interval(Duration::from_millis(1000));
     loop {
         interval.tick().await;
-        println!("");
+        println!();
         println!("> PING");
         let result: RedisResult<String> = redis::cmd("PING").query_async(&mut con).await;
         println!("< {:?}", result);
@@ -36,7 +36,7 @@ async fn run_multi<C: ConnectionLike + Clone>(mut con: C) -> RedisResult<()> {
     let mut interval = interval(Duration::from_millis(100));
     loop {
         interval.tick().await;
-        println!("");
+        println!();
         println!("> PING");
         println!("> PING");
         println!("> PING");

--- a/examples/async-connection-loss.rs
+++ b/examples/async-connection-loss.rs
@@ -22,7 +22,7 @@ enum Mode {
 }
 
 async fn run_single<C: ConnectionLike>(mut con: C) -> RedisResult<()> {
-    let mut interval = interval(Duration::from_millis(1000));
+    let mut interval = interval(Duration::from_millis(100));
     loop {
         interval.tick().await;
         println!();

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -581,8 +581,13 @@ mod connection_manager {
     use futures::future::{self, Shared};
     use futures_util::future::BoxFuture;
 
-    /// A `ConnectionManager` is a proxy that wraps a multiplexed connection and
-    /// automatically reconnects to the server when necessary.
+    /// A `ConnectionManager` is a proxy that wraps a [multiplexed
+    /// connection][multiplexed-connection] and automatically reconnects to the
+    /// server when necessary.
+    ///
+    /// Like the [`MultiplexedConnection`][multiplexed-connection], this
+    /// manager can be cloned, allowing requests to be be sent concurrently on
+    /// the same underlying connection (tcp/unix socket).
     ///
     /// ## Behavior
     ///
@@ -599,6 +604,8 @@ mod connection_manager {
     ///   initiated, will have to await the connection future.
     /// - If reconnecting fails, all pending commands will be failed as well. A
     ///   new reconnection attempt will be triggered if the error is an I/O error.
+    ///
+    /// [multiplexed-connection]: struct.MultiplexedConnection.html
     #[derive(Clone)]
     pub struct ConnectionManager {
         /// Information used for the connection. This is needed to be able to reconnect.

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -700,7 +700,7 @@ mod connection_manager {
                 let connection_result = (**guard)
                     .clone()
                     .await
-                    .map_err(|e| e.clone_mostly(Some("Reconnecting failed")));
+                    .map_err(|e| e.clone_mostly("Reconnecting failed"));
                 reconnect_if_io_error!(self, connection_result, guard);
                 let result = connection_result?.req_packed_command(cmd).await;
                 reconnect_if_dropped!(self, &result, guard);
@@ -721,7 +721,7 @@ mod connection_manager {
                 let connection_result = (**guard)
                     .clone()
                     .await
-                    .map_err(|e| e.clone_mostly(Some("Reconnecting failed")));
+                    .map_err(|e| e.clone_mostly("Reconnecting failed"));
                 reconnect_if_io_error!(self, connection_result, guard);
                 let result = connection_result?
                     .req_packed_commands(cmd, offset, count)

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -571,7 +571,7 @@ impl ConnectionLike for MultiplexedConnection {
     }
 }
 
-#[cfg(feature = "tokio-rt-core")]
+#[cfg(feature = "connection-manager")]
 mod connection_manager {
     use super::*;
 
@@ -590,7 +590,8 @@ mod connection_manager {
     impl ConnectionManager {
         /// Connect to the server and store the connection inside the returned `ConnectionManager`.
         ///
-        /// This requires the `tokio-rt-core` feature as it uses the default tokio executor.
+        /// This requires the `connection-manager` feature, which will also pull in
+        /// the Tokio executor.
         pub async fn new(connection_info: ConnectionInfo) -> RedisResult<Self> {
             // Wait for the initial connection to be established
             let inner_connection = connect(&connection_info).await?;
@@ -675,5 +676,5 @@ mod connection_manager {
     }
 }
 
-#[cfg(feature = "tokio-rt-core")]
+#[cfg(feature = "connection-manager")]
 pub use connection_manager::ConnectionManager;

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -622,11 +622,8 @@ mod connection_manager {
         /// This requires the `connection-manager` feature, which will also pull in
         /// the Tokio executor.
         pub async fn new(connection_info: ConnectionInfo) -> RedisResult<Self> {
-            // Wait for the initial connection to be established
-            let inner_connection = connect(&connection_info).await?;
-
-            // Wrap the connection in a MultiplexedConnection
-            let (connection, driver) = MultiplexedConnection::new(inner_connection);
+            // Create a MultiplexedConnection and wait for it to be established
+            let (connection, driver) = MultiplexedConnection::new(&connection_info).await?;
 
             // Spawn the driver that drives the connection future
             tokio::spawn(driver);
@@ -650,8 +647,7 @@ mod connection_manager {
         ) {
             let connection_info = self.connection_info.clone();
             let new_connection: SharedRedisFuture<MultiplexedConnection> = async move {
-                let (new_connection, driver) =
-                    MultiplexedConnection::new(connect(&connection_info).await?);
+                let (new_connection, driver) = MultiplexedConnection::new(&connection_info).await?;
                 tokio::spawn(driver);
                 Ok(new_connection)
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -90,7 +90,7 @@ impl Client {
         crate::aio::MultiplexedConnection::new(&self.connection_info).await
     }
 
-    /// Returns an async [`ConnectionManager`][connectionmanager] from the client.
+    /// Returns an async [`ConnectionManager`][connection-manager] from the client.
     ///
     /// The connection manager wraps a
     /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
@@ -98,10 +98,9 @@ impl Client {
     /// established in the background and the error is returned to the caller.
     ///
     /// This means that on connection loss at least one command will fail, but
-    /// the connection will be re-established automatically if possible. (TODO
-    /// dbrgn: Document what happens if reconnection attempts fail, and what happens
-    /// to commands that are invoked while a reconnection attempt is in
-    /// progress.)
+    /// the connection will be re-established automatically if possible. Please
+    /// refer to the [`ConnectionManager`][connection-manager] docs for
+    /// detailed reconnecting behavior.
     ///
     /// A connection manager can be cloned, allowing requests to be be sent concurrently
     /// on the same underlying connection (tcp/unix socket).

--- a/src/client.rs
+++ b/src/client.rs
@@ -90,7 +90,7 @@ impl Client {
         crate::aio::MultiplexedConnection::new(&self.connection_info).await
     }
 
-    #[cfg(feature = "tokio-rt-core")]
+    #[cfg(feature = "connection-manager")]
     pub async fn get_tokio_connection_manager(
         &self,
     ) -> RedisResult<crate::aio::ConnectionManager> {

--- a/src/client.rs
+++ b/src/client.rs
@@ -112,9 +112,7 @@ impl Client {
     /// [connection-manager]: aio/struct.ConnectionManager.html
     /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
-    pub async fn get_tokio_connection_manager(
-        &self,
-    ) -> RedisResult<crate::aio::ConnectionManager> {
+    pub async fn get_tokio_connection_manager(&self) -> RedisResult<crate::aio::ConnectionManager> {
         Ok(crate::aio::ConnectionManager::new(self.connection_info.clone()).await?)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -89,6 +89,13 @@ impl Client {
     )> {
         crate::aio::MultiplexedConnection::new(&self.connection_info).await
     }
+
+    #[cfg(feature = "tokio-rt-core")]
+    pub async fn get_tokio_connection_manager(
+        &self,
+    ) -> RedisResult<crate::aio::ConnectionManager> {
+        Ok(crate::aio::ConnectionManager::new(self.connection_info.clone()).await?)
+    }
 }
 
 impl ConnectionLike for Client {

--- a/src/client.rs
+++ b/src/client.rs
@@ -90,6 +90,27 @@ impl Client {
         crate::aio::MultiplexedConnection::new(&self.connection_info).await
     }
 
+    /// Returns an async [`ConnectionManager`][connectionmanager] from the client.
+    ///
+    /// The connection manager wraps a
+    /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
+    /// connection fails with a connection error, then a new connection is
+    /// established in the background and the error is returned to the caller.
+    ///
+    /// This means that on connection loss at least one command will fail, but
+    /// the connection will be re-established automatically if possible. (TODO
+    /// dbrgn: Document what happens if reconnection attempts fail, and what happens
+    /// to commands that are invoked while a reconnection attempt is in
+    /// progress.)
+    ///
+    /// A connection manager can be cloned, allowing requests to be be sent concurrently
+    /// on the same underlying connection (tcp/unix socket).
+    ///
+    /// This requires the `connection-manager` feature, which in turn pulls in
+    /// the Tokio executor.
+    ///
+    /// [connection-manager]: aio/struct.ConnectionManager.html
+    /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
     #[cfg(feature = "connection-manager")]
     pub async fn get_tokio_connection_manager(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 //! * `r2d2`: enables r2d2 connection pool support (optional)
 //! * `cluster`: enables redis cluster support (optional)
 //! * `tokio-rt-core`: enables support for tokio-rt (optional)
+//! * `connection-manager`: enables support for automatic reconnection (optional)
 //!
 //! ## Connection Parameters
 //!


### PR DESCRIPTION
Early draft of a ConnectionManager that would address the reconnect behavior discussed in #218.

Would be great to get some feedback on it. @Marwes you've written something like this in the past, right?

To test, run `cargo run --example async-connection-loss --features="tokio-rt-core" reconnect` and then restart and/or stop redis. Output for a 2s server downtime:

```
PING
Query result: Ok("PONG")
PING
Query result: Ok("PONG")
PING
Connection lost, reconnecting
Reconnecting failed: Connection refused (os error 111)
Query result: Err(broken pipe)
PING
Connection lost, reconnecting
Reconnecting failed: Connection refused (os error 111)
Query result: Err(broken pipe)
PING
Connection lost, reconnecting
Query result: Err(broken pipe)
PING
Query result: Ok("PONG")
```

I'll add some comments inline.

Based on #276.