### PR TITLE
Boolean implementation fixes

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -765,7 +765,7 @@ impl ToRedisArgs for bool {
     where
         W: ?Sized + RedisWrite,
     {
-        out.write_arg(if *self { b"true" } else { b"false" })
+        out.write_arg(if *self { b"1" } else { b"0" })
     }
 }
 
@@ -1057,6 +1057,16 @@ impl FromRedisValue for bool {
                     invalid_type_error!(v, "Response status not valid boolean");
                 }
             }
+            Value::Data(ref bytes) => {
+                let res = from_utf8(bytes)?.to_string();
+                if res == "1" {
+                    Ok(true)
+                } else if res == "0" {
+                    Ok(false)
+                } else {
+                     invalid_type_error!(v, "Response type not bool compatible.");
+                }
+            },
             Value::Okay => Ok(true),
             _ => invalid_type_error!(v, "Response type not bool compatible."),
         }

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -132,6 +132,15 @@ fn test_hashmap() {
 fn test_bool() {
     use redis::{ErrorKind, FromRedisValue, Value};
 
+    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+    assert_eq!(v, Ok(true));
+
+    let v = FromRedisValue::from_redis_value(&Value::Data("0".into()));
+    assert_eq!(v, Ok(false));
+
+    let v: Result<bool, _> = FromRedisValue::from_redis_value(&Value::Data("garbage".into()));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
     let v = FromRedisValue::from_redis_value(&Value::Status("1".into()));
     assert_eq!(v, Ok(true));
 


### PR DESCRIPTION
Should resolve #324. I changed the `ToRedisArgs` implementation of booleans to encode them as `1` or `0` as redis does, and their `FromRedisValue` implementation to also parse from `Value::Data`. The latter change means that calling GET on boolean values should stop dying now.
