### PR TITLE
Redis 6 AUTH <username> <password>

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -380,7 +380,11 @@ where
     C: ConnectionLike,
 {
     if let Some(passwd) = &connection_info.passwd {
-        match cmd("AUTH").arg(passwd).query_async(con).await {
+        let mut command = cmd("AUTH");
+        if let Some(username) = &connection_info.username {
+            command.arg(username);
+        }
+        match command.arg(passwd).query_async(con).await {
             Ok(Value::Okay) => (),
             _ => {
                 fail!((

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -860,3 +860,89 @@ pub fn transaction<
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_redis_url() {
+        let cases = vec![
+            ("redis://127.0.0.1", true),
+            ("redis+unix:///run/redis.sock", true),
+            ("unix:///run/redis.sock", true),
+            ("http://127.0.0.1", false),
+            ("tcp://127.0.0.1", false),
+        ];
+        for (url, expected) in cases.into_iter() {
+            let res = parse_redis_url(&url);
+            assert_eq!(
+                res.is_ok(),
+                expected,
+                "Parsed result of `{}` is not expected",
+                url,
+            );
+        }
+    }
+
+    #[test]
+    fn test_url_to_tcp_connection_info() {
+        let cases = vec![
+            (
+                url::Url::parse("redis://127.0.0.1").unwrap(),
+                ConnectionInfo {
+                    addr: Box::new(ConnectionAddr::Tcp("127.0.0.1".to_string(), 6379)),
+                    db: 0,
+                    username: None,
+                    passwd: None,
+                }
+            ),
+            (
+                url::Url::parse("redis://%25johndoe%25:%23%40%3C%3E%24@example.com/2").unwrap(),
+                ConnectionInfo {
+                    addr: Box::new(ConnectionAddr::Tcp("example.com".to_string(), 6379)),
+                    db: 2,
+                    username: Some("%johndoe%".to_string()),
+                    passwd: Some("#@<>$".to_string()),
+                }
+            ),
+        ];
+        for (url, expected) in cases.into_iter() {
+            let res = url_to_tcp_connection_info(url.clone()).unwrap();
+            assert_eq!(res.addr, expected.addr, "addr of {} is not expected", url);
+            assert_eq!(res.db, expected.db, "db of {} is not expected", url);
+            assert_eq!(res.username, expected.username, "username of {} is not expected", url);
+            assert_eq!(res.passwd, expected.passwd, "passwd of {} is not expected", url);
+        }
+    }
+
+    #[test]
+    fn test_url_to_tcp_connection_info_failed() {
+        let cases = vec![
+            (url::Url::parse("redis://").unwrap(), "Missing hostname"),
+            (url::Url::parse("redis://127.0.0.1/db").unwrap(), "Invalid database number"),
+            (url::Url::parse("redis://C3%B0@127.0.0.1").unwrap(), "Username is not valid UTF-8 string"),
+            (url::Url::parse("redis://:C3%B0@127.0.0.1").unwrap(), "Password is not valid UTF-8 string"),
+        ];
+        for (url, expected) in cases.into_iter() {
+            let res = url_to_tcp_connection_info(url);
+            assert_eq!(
+                res.as_ref().unwrap_err().kind(),
+                crate::ErrorKind::InvalidClientConfig,
+                "{}",
+                res.as_ref().unwrap_err(),
+            );
+            assert_eq!(
+                res.as_ref().unwrap_err().to_string(),
+                expected,
+                "{}",
+                res.as_ref().unwrap_err(),
+            );
+        }
+    }
+
+    #[ignore]
+    #[test]
+    #[cfg(unix)]
+    fn test_url_to_unix_connection_info() { }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -895,7 +895,7 @@ mod tests {
                     db: 0,
                     username: None,
                     passwd: None,
-                }
+                },
             ),
             (
                 url::Url::parse("redis://%25johndoe%25:%23%40%3C%3E%24@example.com/2").unwrap(),
@@ -904,15 +904,23 @@ mod tests {
                     db: 2,
                     username: Some("%johndoe%".to_string()),
                     passwd: Some("#@<>$".to_string()),
-                }
+                },
             ),
         ];
         for (url, expected) in cases.into_iter() {
             let res = url_to_tcp_connection_info(url.clone()).unwrap();
             assert_eq!(res.addr, expected.addr, "addr of {} is not expected", url);
             assert_eq!(res.db, expected.db, "db of {} is not expected", url);
-            assert_eq!(res.username, expected.username, "username of {} is not expected", url);
-            assert_eq!(res.passwd, expected.passwd, "passwd of {} is not expected", url);
+            assert_eq!(
+                res.username, expected.username,
+                "username of {} is not expected",
+                url
+            );
+            assert_eq!(
+                res.passwd, expected.passwd,
+                "passwd of {} is not expected",
+                url
+            );
         }
     }
 
@@ -920,9 +928,18 @@ mod tests {
     fn test_url_to_tcp_connection_info_failed() {
         let cases = vec![
             (url::Url::parse("redis://").unwrap(), "Missing hostname"),
-            (url::Url::parse("redis://127.0.0.1/db").unwrap(), "Invalid database number"),
-            (url::Url::parse("redis://C3%B0@127.0.0.1").unwrap(), "Username is not valid UTF-8 string"),
-            (url::Url::parse("redis://:C3%B0@127.0.0.1").unwrap(), "Password is not valid UTF-8 string"),
+            (
+                url::Url::parse("redis://127.0.0.1/db").unwrap(),
+                "Invalid database number",
+            ),
+            (
+                url::Url::parse("redis://C3%B0@127.0.0.1").unwrap(),
+                "Username is not valid UTF-8 string",
+            ),
+            (
+                url::Url::parse("redis://:C3%B0@127.0.0.1").unwrap(),
+                "Password is not valid UTF-8 string",
+            ),
         ];
         for (url, expected) in cases.into_iter() {
             let res = url_to_tcp_connection_info(url);
@@ -944,5 +961,5 @@ mod tests {
     #[ignore]
     #[test]
     #[cfg(unix)]
-    fn test_url_to_unix_connection_info() { }
+    fn test_url_to_unix_connection_info() {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //! * URL objects from the redis-url crate.
 //! * `ConnectionInfo` objects.
 //!
-//! The URL format is `redis://[:<passwd>@]<hostname>[:port][/<db>]`
+//! The URL format is `redis://[<username>][:<passwd>@]<hostname>[:port][/<db>]`
 //!
 //! If Unix socket support is available you can use a unix URL in this format:
 //!

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -149,6 +149,7 @@ impl TestContext {
         let client = redis::Client::open(redis::ConnectionInfo {
             addr: Box::new(server.get_client_addr().clone()),
             db: 0,
+            username: None,
             passwd: None,
         })
         .unwrap();


### PR DESCRIPTION
## Implement Redis 6 `AUTH <username> <password>`

Related #330

The unix socket URL parsing is wrong (see #132). Would like to fix it but we need discussion the URL format. Seems `url` crate does not support empty host (see https://github.com/servo/rust-url/issues/25), the alternative format with queries may be acceptable:

```
redix+unix:///<path>[?db=<db>[&pass=<password>][&user=<username>]]
```

## Breaking changes

Possibly no. If an URL does not contain `username`, it would behave in the old fashion.

Any input are welcome.

