### PR TITLE
Use password from query string for unix instead of password param which is not supported by url::Url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,12 +75,12 @@
 //!
 //! If Unix socket support is available you can use a unix URL in this format:
 //!
-//! `redis+unix:///[:<passwd>@]<path>[?db=<db>]`
+//! `redis+unix:///<path>[?db=<db>][&password=<password>]`
 //!
 //! For compatibility with some other redis libraries, the "unix" scheme
 //! is also supported:
 //!
-//! `unix:///[:<passwd>@]<path>[?db=<db>]`
+//! `unix:///<path>[?db=<db>][&password=<password>]`
 //!
 //! ## Executing Low-Level Commands
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,12 +75,12 @@
 //!
 //! If Unix socket support is available you can use a unix URL in this format:
 //!
-//! `redis+unix:///<path>[?db=<db>][&password=<password>]`
+//! `redis+unix:///<path>[?db=<db>[&pass=<password>][&user=<username>]]`
 //!
 //! For compatibility with some other redis libraries, the "unix" scheme
 //! is also supported:
 //!
-//! `unix:///<path>[?db=<db>][&password=<password>]`
+//! `unix:///<path>[?db=<db>][&pass=<password>][&user=<username>]]`
 //!
 //! ## Executing Low-Level Commands
 //!


### PR DESCRIPTION
Using a password for unix protocol is not working from url, this can fix it by reading password from query string instead