### PR TITLE
Break the loop after processing the initial results, when cursor == None

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -110,6 +110,8 @@ impl<'a, T: FromRedisValue + 'a> AsyncIter<'a, T> {
                 if cursor == 0 {
                     return None;
                 }
+            } else {
+                return None;
             }
 
             let rv = unwrap_or!(


### PR DESCRIPTION
Break the loop after processing the initial results, when cursor == None. This prevents duplicate results when processing small batches. Fixes #377 

Tested with various batch sizes: 10, 100, 1000, 10.000, 100.000