### PR TITLE
Remove spammy travis IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,3 @@ script:
 
 notifications:
   email: false
-  irc:
-    channels:
-      - "chat.freenode.net#pocoo"
-    on_success: change
-    on_failure: always
-    use_notice: true
-    skip_join: true


### PR DESCRIPTION
They are especially annoying because sometimes people enable travis on their forks and thus end up spamming the channel.

```
* Joins: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#2 (redis-tls - 209c11d : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/3de1a6a8042b...209c11dc2513
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174679889
* Parts: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
* Quits: lastmikoi (~lastmikoi@195.154.38.38) (Quit: ...)
* Joins: jarthur_ (~jarthur@2605:6000:1019:48d9:3940:9517:7a97:598a)
<+Pallets> <tachyondecay_discord> > Can I dynamically create the values for the AnyOf validator? @Smye Glancing at the docs/source code, I don't believe so. It looks like the validator expects a list when defining it. Instead, if you call Form.validate directly rather than validate_on_submit (if you're using Flask-WTF), then you could create the validator dynamically in your view function and pass it in with extra_validators:
<+Pallets> https://wtforms.readthedocs.io/en/2.2.1/forms/#wtforms.form.Form.validate
* Joins: travis-ci (~travis-ci@67.134.243.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#3 (redis-tls - da94607 : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/209c11dc2513...da946077a797
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174681403
* Parts: travis-ci (~travis-ci@67.134.243.35.bc.googleusercontent.com)
* Quits: jarthur (~jarthur@2605:6000:1019:48d9:7492:c1da:37ae:8664) (Ping timeout: 244 seconds)
* Joins: lastmikoi (~lastmikoi@195.154.38.38)
* Joins: travis-ci (~travis-ci@67.134.243.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#4 (redis-tls - 1261566 : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/da946077a797...126156648f18
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174682560
* Parts: travis-ci (~travis-ci@67.134.243.35.bc.googleusercontent.com)
* Joins: travis-ci (~travis-ci@67.134.243.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#5 (redis-tls - 2c37e62 : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/126156648f18...2c37e62647ae
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174683603
* Parts: travis-ci (~travis-ci@67.134.243.35.bc.googleusercontent.com)
* Joins: aleagori (~ale@2a02:a312:c63d:8e00:1df2:cc2f:1579:7a81)
* Joins: stinkpot (~none@ip72-220-148-31.sd.sd.cox.net)
* Joins: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#6 (redis-tls - dcde3db : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/2c37e62647ae...dcde3dbb3501
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174695986
* Parts: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
* Joins: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#7 (redis-tls - 74f0590 : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/dcde3dbb3501...74f0590f75ad
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174696294
* Parts: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
* Joins: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#8 (redis-tls - 9ac2927 : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/74f0590f75ad...9ac29270384d
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174696788
* Parts: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
* Joins: tomkralidis (~tomkralid@osgeo/member/tomkralidis)
* Joins: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#9 (redis-tls - c92e0b3 : Gabriel Féron): The build has errored.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/9ac29270384d...c92e0b3de23f
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174703745
* Parts: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
* Quits: hyiltiz (~quassel@unaffiliated/hyiltiz) (Ping timeout: 244 seconds)
* Joins: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
<travis-ci> gferon/redis-rs#11 (redis-tls - d331d20 : Gabriel Féron): The build failed.
<travis-ci> Change view : https://github.com/gferon/redis-rs/compare/c92e0b3de23f...d331d20e5a6d
<travis-ci> Build details : https://travis-ci.com/gferon/redis-rs/builds/174706091
* Parts: travis-ci (~travis-ci@30.30.237.35.bc.googleusercontent.com)
```