### PR TITLE
Create a connection from a host and port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Support for Redis 6 auth ([#341](https://github.com/mitsuhiko/redis-rs/pull/341))
 * BUGFIX: Make aio::Connection Sync again ([#321](https://github.com/mitsuhiko/redis-rs/pull/321))
 * BUGFIX: Return UnexpectedEof if we try to decode at eof ([#322](https://github.com/mitsuhiko/redis-rs/pull/322))
+* Added support to create a connection from a (host, port) tuple ([#370](https://github.com/mitsuhiko/redis-rs/pull/370))
 
 ## [0.16.0](https://github.com/mitsuhiko/redis-rs/compare/0.15.1...0.16.0) - 2020-05-10
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -245,3 +245,13 @@ impl ConnectionLike for Client {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn regression_293_parse_ipv6_with_interface() {
+        assert!(Client::open(("fe80::cafe:beef%eno1", 6379)).is_ok());
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -132,6 +132,20 @@ impl<'a> IntoConnectionInfo for &'a str {
     }
 }
 
+impl<T> IntoConnectionInfo for (T, u16)
+where
+    T: Into<String>,
+{
+    fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
+        Ok(ConnectionInfo {
+            addr: Box::new(ConnectionAddr::Tcp(self.0.into(), self.1)),
+            db: 0,
+            username: None,
+            passwd: None,
+        })
+    }
+}
+
 impl IntoConnectionInfo for String {
     fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
         match parse_redis_url(&self) {


### PR DESCRIPTION
A TCP connection only needs a host and a port.
These can be passed in as a tuple now:

  redis::Client::open(("127.0.0.1", 6379))

In addition one should be able to specify an interface:

  redis::Client::open(("fe80::cafe:beef%eno1", 6379))

Fixes #293

--- 

Opening to get a CI run