### PR TITLE
Add Redis 6 ACL commands support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,17 @@ cache:
 before_cache:
   - rm -rf /home/travis/.cargo/registry
 
+# This is not a an official ppa but seems to be a well-known one. Replace it if
+# we can get Redis 6 from main stream package mananger.
+#
+# Refs:
+# - https://github.com/antirez/redis/issues/1732
+# - https://launchpad.net/~chris-lea/+archive/ubuntu/redis-server
+before_install: |
+  sudo add-apt-repository ppa:chris-lea/redis-server -y
+  sudo apt-get update
+  sudo apt-get install redis-server=5:6.0.5-1chl1~xenial1 -y
+
 matrix:
   include:
     - rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ async-std = { version = "1.5.0", optional = true}
 async-trait = "0.1.24"
 
 [features]
-default = ["streams", "geospatial", "tokio-comp", "async-std-comp", "script"]
+default = ["acl", "streams", "geospatial", "tokio-comp", "async-std-comp", "script"]
+acl = []
 aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/sink", "tokio/sync", "tokio/stream", "tokio/tcp", "tokio/uds", "tokio/io-util", "tokio-util", "tokio-util/codec", "combine/tokio-02"]
 tokio-rt-core = ["tokio-comp", "tokio/rt-core"]
 geospatial = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,9 @@ required-features = ["async-std-comp"]
 name = "parser"
 required-features = ["aio"]
 
+[[test]]
+name = "test_acl"
+
 [[bench]]
 name = "bench_basic"
 harness = false

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -2,6 +2,16 @@
 
 use crate::types::{ErrorKind, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, Value};
 
+macro_rules! not_convertible_type_error {
+    ($v:expr, $det:expr) => {{
+        fail!((
+            ErrorKind::TypeError,
+            "Response type not convertible to Rule",
+            format!("{:?} (response was {:?})", $det, $v)
+        ))
+    }};
+}
+
 /// ACL rules are used in order to activate or remove a flag, or to perform a
 /// given change to the user ACL, which under the hood are just single words.
 #[derive(Debug, Eq, PartialEq)]
@@ -89,6 +99,105 @@ impl ToRedisArgs for Rule {
     }
 }
 
