### PR TITLE
fix: Return UnexpectedEof if we try to decode at eof

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 use_try_shorthand = true
+edition = "2018"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::io::Write;
+use std::io::{self, Write};
 use std::net::{self, TcpStream, ToSocketAddrs};
 use std::path::PathBuf;
 use std::str::from_utf8;
@@ -557,19 +557,25 @@ impl Connection {
             }
         };
         // shutdown connection on protocol error
-        match result {
-            Err(ref e) if e.kind() == ErrorKind::ResponseError => match self.con {
-                ActualConnection::Tcp(ref mut connection) => {
-                    let _ = connection.reader.shutdown(net::Shutdown::Both);
-                    connection.open = false;
+        if let Err(e) = &result {
+            let shutdown = e.kind() == ErrorKind::ResponseError
+                || match e.as_io_error() {
+                    Some(e) => e.kind() == io::ErrorKind::UnexpectedEof,
+                    None => false,
+                };
+            if shutdown {
+                match self.con {
+                    ActualConnection::Tcp(ref mut connection) => {
+                        let _ = connection.reader.shutdown(net::Shutdown::Both);
+                        connection.open = false;
+                    }
+                    #[cfg(unix)]
+                    ActualConnection::Unix(ref mut connection) => {
+                        let _ = connection.sock.shutdown(net::Shutdown::Both);
+                        connection.open = false;
+                    }
                 }
-                #[cfg(unix)]
-                ActualConnection::Unix(ref mut connection) => {
-                    let _ = connection.sock.shutdown(net::Shutdown::Both);
-                    connection.open = false;
-                }
-            },
-            _ => (),
+            }
         }
         result
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -326,6 +326,13 @@ impl RedisError {
         }
     }
 
+    pub(crate) fn as_io_error(&self) -> Option<&io::Error> {
+        match &self.repr {
+            ErrorRepr::IoError(e) => Some(e),
+            _ => None,
+        }
+    }
+
     /// Indicates that this is a cluster error.
     pub fn is_cluster_error(&self) -> bool {
         match self.kind() {

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -1,5 +1,5 @@
 use futures::{future, prelude::*};
-use redis::{aio::MultiplexedConnection, AsyncCommands, RedisResult};
+use redis::{aio::MultiplexedConnection, cmd, AsyncCommands, ErrorKind, RedisResult};
 
 use crate::support::*;
 
@@ -277,6 +277,56 @@ fn test_script_returning_complex_type() {
             .await
     })
     .unwrap();
+}
+
+#[tokio::test]
+async fn io_error_on_kill_issue_320() {
+    let ctx = TestContext::new();
+
+    let mut conn_to_kill = ctx.async_connection().await.unwrap();
+    cmd("CLIENT")
+        .arg("SETNAME")
+        .arg("to-kill")
+        .query_async::<_, ()>(&mut conn_to_kill)
+        .await
+        .unwrap();
+
+    let client_list: String = cmd("CLIENT")
+        .arg("LIST")
+        .query_async(&mut conn_to_kill)
+        .await
+        .unwrap();
+
+    eprintln!("{}", client_list);
+    let client_to_kill = client_list
+        .split('\n')
+        .find(|line| line.contains("to-kill"))
+        .expect("line")
+        .split(' ')
+        .nth(0)
+        .expect("id")
+        .split('=')
+        .nth(1)
+        .expect("id value");
+
+    let mut killer_conn = ctx.async_connection().await.unwrap();
+    let _: () = cmd("CLIENT")
+        .arg("KILL")
+        .arg("ID")
+        .arg(client_to_kill)
+        .query_async(&mut killer_conn)
+        .await
+        .unwrap();
+    let mut killed_client = conn_to_kill;
+
+    let err = loop {
+        match killed_client.get::<_, Option<String>>("a").await {
+            // We are racing against the server being shutdown so try until we a get an io error
+            Ok(_) => tokio::time::delay_for(std::time::Duration::from_millis(50)).await,
+            Err(err) => break err,
+        }
+    };
+    assert_eq!(err.kind(), ErrorKind::IoError); // Shouldn't this be IoError?
 }
 
 mod pub_sub {

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -794,5 +794,6 @@ fn test_redis_server_down() {
     let ping = redis::cmd("PING").query::<String>(&mut con);
 
     assert_eq!(ping.is_err(), true);
+    eprintln!("{}", ping.unwrap_err());
     assert_eq!(con.is_open(), false);
 }


### PR DESCRIPTION
The underlying read may just return 0 (indicating eof), which will
then propagate to the next parse attempt which explicitly handles end of
file and returns the error.

Had to alter the test case so it works on redis < 5

Fixes #320

