### PR TITLE
Add a note about sub-commands to the "Executing Low-Level Commands" documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,20 @@
 //! about the actual return value (other than that it is not a failure)
 //! you can always type annotate it to the unit type `()`.
 //!
+//! Note that commands with a sub-command (like "MEMORY USAGE", "ACL WHOAMI",
+//! "LATENCY HISTORY", etc) must specify the sub-command as a separate `arg`:
+//!
+//! ```rust,no_run
+//! fn do_something(con: &mut redis::Connection) -> redis::RedisResult<usize> {
+//!     // This will result in a server error: "unknown command `MEMORY USAGE`"
+//!     // because "USAGE" is technically a sub-command of "MEMORY".
+//!     redis::cmd("MEMORY USAGE").arg("my_key").query(con)?;
+//!
+//!     // However, this will work as you'd expect
+//!     redis::cmd("MEMORY").arg("USAGE").arg("my_key").query(con)
+//! }
+//! ```
+//!
 //! ## Executing High-Level Commands
 //!
 //! The high-level interface is similar.  For it to become available you


### PR DESCRIPTION
First of all, thank you for this library - it's been a joy to use!

This is my anecdotal story: I was trying to use the [`MEMORY USAGE`](https://redis.io/commands/memory-usage) command in a tool I'm writing.  It's not implemented as a function in the library, so I was using `redis::cmd`:

```rust
let size: Option<usize> = redis::cmd("MEMORY USAGE").arg("my_key").query(con);
```

However, I was getting a (somewhat misleading) error:

```
An error was signalled by the server: unknown command `MEMORY USAGE`, with args beginning with: `my_key`
```

I spent a good amount of time trying to figure out if `MEMORY USAGE` was disabled for security reasons on my local Redis for some reason, if I was somehow running it against an old version of Redis, etc.

Eventually, I found some of the `ACL` commands in the source code, which break out the sub-command as a separate argument:

https://github.com/mitsuhiko/redis-rs/blob/13b55eb134c6ef37991135930468e8d18d7f93cc/src/commands.rs#L928-L930

Obviously, this is user error on my part.  However, I think this could be a useful addition to the documentation for others who find themselves facing this same error.  Even the Redis docs for [`MEMORY USAGE`](https://redis.io/commands/memory-usage) lead me to believe that `"MEMORY USAGE"` was a "command" I could pass wholesale to `redis::cmd("MEMORY USAGE")`, and not a "command + sub-command":

> The MEMORY USAGE command reports the number of bytes that a key and its value require to be stored in RAM.

I went back and forth on whether this would be better here, or in `src/cmd.rs`.  Ultimately, I thought it was more discoverable here, but if you'd rather see it co-located with `Cmd`, I'm happy to move it there.  I'm also happy to close this if you feel this is rare enough or user-error-enough.  Thank you!