### PR TITLE
Async timeout support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,3 +126,7 @@ required-features = ["connection-manager"]
 [[example]]
 name = "streams"
 required-features = ["streams"]
+
+[[example]]
+name = "async-timeout"
+required-features = ["connection-manager"]

--- a/examples/async-timeout.rs
+++ b/examples/async-timeout.rs
@@ -1,0 +1,22 @@
+use redis::AsyncCommands;
+use tokio::time;
+
+// use SIGTSTP (Ctrl+Z) to stop the redis server in order to induce timeouts
+
+#[tokio::main]
+async fn main() -> redis::RedisResult<()> {
+    let client = redis::Client::open("redis://127.0.0.1/")?;
+
+    let mut con = client
+        .get_tokio_connection_manager_timeout(time::Duration::from_secs(5))
+        .await?;
+
+    loop {
+        match con.set_ex::<_, _, ()>("async-timeout", 1, 30).await {
+            Ok(_) => (),
+            Err(e) => eprintln!("redis error: {}", e),
+        }
+
+        time::delay_for(time::Duration::from_secs(15)).await;
+    }
+}

--- a/examples/async-timeout.rs
+++ b/examples/async-timeout.rs
@@ -1,7 +1,7 @@
 use redis::AsyncCommands;
 use tokio::time;
 
-// use SIGTSTP (Ctrl+Z) to stop the redis server in order to induce timeouts
+// use SIGTSTP (Ctrl+Z) to stop the redis server in order to induce a timeout here
 
 #[tokio::main]
 async fn main() -> redis::RedisResult<()> {
@@ -11,12 +11,10 @@ async fn main() -> redis::RedisResult<()> {
         .get_tokio_connection_manager_timeout(time::Duration::from_secs(5))
         .await?;
 
-    loop {
-        match con.set_ex::<_, _, ()>("async-timeout", 1, 30).await {
-            Ok(_) => (),
-            Err(e) => eprintln!("redis error: {}", e),
-        }
-
-        time::delay_for(time::Duration::from_secs(15)).await;
+    match con.set_ex::<_, _, ()>("async-timeout", 1, 30).await {
+        Ok(_) => (),
+        Err(e) => eprintln!("redis error: {}", e),
     }
+
+    Ok(())
 }

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -972,7 +972,7 @@ mod connection_manager {
             current: arc_swap::Guard<'_, Arc<SharedRedisFuture<MultiplexedConnection>>>,
         ) {
             let client = self.client.clone();
-            let timeout = self.timeout.clone();
+            let timeout = self.timeout;
             let new_connection: SharedRedisFuture<MultiplexedConnection> = async move {
                 let mut connection = client.get_multiplexed_async_connection().await?;
                 connection.set_timeout(timeout);

--- a/src/client.rs
+++ b/src/client.rs
@@ -207,6 +207,32 @@ impl Client {
         Ok(crate::aio::ConnectionManager::new(self.clone()).await?)
     }
 
+    /// Returns an async [`ConnectionManager`][connection-manager] from the client.
+    ///
+    /// The connection manager wraps a
+    /// [`MultiplexedConnection`][multiplexed-connection]. If a command to that
+    /// connection fails with a connection error, then a new connection is
+    /// established in the background and the error is returned to the caller.
+    ///
+    /// This means that on connection loss at least one command will fail, but
+    /// the connection will be re-established automatically if possible. Please
+    /// refer to the [`ConnectionManager`][connection-manager] docs for
+    /// detailed reconnecting behavior.
+    ///
+    /// A connection manager can be cloned, allowing requests to be be sent concurrently
+    /// on the same underlying connection (tcp/unix socket).
+    ///
+    /// [connection-manager]: aio/struct.ConnectionManager.html
+    /// [multiplexed-connection]: aio/struct.MultiplexedConnection.html
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
+    pub async fn get_tokio_connection_manager_timeout(
+        &self,
+        timeout: Duration,
+    ) -> RedisResult<crate::aio::ConnectionManager> {
+        Ok(crate::aio::ConnectionManager::with_timeout(self.clone(), timeout).await?)
+    }
+
     async fn get_multiplexed_async_connection_inner<T>(
         &self,
     ) -> RedisResult<crate::aio::MultiplexedConnection>


### PR DESCRIPTION
This adds some basic timeout support to MultiplexedConnection and ConnectionManager (https://github.com/mitsuhiko/redis-rs/issues/395) by wrapping the req_packed_command() and req_packed_commands() contents in a tokio timeout when a timeout is set. I've also added a simple example that can be used to induce a timeout with some special treatment of the redis server - SIGTSTP / Ctrl+Z it so that it accepts connections but never responds to commands. This should help with scenarios where an async redis connection stops responding but isn't broken.