### PR TITLE
perf: Add write_arg_fmt to RedisWrite

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{fmt, io};
 
 use crate::connection::ConnectionLike;
 use crate::types::{
@@ -243,9 +243,14 @@ fn write_pipeline(rv: &mut Vec<u8>, cmds: &[Cmd], atomic: bool) {
 
 impl RedisWrite for Cmd {
     fn write_arg(&mut self, arg: &[u8]) {
-        let prev = self.data.len();
-        self.args.push(Arg::Simple(prev + arg.len()));
         self.data.extend_from_slice(arg);
+        self.args.push(Arg::Simple(self.data.len()));
+    }
+
+    fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
+        use std::io::Write;
+        write!(self.data, "{}", arg).unwrap();
+        self.args.push(Arg::Simple(self.data.len()));
     }
 }
 

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -212,7 +212,7 @@ impl ToRedisArgs for RadiusOptions {
 
         if let Some(n) = self.count {
             out.write_arg(b"COUNT");
-            out.write_arg(format!("{}", n).as_bytes());
+            out.write_arg_fmt(n);
         }
 
         match self.order {

--- a/src/types.rs
+++ b/src/types.rs
@@ -590,11 +590,20 @@ impl InfoDict {
 pub trait RedisWrite {
     /// Accepts a serialized redis command.
     fn write_arg(&mut self, arg: &[u8]);
+
+    /// Accepts a serialized redis command.
+    fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
+        self.write_arg(&arg.to_string().as_bytes())
+    }
 }
 
 impl RedisWrite for Vec<Vec<u8>> {
     fn write_arg(&mut self, arg: &[u8]) {
         self.push(arg.to_owned());
+    }
+
+    fn write_arg_fmt(&mut self, arg: impl fmt::Display) {
+        self.push(arg.to_string().into_bytes())
     }
 }
 


### PR DESCRIPTION
Can help avoid allocations when writing redis arguments