### PR TITLE
Release 0.18

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,6 @@
+[clog]
+repository = "https://github.com/mitsuhiko/redis-rs"
+
+changelog = "CHANGELOG.md"
+
+from-latest-tag = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
-<a name=""></a>
-##  (2020-12-03)
+<a name="0.18.0"></a>
+## 0.18.0 (2020-12-03)
 
 
 #### Bug Fixes
 
 *   Don't require tokio for the connection manager ([46be86f3](https://github.com/mitsuhiko/redis-rs/commit/46be86f3f07df4900559bf9a4dfd0b5138c3ac52))
 
+* Make ToRedisArgs and FromRedisValue consistent for booleans
+
+BREAKING CHANGE
+
+bool are now written as 0 and 1 instead of true and false. Parsing a bool still accept true and false so this should not break anything for must users however if you are reading something out that was stored as a bool you may see different results.
+
 #### Features
 
 *   Update tokio dependency to 0.3 ([bf5e0af3](https://github.com/mitsuhiko/redis-rs/commit/bf5e0af31c08be1785656031ffda96c355ee83c4), closes [#396](https://github.com/mitsuhiko/redis-rs/issues/396))
 *   add doc_cfg for Makefile and docs.rs config ([1bf79517](https://github.com/mitsuhiko/redis-rs/commit/1bf795174521160934f3695326897458246e4978))
-
+*   Impl FromRedisValue for i128 and u128
 
 
 # Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name=""></a>
+##  (2020-12-03)
+
+
+#### Bug Fixes
+
+*   Don't require tokio for the connection manager ([46be86f3](https://github.com/mitsuhiko/redis-rs/commit/46be86f3f07df4900559bf9a4dfd0b5138c3ac52))
+
+#### Features
+
+*   Update tokio dependency to 0.3 ([bf5e0af3](https://github.com/mitsuhiko/redis-rs/commit/bf5e0af31c08be1785656031ffda96c355ee83c4), closes [#396](https://github.com/mitsuhiko/redis-rs/issues/396))
+*   add doc_cfg for Makefile and docs.rs config ([1bf79517](https://github.com/mitsuhiko/redis-rs/commit/1bf795174521160934f3695326897458246e4978))
+
+
+
 # Changelog
 
 ## [Unreleased](https://github.com/mitsuhiko/redis-rs/compare/0.17.0...HEAD) - ReleaseDate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ bool are now written as 0 and 1 instead of true and false. Parsing a bool still 
 
 # Changelog
 
-## [Unreleased](https://github.com/mitsuhiko/redis-rs/compare/0.17.0...HEAD) - ReleaseDate
+## [0.18.0](https://github.com/mitsuhiko/redis-rs/compare/0.17.0...0.18.0) - 2020-12-03
 
 ## [0.17.0](https://github.com/mitsuhiko/redis-rs/compare/0.16.0...0.17.0) - 2020-07-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis"
-version = "0.18.0"
+version = "0.18.1-alpha.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>", "Jan-Erik Rediger <janerik@fnordig.de>"]
 keywords = ["redis", "database"]
 description = "Redis driver for Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis"
-version = "0.17.1-alpha.0"
+version = "0.18.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>", "Jan-Erik Rediger <janerik@fnordig.de>"]
 keywords = ["redis", "database"]
 description = "Redis driver for Rust."

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The crate is called `redis` and you can depend on it via cargo:
 
 ```ini
 [dependencies]
-redis = "0.17.0"
+redis = "0.18.0"
 ```
 
 Documentation on the library can be found at


### PR DESCRIPTION
Will need to run cargo release manually after this, probably some things I missed in the changelog but I'd rather just roll this out now