### PR TITLE
fix: Don't hang in password authentication using a multiplexed connection

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -822,7 +822,20 @@ impl MultiplexedConnection {
             pipeline,
             db: connection_info.db,
         };
-        authenticate(connection_info, &mut con).await?;
+        let driver = {
+            let auth = authenticate(connection_info, &mut con);
+            futures_util::pin_mut!(auth);
+
+            match futures_util::future::select(auth, driver).await {
+                futures_util::future::Either::Left((result, driver)) => {
+                    result?;
+                    driver
+                }
+                futures_util::future::Either::Right(((), _)) => {
+                    unreachable!("Multiplexed connection driver unexpectedly terminated")
+                }
+            }
+        };
         Ok((con, driver))
     }
 }

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -374,6 +374,29 @@ async fn io_error_on_kill_issue_320() {
     assert_eq!(err.kind(), ErrorKind::IoError); // Shouldn't this be IoError?
 }
 
+#[tokio::test]
+async fn invalid_password_issue_343() {
+    let ctx = TestContext::new();
+    let coninfo = redis::ConnectionInfo {
+        addr: Box::new(ctx.server.get_client_addr().clone()),
+        db: 0,
+        username: None,
+        passwd: Some("asdcasc".to_string()),
+    };
+    let client = redis::Client::open(coninfo).unwrap();
+    let err = client
+        .get_multiplexed_tokio_connection()
+        .await
+        .err()
+        .unwrap();
+    assert_eq!(
+        err.kind(),
+        ErrorKind::AuthenticationFailed,
+        "Unexpected error: {}",
+        err
+    );
+}
+
 mod pub_sub {
     use std::collections::HashMap;
     use std::time::Duration;


### PR DESCRIPTION
The driver future were never polled during the authentiction step.

Fixes #343