### PR TITLE
Display feature-listing markers on docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # These two are generally really common simple dependencies so it does not seem

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ test-single: test
 bench:
 	cargo bench --all-features --test-threads=1
 
-docs: build
-	@cargo doc --no-deps
+docs:
+	@RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps
 
 upload-docs: docs
 	@./upload-docs.sh

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To run benchmarks:
 
     $ make bench
 
-To build the docs:
+To build the docs (require nightly compiler, see [rust-lang/rust#43781](https://github.com/rust-lang/rust/issues/43781)):
 
     $ make docs
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,8 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 
 #![deny(non_camel_case_types)]
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, warn(broken_intra_doc_links))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // public api
 pub use crate::client::Client;


### PR DESCRIPTION
This would refine docs on docs.rs to display feature-listing markers.

## Changes

- Set `RUSTDOCFLAGS="--cfg docsrs"` for [docs.rs](https://docs.rs/about/builds#detecting-docsrs) metadata
- Update `make docs` to use nightly compiler for feature-listing markers
- Warn for `#![cfg_attr(docsrs, warn(broken_intra_doc_links))]`

## Screenshots

<img width="577" alt="image" src="https://user-images.githubusercontent.com/14314532/94502477-cdd96c80-0236-11eb-864f-dc0c7394244b.png">
