### PR TITLE
Converts native_tls::Error to WithDescriptionAndDetail

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -246,9 +246,13 @@ impl From<Utf8Error> for RedisError {
 
 #[cfg(feature = "tls")]
 impl From<native_tls::Error> for RedisError {
-    fn from(_: native_tls::Error) -> RedisError {
+    fn from(err: native_tls::Error) -> RedisError {
         RedisError {
-            repr: ErrorRepr::WithDescription(ErrorKind::IoError, "TLS error"),
+            repr: ErrorRepr::WithDescriptionAndDetail(
+                ErrorKind::IoError,
+                "TLS error",
+                format!("{:?}", err),
+            ),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -251,7 +251,7 @@ impl From<native_tls::Error> for RedisError {
             repr: ErrorRepr::WithDescriptionAndDetail(
                 ErrorKind::IoError,
                 "TLS error",
-                format!("{:?}", err),
+                err.to_string(),
             ),
         }
     }


### PR DESCRIPTION
Previously, the tls error was consumed and dropped by the From trait
implementation. This makes debugging difficult when there is a TLS error
as the only output is "TLS error". This change will serialize the error
that's passed in as a debug detail.