### PR TITLE
Support *SCAN methods on async connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,14 +55,14 @@ async-trait = "0.1.24"
 
 [features]
 default = ["geospatial", "tokio-comp", "async-std-comp", "script"]
-aio = ["futures", "bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
+aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
 tokio-rt-core = ["tokio-comp", "tokio/rt-core"]
 geospatial = []
 cluster = ["crc16", "rand"]
 script = ["sha1"]
 async-std-comp = ["aio", "async-std"]
 tokio-comp = ["aio", "tokio"]
-connection-manager = ["tokio-rt-core", "arc-swap", "futures"]
+connection-manager = ["futures", "tokio-rt-core", "arc-swap", "futures"]
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ async-trait = "0.1.24"
 
 [features]
 default = ["geospatial", "tokio-comp", "async-std-comp", "script"]
-aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
+aio = ["futures", "bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
 tokio-rt-core = ["tokio-comp", "tokio/rt-core"]
 geospatial = []
 cluster = ["crc16", "rand"]

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -455,8 +455,7 @@ impl ConnectionLike for Connection {
             if self.pubsub {
                 self.exit_pubsub().await?;
             }
-            self.buf.clear();
-            self.buf.copy_from_slice(cmd);
+            self.buf = Vec::from(cmd);
             self.con.write_all(&self.buf).await?;
             self.read_response().await
         })

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -455,7 +455,8 @@ impl ConnectionLike for Connection {
             if self.pubsub {
                 self.exit_pubsub().await?;
             }
-            self.buf = Vec::from(cmd);
+            self.buf.clear();
+            self.buf.copy_from_slice(cmd);
             self.con.write_all(&self.buf).await?;
             self.read_response().await
         })

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -427,7 +427,7 @@ fn get_socket_addrs(host: &str, port: u16) -> RedisResult<SocketAddr> {
 }
 
 /// An async abstraction over connections.
