### PR TITLE
Fix some low level stream commands for redis cluster

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -725,7 +725,6 @@ impl RoutingInfo {
             }
             b"XGROUP" | b"XINFO" => get_arg(&args, 2).and_then(RoutingInfo::for_key),
             b"XREAD" | b"XREADGROUP" => {
-                let streams_command = Value::Data("STREAMS".into());
                 let streams_position = args.iter().position(|a| match a {
                     Value::Data(a) => a == b"STREAMS",
                     _ => false,

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -726,7 +726,10 @@ impl RoutingInfo {
             b"XGROUP" | b"XINFO" => get_arg(&args, 2).and_then(RoutingInfo::for_key),
             b"XREAD" | b"XREADGROUP" => {
                 let streams_command = Value::Data("STREAMS".into());
-                let streams_position = args.iter().position(|a| *a == streams_command)?;
+                let streams_position = args.iter().position(|a| match a {
+                    Value::Data(a) => a == b"STREAMS",
+                    _ => false,
+                })?;
                 get_arg(&args, streams_position + 1).and_then(RoutingInfo::for_key)
             }
             _ => match get_arg(&args, 1) {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -723,6 +723,13 @@ impl RoutingInfo {
                     get_arg(&args, 3).and_then(RoutingInfo::for_key)
                 }
             }
+            b"XGROUP" | b"XINFO" => get_arg(&args, 2).and_then(RoutingInfo::for_key),
+            b"XREAD" | b"XREADGROUP" => {
+                let streams_position = args
+                    .iter()
+                    .position(|a| *a == Value::Data(b"STREAMS".to_vec()))?;
+                get_arg(&args, streams_position + 1).and_then(RoutingInfo::for_key)
+            }
             _ => match get_arg(&args, 1) {
                 Some(key) => RoutingInfo::for_key(key),
                 None => Some(RoutingInfo::Random),

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -725,9 +725,8 @@ impl RoutingInfo {
             }
             b"XGROUP" | b"XINFO" => get_arg(&args, 2).and_then(RoutingInfo::for_key),
             b"XREAD" | b"XREADGROUP" => {
-                let streams_position = args
-                    .iter()
-                    .position(|a| *a == Value::Data(b"STREAMS".to_vec()))?;
+                let streams_command = Value::Data("STREAMS".into());
+                let streams_position = args.iter().position(|a| *a == streams_command)?;
                 get_arg(&args, streams_position + 1).and_then(RoutingInfo::for_key)
             }
             _ => match get_arg(&args, 1) {


### PR DESCRIPTION
Fix key position for stream commands:
- `xgroup` and `xinfo` have key position on 3rd place
- `xread` and `xreadgroup` have key right after **STREAMS** keyword


Small note: `xread` and `xreadgroup` command can take multiple streams (multiple keys) and my proposed solution is calculating hash only based on first key.  
I think this assumption is correct because 2 things could happen:
- all stream keys will belong to the same slot, so no point of calculating slot for each key (highly unlikely)
- some stream keys will map to different slots, then no matter how we calculate routing, redis command will fail with error: `(error) CROSSSLOT Keys in request don't hash to the same slot`