+/// An info dictionary type storing Redis ACL information as multiple `Rule`.
+/// This type collects key/value data returned by the [`ACL GETUSER`][1] command.
+///
+/// [1]: https://redis.io/commands/acl-getuser
+#[derive(Debug, Eq, PartialEq)]
+pub struct AclInfo {
+    /// Describes flag rules for the user. Represented by [`Rule::On`][1],
+    /// [`Rule::Off`][2], [`Rule::AllKeys`][3], [`Rule::AllCommands`][4] and
+    /// [`Rule::NoPass`][5].
+    ///
+    /// [1]: ./enum.Rule.html#variant.On
+    /// [2]: ./enum.Rule.html#variant.Off
+    /// [3]: ./enum.Rule.html#variant.AllKeys
+    /// [4]: ./enum.Rule.html#variant.AllCommands
+    /// [5]: ./enum.Rule.html#variant.NoPass
+    pub flags: Vec<Rule>,
+    /// Describes the user's passwords. Represented by [`Rule::AddHashedPass`][1].
+    ///
+    /// [1]: ./enum.Rule.html#variant.AddHashedPass
+    pub passwords: Vec<Rule>,
+    /// Describes capabilities of which commands the user can call.
+    /// Represented by [`Rule::AddCommand`][1], [`Rule::AddCategory`][2],
+    /// [`Rule::RemoveCommand`][3] and [`Rule::RemoveCategory`][4].
+    ///
+    /// [1]: ./enum.Rule.html#variant.AddCommand
+    /// [2]: ./enum.Rule.html#variant.AddCategory
+    /// [3]: ./enum.Rule.html#variant.RemoveCommand
+    /// [4]: ./enum.Rule.html#variant.RemoveCategory
+    pub commands: Vec<Rule>,
+    /// Describes patterns of keys which the user can access. Represented by
+    /// [`Rule::Pattern`][1].
+    ///
+    /// [1]: ./enum.Rule.html#variant.Pattern
+    pub keys: Vec<Rule>,
+}
+
+impl FromRedisValue for AclInfo {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        let values: Vec<Value> = FromRedisValue::from_redis_value(v)?;
+        let mut it = values.into_iter().skip(1).step_by(2);
+        let (flags, passwords, commands, keys) = match (it.next(), it.next(), it.next(), it.next())
+        {
+            (Some(flags), Some(passwords), Some(commands), Some(keys)) => {
+                // Parse flags
+                // Ref: https://git.io/JfNyb
+                let flag_values: Vec<Vec<u8>> = FromRedisValue::from_redis_value(&flags)?;
+                let mut flags = Vec::with_capacity(flag_values.len());
+                for flag in flag_values.into_iter() {
+                    let rule = match flag.as_slice() {
+                        b"on" => Rule::On,
+                        b"off" => Rule::Off,
+                        b"allkeys" => Rule::AllKeys,
+                        b"allcommands" => Rule::AllCommands,
+                        b"nopass" => Rule::NoPass,
+                        _ => not_convertible_type_error!("", "Expect an ACL flag"),
+                    };
+                    flags.push(rule);
+                }
+
+                let passwords: Vec<String> = FromRedisValue::from_redis_value(&passwords)?;
+                let passwords = passwords
+                    .into_iter()
+                    .map(|pass| Rule::AddHashedPass(pass))
+                    .collect::<Vec<Rule>>();
+
+                let command_values: String = FromRedisValue::from_redis_value(&commands)?;
+                let mut commands = Vec::new();
+                for command in command_values.split_terminator(' ') {
+                    let rule = match command {
+                        x if x.starts_with("+@") => Rule::AddCategory(x[2..].to_owned()),
+                        x if x.starts_with("-@") => Rule::RemoveCategory(x[2..].to_owned()),
+                        x if x.starts_with("+") => Rule::AddCommand(x[1..].to_owned()),
+                        x if x.starts_with("-") => Rule::RemoveCommand(x[1..].to_owned()),
+                        _ => not_convertible_type_error!(
+                            command,
+                            "Expect a command addition/removal"
+                        ),
+                    };
+                    commands.push(rule);
+                }
+
+                let keys: Vec<String> = FromRedisValue::from_redis_value(&keys)?;
+                let keys = keys
+                    .into_iter()
+                    .map(|pat| Rule::Pattern(pat))
+                    .collect::<Vec<Rule>>();
+                (flags, passwords, commands, keys)
+            }
+            _ => not_convertible_type_error!(v, "Response type not convertible to Rule."),
+        };
+
+        Ok(Self {
+            flags,
+            passwords,
+            commands,
+            keys,
+        })
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -97,7 +206,7 @@ mod tests {
     macro_rules! assert_args {
         ($rule:expr, $arg:expr) => {
             assert_eq!($rule.to_redis_args(), vec![$arg.to_vec()]);
-        }
+        };
     }
 
     #[test]
@@ -115,11 +224,15 @@ mod tests {
         assert_args!(AddPass("mypass".to_owned()), b">mypass");
         assert_args!(RemovePass("mypass".to_owned()), b"<mypass");
         assert_args!(
-            AddHashedPass("c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()),
+            AddHashedPass(
+                "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()
+            ),
             b"#c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
         );
         assert_args!(
-            RemoveHashedPass("c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()),
+            RemoveHashedPass(
+                "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()
+            ),
             b"!c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
         );
         assert_args!(NoPass, b"nopass");
@@ -127,5 +240,33 @@ mod tests {
         assert_args!(AllKeys, b"allkeys");
         assert_args!(ResetKeys, b"resetkeys");
         assert_args!(Reset, b"reset");
+    }
+
+    #[test]
+    fn test_from_redis_value() {
+        let redis_value = Value::Bulk(vec![
+            Value::Data("flags".into()),
+            Value::Bulk(vec![Value::Data("on".into())]),
+            Value::Data("passwords".into()),
+            Value::Bulk(vec![]),
+            Value::Data("commands".into()),
+            Value::Data("-@all +get".into()),
+            Value::Data("keys".into()),
+            Value::Bulk(vec![Value::Data("pat:*".into())]),
+        ]);
+        let acl_info = AclInfo::from_redis_value(&redis_value).expect("Parse successfully");
+
+        assert_eq!(
+            acl_info,
+            AclInfo {
+                flags: vec![Rule::On],
+                passwords: vec![],
+                commands: vec![
+                    Rule::RemoveCategory("all".to_owned()),
+                    Rule::AddCommand("get".to_owned()),
+                ],
+                keys: vec![Rule::Pattern("pat:*".to_owned())],
+            }
+        );
     }
 }

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -1,0 +1,131 @@
+//! Defines types to use with the ACL commands.
+
+use crate::types::{ErrorKind, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, Value};
+
+/// ACL rules are used in order to activate or remove a flag, or to perform a
+/// given change to the user ACL, which under the hood are just single words.
+#[derive(Debug, Eq, PartialEq)]
+pub enum Rule {
+    /// Enable the user: it is possible to authenticate as this user.
+    On,
+    /// Disable the user: it's no longer possible to authenticate with this
+    /// user, however the already authenticated connections will still work.
+    Off,
+
+    /// Add the command to the list of commands the user can call.
+    AddCommand(String),
+    /// Remove the command to the list of commands the user can call.
+    RemoveCommand(String),
+    /// Add all the commands in such category to be called by the user.
+    AddCategory(String),
+    /// Remove the commands from such category the client can call.
+    RemoveCategory(String),
+    /// Alias for `+@all`. Note that it implies the ability to execute all the
+    /// future commands loaded via the modules system.
+    AllCommands,
+    /// Alias for `-@all`.
+    NoCommands,
+
+    /// Add this password to the list of valid password for the user.
+    AddPass(String),
+    /// Remove this password from the list of valid passwords.
+    RemovePass(String),
+    /// Add this SHA-256 hash value to the list of valid passwords for the user.
+    AddHashedPass(String),
+    /// Remove this hash value from from the list of valid passwords
+    RemoveHashedPass(String),
+    /// All the set passwords of the user are removed, and the user is flagged
+    /// as requiring no password: it means that every password will work
+    /// against this user.
+    NoPass,
+    /// Flush the list of allowed passwords. Moreover removes the _nopass_ status.
+    ResetPass,
+
+    /// Add a pattern of keys that can be mentioned as part of commands.
+    Pattern(String),
+    /// Alias for `~*`.
+    AllKeys,
+    /// Flush the list of allowed keys patterns.
+    ResetKeys,
+
+    /// Performs the following actions: `resetpass`, `resetkeys`, `off`, `-@all`.
+    /// The user returns to the same state it has immediately after its creation.
+    Reset,
+}
+
+impl ToRedisArgs for Rule {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        use self::Rule::*;
+
+        let rule = match self {
+            On => "on".to_owned(),
+            Off => "off".to_owned(),
+
+            AddCommand(cmd) => "+".to_owned() + cmd,
+            RemoveCommand(cmd) => "-".to_owned() + cmd,
+            AddCategory(cat) => "+@".to_owned() + cat,
+            RemoveCategory(cat) => "-@".to_owned() + cat,
+            AllCommands => "allcommands".to_owned(),
+            NoCommands => "nocommands".to_owned(),
+
+            AddPass(pass) => ">".to_owned() + pass,
+            RemovePass(pass) => "<".to_owned() + pass,
+            AddHashedPass(pass) => "#".to_owned() + pass,
+            RemoveHashedPass(pass) => "!".to_owned() + pass,
+            NoPass => "nopass".to_owned(),
+            ResetPass => "resetpass".to_owned(),
+
+            Pattern(pat) => "~".to_owned() + pat,
+            AllKeys => "allkeys".to_owned(),
+            ResetKeys => "resetkeys".to_owned(),
+
+            Reset => "reset".to_owned(),
+        };
+
+        out.write_arg(rule.as_bytes());
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! assert_args {
+        ($rule:expr, $arg:expr) => {
+            assert_eq!($rule.to_redis_args(), vec![$arg.to_vec()]);
+        }
+    }
+
+    #[test]
+    fn test_rule_to_arg() {
+        use self::Rule::*;
+
+        assert_args!(On, b"on");
+        assert_args!(Off, b"off");
+        assert_args!(AddCommand("set".to_owned()), b"+set");
+        assert_args!(RemoveCommand("set".to_owned()), b"-set");
+        assert_args!(AddCategory("hyperloglog".to_owned()), b"+@hyperloglog");
+        assert_args!(RemoveCategory("hyperloglog".to_owned()), b"-@hyperloglog");
+        assert_args!(AllCommands, b"allcommands");
+        assert_args!(NoCommands, b"nocommands");
+        assert_args!(AddPass("mypass".to_owned()), b">mypass");
+        assert_args!(RemovePass("mypass".to_owned()), b"<mypass");
+        assert_args!(
+            AddHashedPass("c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()),
+            b"#c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
+        );
+        assert_args!(
+            RemoveHashedPass("c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()),
+            b"!c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2"
+        );
+        assert_args!(NoPass, b"nopass");
+        assert_args!(Pattern("pat:*".to_owned()), b"~pat:*");
+        assert_args!(AllKeys, b"allkeys");
+        assert_args!(ResetKeys, b"resetkeys");
+        assert_args!(Reset, b"reset");
+    }
+}

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -70,32 +70,30 @@ impl ToRedisArgs for Rule {
     {
         use self::Rule::*;
 
-        let rule = match self {
-            On => "on".to_owned(),
-            Off => "off".to_owned(),
+        match self {
+            On => out.write_arg(b"on"),
+            Off => out.write_arg(b"off"),
 
-            AddCommand(cmd) => "+".to_owned() + cmd,
-            RemoveCommand(cmd) => "-".to_owned() + cmd,
-            AddCategory(cat) => "+@".to_owned() + cat,
-            RemoveCategory(cat) => "-@".to_owned() + cat,
-            AllCommands => "allcommands".to_owned(),
-            NoCommands => "nocommands".to_owned(),
+            AddCommand(cmd) => out.write_arg_fmt(format_args!("+{}", cmd)),
+            RemoveCommand(cmd) => out.write_arg_fmt(format_args!("-{}", cmd)),
+            AddCategory(cat) => out.write_arg_fmt(format_args!("+@{}", cat)),
+            RemoveCategory(cat) => out.write_arg_fmt(format_args!("-@{}", cat)),
+            AllCommands => out.write_arg(b"allcommands"),
+            NoCommands => out.write_arg(b"nocommands"),
 
-            AddPass(pass) => ">".to_owned() + pass,
-            RemovePass(pass) => "<".to_owned() + pass,
-            AddHashedPass(pass) => "#".to_owned() + pass,
-            RemoveHashedPass(pass) => "!".to_owned() + pass,
-            NoPass => "nopass".to_owned(),
-            ResetPass => "resetpass".to_owned(),
+            AddPass(pass) => out.write_arg_fmt(format_args!(">{}", pass)),
+            RemovePass(pass) => out.write_arg_fmt(format_args!("<{}", pass)),
+            AddHashedPass(pass) => out.write_arg_fmt(format_args!("#{}", pass)),
+            RemoveHashedPass(pass) => out.write_arg_fmt(format_args!("!{}", pass)),
+            NoPass => out.write_arg(b"nopass"),
+            ResetPass => out.write_arg(b"resetpass"),
 
-            Pattern(pat) => "~".to_owned() + pat,
-            AllKeys => "allkeys".to_owned(),
-            ResetKeys => "resetkeys".to_owned(),
+            Pattern(pat) => out.write_arg_fmt(format_args!("~{}", pat)),
+            AllKeys => out.write_arg(b"allkeys"),
+            ResetKeys => out.write_arg(b"resetkeys"),
 
-            Reset => "reset".to_owned(),
+            Reset => out.write_arg(b"reset"),
         };
-
-        out.write_arg(rule.as_bytes());
     }
 }
 

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -161,7 +161,7 @@ impl FromRedisValue for AclInfo {
                 let passwords: Vec<String> = FromRedisValue::from_redis_value(&passwords)?;
                 let passwords = passwords
                     .into_iter()
-                    .map(|pass| Rule::AddHashedPass(pass))
+                    .map(Rule::AddHashedPass)
                     .collect::<Vec<Rule>>();
 
                 let command_values: String = FromRedisValue::from_redis_value(&commands)?;
@@ -170,8 +170,8 @@ impl FromRedisValue for AclInfo {
                     let rule = match command {
                         x if x.starts_with("+@") => Rule::AddCategory(x[2..].to_owned()),
                         x if x.starts_with("-@") => Rule::RemoveCategory(x[2..].to_owned()),
-                        x if x.starts_with("+") => Rule::AddCommand(x[1..].to_owned()),
-                        x if x.starts_with("-") => Rule::RemoveCommand(x[1..].to_owned()),
+                        x if x.starts_with('+') => Rule::AddCommand(x[1..].to_owned()),
+                        x if x.starts_with('-') => Rule::RemoveCommand(x[1..].to_owned()),
                         _ => not_convertible_type_error!(
                             command,
                             "Expect a command addition/removal"
@@ -181,10 +181,7 @@ impl FromRedisValue for AclInfo {
                 }
 
                 let keys: Vec<String> = FromRedisValue::from_redis_value(&keys)?;
-                let keys = keys
-                    .into_iter()
-                    .map(|pat| Rule::Pattern(pat))
-                    .collect::<Vec<Rule>>();
+                let keys = keys.into_iter().map(Rule::Pattern).collect::<Vec<Rule>>();
                 (flags, passwords, commands, keys)
             }
             _ => not_convertible_type_error!(v, "Response type not convertible to Rule."),

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,6 +10,8 @@ use crate::geo;
 #[cfg(feature = "streams")]
 use crate::streams;
 
+use crate::acl;
+
 macro_rules! implement_commands {
     (
         $lifetime: lifetime
@@ -903,6 +905,96 @@ implement_commands! {
     /// Posts a message to the given channel.
     fn publish<K: ToRedisArgs, E: ToRedisArgs>(channel: K, message: E) {
         cmd("PUBLISH").arg(channel).arg(message)
+    }
+
+    // ACL commands
+
+    /// When Redis is configured to use an ACL file (with the aclfile
+    /// configuration option), this command will reload the ACLs from the file,
+    /// replacing all the current ACL rules with the ones defined in the file.
+    fn acl_load<>() {
+        cmd("ACL").arg("LOAD")
+    }
+
+    /// When Redis is configured to use an ACL file (with the aclfile
+    /// configuration option), this command will save the currently defined
+    /// ACLs from the server memory to the ACL file.
+    fn acl_save<>() {
+        cmd("ACL").arg("SAVE")
+    }
+
+    /// Shows the currently active ACL rules in the Redis server.
+    fn acl_list<>() {
+        cmd("ACL").arg("LIST")
+    }
+
+    /// Shows a list of all the usernames of the currently configured users in
+    /// the Redis ACL system.
+    fn acl_users<>() {
+        cmd("ACL").arg("USERS")
+    }
+
+    /// Returns all the rules defined for an existing ACL user.
+    fn acl_getuser<K: ToRedisArgs>(username: K) {
+        cmd("ACL").arg("GETUSER").arg(username)
+    }
+
+    /// Creates an ACL user without any privilege.
+    fn acl_setuser<K: ToRedisArgs>(username: K) {
+        cmd("ACL").arg("SETUSER").arg(username)
+    }
+
+    /// Creates an ACL user with the specified rules or modify the rules of
+    /// an existing user.
+    fn acl_setuser_rules<K: ToRedisArgs>(username: K, rules: &'a [acl::Rule]) {
+        cmd("ACL").arg("SETUSER").arg(username).arg(rules)
+    }
+
+    /// Delete all the specified ACL users and terminate all the connections
+    /// that are authenticated with such users.
+    fn acl_deluser<K: ToRedisArgs>(usernames: &'a [K]) {
+        cmd("ACL").arg("DELUSER").arg(usernames)
+    }
+
+    /// Shows the available ACL categories.
+    fn acl_cat<>() {
+        cmd("ACL").arg("CAT")
+    }
+
+    /// Shows all the Redis commands in the specified category.
+    fn acl_cat_categoryname<K: ToRedisArgs>(categoryname: K) {
+        cmd("ACL").arg("CAT").arg(categoryname)
+    }
+
+    /// Generates a 256-bits password starting from /dev/urandom if available.
+    fn acl_genpass<>() {
+        cmd("ACL").arg("GENPASS")
+    }
+
+    /// Generates a 1-to-1024-bits password starting from /dev/urandom if available.
+    fn acl_genpass_bits<>(bits: isize) {
+        cmd("ACL").arg("GENPASS").arg(bits)
+    }
+
+    /// Returns the username the current connection is authenticated with.
+    fn acl_whoami<>() {
+        cmd("ACL").arg("WHOAMI")
+    }
+
+    /// Shows a list of recent ACL security events
+    fn acl_log<>(count: isize) {
+        cmd("ACL").arg("LOG").arg(count)
+
+    }
+
+    /// Clears the ACL log.
+    fn acl_log_reset<>() {
+        cmd("ACL").arg("LOG").arg("RESET")
+    }
+
+    /// Returns a helpful text describing the different subcommands.
+    fn acl_help<>() {
+        cmd("ACL").arg("HELP")
     }
 
     //

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,6 +10,7 @@ use crate::geo;
 #[cfg(feature = "streams")]
 use crate::streams;
 
+#[cfg(feature = "acl")]
 use crate::acl;
 
 macro_rules! implement_commands {
@@ -912,6 +913,8 @@ implement_commands! {
     /// When Redis is configured to use an ACL file (with the aclfile
     /// configuration option), this command will reload the ACLs from the file,
     /// replacing all the current ACL rules with the ones defined in the file.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_load<>() {
         cmd("ACL").arg("LOAD")
     }
@@ -919,80 +922,110 @@ implement_commands! {
     /// When Redis is configured to use an ACL file (with the aclfile
     /// configuration option), this command will save the currently defined
     /// ACLs from the server memory to the ACL file.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_save<>() {
         cmd("ACL").arg("SAVE")
     }
 
     /// Shows the currently active ACL rules in the Redis server.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_list<>() {
         cmd("ACL").arg("LIST")
     }
 
     /// Shows a list of all the usernames of the currently configured users in
     /// the Redis ACL system.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_users<>() {
         cmd("ACL").arg("USERS")
     }
 
     /// Returns all the rules defined for an existing ACL user.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_getuser<K: ToRedisArgs>(username: K) {
         cmd("ACL").arg("GETUSER").arg(username)
     }
 
     /// Creates an ACL user without any privilege.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_setuser<K: ToRedisArgs>(username: K) {
         cmd("ACL").arg("SETUSER").arg(username)
     }
 
     /// Creates an ACL user with the specified rules or modify the rules of
     /// an existing user.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_setuser_rules<K: ToRedisArgs>(username: K, rules: &'a [acl::Rule]) {
         cmd("ACL").arg("SETUSER").arg(username).arg(rules)
     }
 
     /// Delete all the specified ACL users and terminate all the connections
     /// that are authenticated with such users.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_deluser<K: ToRedisArgs>(usernames: &'a [K]) {
         cmd("ACL").arg("DELUSER").arg(usernames)
     }
 
     /// Shows the available ACL categories.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_cat<>() {
         cmd("ACL").arg("CAT")
     }
 
     /// Shows all the Redis commands in the specified category.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_cat_categoryname<K: ToRedisArgs>(categoryname: K) {
         cmd("ACL").arg("CAT").arg(categoryname)
     }
 
     /// Generates a 256-bits password starting from /dev/urandom if available.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_genpass<>() {
         cmd("ACL").arg("GENPASS")
     }
 
     /// Generates a 1-to-1024-bits password starting from /dev/urandom if available.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_genpass_bits<>(bits: isize) {
         cmd("ACL").arg("GENPASS").arg(bits)
     }
 
     /// Returns the username the current connection is authenticated with.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_whoami<>() {
         cmd("ACL").arg("WHOAMI")
     }
 
     /// Shows a list of recent ACL security events
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_log<>(count: isize) {
         cmd("ACL").arg("LOG").arg(count)
 
     }
 
     /// Clears the ACL log.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_log_reset<>() {
         cmd("ACL").arg("LOG").arg("RESET")
     }
 
     /// Returns a helpful text describing the different subcommands.
+    #[cfg(feature = "acl")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
     fn acl_help<>() {
         cmd("ACL").arg("HELP")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,8 @@ pub use crate::{
 
 mod macros;
 
+pub mod acl;
+
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 pub mod aio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 //! There are a few features defined that can enable additional functionality
 //! if so desired.  Some of them are turned on by default.
 //!
+//! * `acl`: enables acl support (enabled by default)
 //! * `aio`: enables async IO support (enabled by default)
 //! * `geospatial`: enables geospatial support (enabled by default)
 //! * `script`: enables script support (enabled by default)
@@ -385,6 +386,8 @@ pub use crate::{
 
 mod macros;
 
+#[cfg(feature = "acl")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
 pub mod acl;
 
 #[cfg(feature = "aio")]

--- a/tests/test_acl.rs
+++ b/tests/test_acl.rs
@@ -1,0 +1,157 @@
+use std::collections::HashSet;
+
+use redis::acl::{AclInfo, Rule};
+use redis::{Commands, Value};
+
+mod support;
+use crate::support::*;
+
+#[test]
+fn test_acl_whoami() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+    assert_eq!(con.acl_whoami(), Ok("default".to_owned()));
+}
+
+#[test]
+fn test_acl_help() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+    let res: Vec<String> = con.acl_help().expect("Got help manual");
+    assert!(res.len() > 0);
+}
+
+#[test]
+fn test_acl_getsetdel_users() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+    assert_eq!(
+        con.acl_list(),
+        Ok(vec!["user default on nopass ~* +@all".to_owned()])
+    );
+    assert_eq!(con.acl_users(), Ok(vec!["default".to_owned()]));
+    // bob
+    assert_eq!(con.acl_setuser("bob"), Ok(()));
+    assert_eq!(
+        con.acl_users(),
+        Ok(vec!["bob".to_owned(), "default".to_owned()])
+    );
+
+    // ACL SETUSER bob on ~redis:* +set
+    assert_eq!(
+        con.acl_setuser_rules(
+            "bob",
+            &[
+                Rule::On,
+                Rule::AddHashedPass(
+                    "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()
+                ),
+                Rule::Pattern("redis:*".to_owned()),
+                Rule::AddCommand("set".to_owned())
+            ],
+        ),
+        Ok(())
+    );
+    let acl_info: AclInfo = con.acl_getuser("bob").expect("Got user");
+    assert_eq!(
+        acl_info,
+        AclInfo {
+            flags: vec![Rule::On],
+            passwords: vec![Rule::AddHashedPass(
+                "c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2".to_owned()
+            )],
+            commands: vec![
+                Rule::RemoveCategory("all".to_owned()),
+                Rule::AddCommand("set".to_owned())
+            ],
+            keys: vec![Rule::Pattern("redis:*".to_owned())],
+        }
+    );
+    assert_eq!(
+        con.acl_list(),
+        Ok(vec![
+            "user bob on #c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2 ~redis:* -@all +set".to_owned(),
+            "user default on nopass ~* +@all".to_owned(),
+        ])
+    );
+
+    // ACL SETUSER eve
+    assert_eq!(con.acl_setuser("eve"), Ok(()));
+    assert_eq!(
+        con.acl_users(),
+        Ok(vec![
+            "bob".to_owned(),
+            "default".to_owned(),
+            "eve".to_owned()
+        ])
+    );
+    assert_eq!(con.acl_deluser(&["bob", "eve"]), Ok(2));
+    assert_eq!(con.acl_users(), Ok(vec!["default".to_owned()]));
+}
+
+#[test]
+fn test_acl_cat() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+    let res: HashSet<String> = con.acl_cat().expect("Got categories");
+    let expects = vec![
+        "keyspace",
+        "read",
+        "write",
+        "set",
+        "sortedset",
+        "list",
+        "hash",
+        "string",
+        "bitmap",
+        "hyperloglog",
+        "geo",
+        "stream",
+        "pubsub",
+        "admin",
+        "fast",
+        "slow",
+        "blocking",
+        "dangerous",
+        "connection",
+        "transaction",
+        "scripting",
+    ];
+    for cat in expects.iter() {
+        assert!(
+            res.contains(*cat),
+            format!("Category `{}` does not exist", cat)
+        );
+    }
+
+    let expects = vec!["pfmerge", "pfcount", "pfselftest", "pfadd"];
+    let res: HashSet<String> = con
+        .acl_cat_categoryname("hyperloglog")
+        .expect("Got commands of a category");
+    for cmd in expects.iter() {
+        assert!(
+            res.contains(*cmd),
+            format!("Command `{}` does not exist", cmd)
+        );
+    }
+}
+
+#[test]
+fn test_acl_genpass() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+    let pass: String = con.acl_genpass().expect("Got password");
+    assert_eq!(pass.len(), 64);
+
+    let pass: String = con.acl_genpass_bits(1024).expect("Got password");
+    assert_eq!(pass.len(), 256);
+}
+
+#[test]
+fn test_acl_log() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+    let logs: Vec<Value> = con.acl_log(1).expect("Got logs");
+    assert_eq!(logs.len(), 0);
+    assert_eq!(con.acl_log_reset(), Ok(()));
+}

--- a/tests/test_acl.rs
+++ b/tests/test_acl.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "acl")]
+
 use std::collections::HashSet;
 
 use redis::acl::{AclInfo, Rule};

--- a/tests/test_acl.rs
+++ b/tests/test_acl.rs
@@ -20,7 +20,7 @@ fn test_acl_help() {
     let ctx = TestContext::new();
     let mut con = ctx.connection();
     let res: Vec<String> = con.acl_help().expect("Got help manual");
-    assert!(res.len() > 0);
+    assert!(!res.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## What

Resolves #330

Add high-level command of all [`ACL` commands](https://redis.io/topics/acl) introduced in Redis 6.

## Tasks

- [x] a `Rule` enum represents arbitrary ACL rules.
- [x] a `AclInfo` struct representing response from `ACL GETUSER` command.
- [x] introduce a new `acl` feature and set as a default feature.
- [x] integration tests for `acl` commands