-pub trait ConnectionLike: Send {
+pub trait ConnectionLike {
     /// Sends an already encoded (packed) command into the TCP socket and
     /// reads the single response from it.
     fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value>;

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -35,7 +35,7 @@ use futures_util::{
 
 use pin_project_lite::pin_project;
 
-use crate::cmd::{cmd, Cmd};
+use crate::cmd;
 use crate::connection::Msg;
 use crate::connection::{ConnectionAddr, ConnectionInfo};
 
@@ -430,7 +430,7 @@ fn get_socket_addrs(host: &str, port: u16) -> RedisResult<SocketAddr> {
 pub trait ConnectionLike {
     /// Sends an already encoded (packed) command into the TCP socket and
     /// reads the single response from it.
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value>;
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a [u8]) -> RedisFuture<'a, Value>;
 
     /// Sends multiple already encoded (packed) command into the TCP socket
     /// and reads `count` responses from it.  This is used to implement
@@ -450,13 +450,13 @@ pub trait ConnectionLike {
 }
 
 impl ConnectionLike for Connection {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a [u8]) -> RedisFuture<'a, Value> {
         (async move {
             if self.pubsub {
                 self.exit_pubsub().await?;
             }
             self.buf.clear();
-            cmd.write_packed_command(&mut self.buf);
+            self.buf.copy_from_slice(cmd);
             self.con.write_all(&self.buf).await?;
             self.read_response().await
         })
@@ -811,17 +811,11 @@ impl MultiplexedConnection {
 }
 
 impl ConnectionLike for MultiplexedConnection {
-    fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+    fn req_packed_command<'a>(&'a mut self, cmd: &'a [u8]) -> RedisFuture<'a, Value> {
         (async move {
-            let value = self
-                .pipeline
-                .send(cmd.get_packed_command())
-                .await
-                .map_err(|err| {
-                    err.unwrap_or_else(|| {
-                        RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe))
-                    })
-                })?;
+            let value = self.pipeline.send(Vec::from(cmd)).await.map_err(|err| {
+                err.unwrap_or_else(|| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))
+            })?;
             Ok(value)
         })
         .boxed()
@@ -1020,7 +1014,7 @@ mod connection_manager {
     }
 
     impl ConnectionLike for ConnectionManager {
-        fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value> {
+        fn req_packed_command<'a>(&'a mut self, cmd: &'a [u8]) -> RedisFuture<'a, Value> {
             (async move {
                 // Clone connection to avoid having to lock the ArcSwap in write mode
                 let guard = self.connection.load();

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -427,7 +427,7 @@ fn get_socket_addrs(host: &str, port: u16) -> RedisResult<SocketAddr> {
 }
 
 /// An async abstraction over connections.
-pub trait ConnectionLike: Sized {
+pub trait ConnectionLike: Send {
     /// Sends an already encoded (packed) command into the TCP socket and
     /// reads the single response from it.
     fn req_packed_command<'a>(&'a mut self, cmd: &'a Cmd) -> RedisFuture<'a, Value>;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -73,7 +73,7 @@ impl<'a, T: FromRedisValue> Iterator for Iter<'a, T> {
 
 use crate::aio::ConnectionLike as AsyncConnection;
 
-///Represents a redis iterator that can be used with async connections.  
+/// Represents a redis iterator that can be used with async connections.  
 #[cfg(feature = "aio")]
 pub struct AsyncIter<'a, T: FromRedisValue + 'a> {
     batch: Vec<T>,
@@ -84,15 +84,16 @@ pub struct AsyncIter<'a, T: FromRedisValue + 'a> {
 
 #[cfg(feature = "aio")]
 impl<'a, T: FromRedisValue + 'a> AsyncIter<'a, T> {
-    ///A [futures::Stream](https://docs.rs/futures/0.3.3/futures/stream/trait.Stream.html) over values returned from the redis cursor.
-    ///```rust,no_run
-    ///let iter = conn.sscan("set_key").await.unwrap();
-    ///let stream = iter.stream();
-    ///futures::pin_mut!(stream);
-    ///while let Some(element) = stream.next().await {
+    /// A [futures::Stream](https://docs.rs/futures/0.3.3/futures/stream/trait.Stream.html)
+    /// over values returned from the redis cursor.
+    /// ```rust,no_run
+    /// let iter = conn.sscan("set_key").await.unwrap();
+    /// let stream = iter.stream();
+    /// futures::pin_mut!(stream);
+    /// while let Some(element) = stream.next().await {
     ///    //Do something with element
-    ///}
-    ///```
+    /// }
+    /// ```
     #[inline]
     pub fn stream(self) -> impl futures::Stream<Item = T> + 'a {
         // we need to do this in a loop until we produce at least one item
@@ -428,7 +429,7 @@ impl Cmd {
         })
     }
 
-    /// Similar to `iter()` but returns an [AsyncIter](struct.AsyncIter.html) over the items of the
+    /// Similar to `iter()` but returns an AsyncIter over the items of the
     /// bulk result or iterator.  A [futures::Stream](https://docs.rs/futures/0.3.3/futures/stream/trait.Stream.html)
     /// can be obtained by calling `stream()` on the AsyncIter.  In normal mode this is not in any way more
     /// efficient than just querying into a `Vec<T>` as it's internally

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -92,14 +92,14 @@ impl<'a, T: FromRedisValue + 'a> AsyncIter<'a, T> {
     /// con.sadd("my_set", 42i32).await?;
     /// con.sadd("my_set", 43i32).await?;
     /// let mut iter: redis::AsyncIter<i32> = con.sscan("my_set").await?;
-    /// while let Some(element) = iter.next().await {
+    /// while let Some(element) = iter.next_item().await {
     ///     assert!(element == 42 || element == 43);
     /// }
     /// # Ok(())
     /// # }
     /// ```
     #[inline]
-    pub async fn next(&mut self) -> Option<T> {
+    pub async fn next_item(&mut self) -> Option<T> {
         // we need to do this in a loop until we produce at least one item
         // or we find the actual end of the iteration.  This is necessary
         // because with filtering an iterator it is possible that a whole

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -121,6 +121,8 @@ impl<'a, T: FromRedisValue + 'a> AsyncIter<'a, T> {
             let (cur, mut batch): (u64, Vec<T>) =
                 unwrap_or!(from_redis_value(&rv).ok(), return None);
             batch.reverse();
+            println!("cur: {:?}", cur);
+            println!("batch: {:?}", batch.len());
 
             self.cursor = cur;
             self.batch = batch;

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -121,8 +121,6 @@ impl<'a, T: FromRedisValue + 'a> AsyncIter<'a, T> {
             let (cur, mut batch): (u64, Vec<T>) =
                 unwrap_or!(from_redis_value(&rv).ok(), return None);
             batch.reverse();
-            println!("cur: {:?}", cur);
-            println!("batch: {:?}", batch.len());
 
             self.cursor = cur;
             self.batch = batch;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -179,7 +179,8 @@ macro_rules! implement_commands {
                 }
             )*
 
-            /// Incrementally iterate the keys space.  Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// Incrementally iterate the keys space.  
+            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn scan<RV: FromRedisValue>(&mut self) -> RedisFuture<AsyncIter<'_, RV>> {
                 let mut c = cmd("SCAN");
@@ -188,7 +189,7 @@ macro_rules! implement_commands {
             }
 
             /// Incrementally iterate set elements for elements matching a pattern.
-            /// Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {
                 let mut c = cmd("SCAN");
@@ -197,7 +198,7 @@ macro_rules! implement_commands {
             }
 
             /// Incrementally iterate hash fields and associated values.
-            /// Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisFuture<AsyncIter<'_, RV>> {
                 let mut c = cmd("HSCAN");
@@ -206,7 +207,7 @@ macro_rules! implement_commands {
             }
 
             /// Incrementally iterate hash fields and associated values for
-            /// field names matching a pattern.  Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// field names matching a pattern.  Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
                     (&mut self, key: K, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {
@@ -215,7 +216,8 @@ macro_rules! implement_commands {
                 Box::pin(async move {c.iter_async(self).await })
             }
 
-            /// Incrementally iterate set elements.  Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// Incrementally iterate set elements.  
+            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisFuture<AsyncIter<'_, RV>> {
                 let mut c = cmd("SSCAN");
@@ -224,7 +226,7 @@ macro_rules! implement_commands {
             }
 
             /// Incrementally iterate set elements for elements matching a pattern.
-            /// Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
                     (&mut self, key: K, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {
@@ -233,7 +235,8 @@ macro_rules! implement_commands {
                 Box::pin(async move {c.iter_async(self).await })
             }
 
-            /// Incrementally iterate sorted set elements.  Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// Incrementally iterate sorted set elements.  
+            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisFuture<AsyncIter<'_, RV>> {
                 let mut c = cmd("ZSCAN");
@@ -241,7 +244,8 @@ macro_rules! implement_commands {
                 Box::pin(async move {c.iter_async(self).await })
             }
 
-            /// Incrementally iterate sorted set elements for elements matching a pattern.  Call `stream()` on the resulting AsyncIter to obtain a `futures::Stream`.
+            /// Incrementally iterate sorted set elements for elements matching a pattern.  
+            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
                     (&mut self, key: K, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,8 @@
 // can't use rustfmt here because it screws up the file.
 #![cfg_attr(rustfmt, rustfmt_skip)]
-use crate::cmd::{cmd, Cmd, Iter, AsyncIter, Pipeline};
+use crate::cmd::{cmd, Cmd, Iter, Pipeline};
 use crate::connection::{Connection, ConnectionLike, Msg};
-use crate::types::{FromRedisValue, NumericBehavior, RedisResult, RedisFuture, ToRedisArgs};
+use crate::types::{FromRedisValue, NumericBehavior, RedisResult, ToRedisArgs};
 
 #[cfg(feature = "geospatial")]
 use crate::geo;
@@ -171,7 +171,7 @@ macro_rules! implement_commands {
                 fn $name<$lifetime, $($tyargs: $ty + Send + Sync + $lifetime,)* RV>(
                     & $lifetime mut self
                     $(, $argname: $argty)*
-                ) -> RedisFuture<'a, RV>
+                ) -> crate::types::RedisFuture<'a, RV>
                 where
                     RV: FromRedisValue,
                 {
@@ -180,75 +180,68 @@ macro_rules! implement_commands {
             )*
 
             /// Incrementally iterate the keys space.  
-            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
-            fn scan<RV: FromRedisValue>(&mut self) -> RedisFuture<AsyncIter<'_, RV>> {
+            fn scan<RV: FromRedisValue>(&mut self) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SCAN");
                 c.cursor_arg(0);
                 Box::pin(async move { c.iter_async(self).await })
             }
 
             /// Incrementally iterate set elements for elements matching a pattern.
-            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
-            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {
+            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SCAN");
                 c.cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move { c.iter_async(self).await })
             }
 
             /// Incrementally iterate hash fields and associated values.
-            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
-            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisFuture<AsyncIter<'_, RV>> {
+            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("HSCAN");
                 c.arg(key).cursor_arg(0);
                 Box::pin(async move {c.iter_async(self).await })
             }
 
             /// Incrementally iterate hash fields and associated values for
-            /// field names matching a pattern.  Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
+            /// field names matching a pattern. 
             #[inline]
             fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {
+                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("HSCAN");
                 c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move {c.iter_async(self).await })
             }
 
             /// Incrementally iterate set elements.  
-            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
-            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisFuture<AsyncIter<'_, RV>> {
+            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SSCAN");
                 c.arg(key).cursor_arg(0);
                 Box::pin(async move {c.iter_async(self).await })
             }
 
             /// Incrementally iterate set elements for elements matching a pattern.
-            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {
+                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SSCAN");
                 c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move {c.iter_async(self).await })
             }
 
             /// Incrementally iterate sorted set elements.  
-            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
-            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> RedisFuture<AsyncIter<'_, RV>> {
+            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("ZSCAN");
                 c.arg(key).cursor_arg(0);
                 Box::pin(async move {c.iter_async(self).await })
             }
 
             /// Incrementally iterate sorted set elements for elements matching a pattern.  
-            /// Call `stream()` on the resulting `AsyncIter` to obtain a `futures::Stream`.
             #[inline]
             fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> RedisFuture<AsyncIter<'_, RV>> {
+                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("ZSCAN");
                 c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move {c.iter_async(self).await })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,7 +379,9 @@ pub use crate::types::{
 
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
-pub use crate::{commands::AsyncCommands, parser::parse_redis_value_async, types::RedisFuture};
+pub use crate::{
+    cmd::AsyncIter, commands::AsyncCommands, parser::parse_redis_value_async, types::RedisFuture,
+};
 
 mod macros;
 

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -244,7 +244,7 @@ fn test_async_scanning() {
                         unseen.insert(x);
                     }
 
-                    let iter = redis::cmd("SSCAN")
+                    let mut iter = redis::cmd("SSCAN")
                         .arg("foo")
                         .cursor_arg(0)
                         .clone()
@@ -252,9 +252,7 @@ fn test_async_scanning() {
                         .await
                         .unwrap();
 
-                    let stream = iter.stream();
-                    futures::pin_mut!(stream);
-                    while let Some(x) = stream.next().await {
+                    while let Some(x) = iter.next().await {
                         // type inference limitations
                         let x: usize = x;
                         unseen.remove(&x);

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -252,7 +252,7 @@ fn test_async_scanning() {
                         .await
                         .unwrap();
 
-                    while let Some(x) = iter.next().await {
+                    while let Some(x) = iter.next_item().await {
                         // type inference limitations
                         let x: usize = x;
                         unseen.remove(&x);


### PR DESCRIPTION
Following the pattern set by Iter, I implemented an AsyncIter and exposed it up through AsyncCommands.  Thanks to @Marwes who helped me a lot.
Unfortunately I'm on Windows, so I don't have redis-server installed and I can't run the tests myself.  I usually use Docker to run redis.