### PR TITLE
Follow MOVED (again)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -455,8 +455,9 @@ impl RedisError {
     ///
     /// This returns `(addr, slot_id)`.
     pub fn redirect_node(&self) -> Option<(&str, u16)> {
-        if self.kind() != ErrorKind::Ask {
-            return None;
+        match self.kind() {
+            ErrorKind::Ask | ErrorKind::Moved => (),
+            _ => return None,
         }
         let mut iter = self.detail()?.split_ascii_whitespace();
         let slot_id: u16 = iter.next()?.parse().ok()?;

--- a/tests/test_cluster.rs
+++ b/tests/test_cluster.rs
@@ -22,6 +22,28 @@ fn test_cluster_basics() {
 }
 
 #[test]
+fn test_cluster_readonly() {
+    let cluster =
+        TestClusterContext::new_with_cluster_client_builder(6, 1, |builder| builder.readonly(true));
+    let mut con = cluster.connection();
+
+    // con is a READONLY replica, so we'll get the MOVED response and will be redirected
+    // to the master
+    redis::cmd("SET")
+        .arg("{x}key1")
+        .arg(b"foo")
+        .execute(&mut con);
+    redis::cmd("SET").arg(&["{x}key2", "bar"]).execute(&mut con);
+
+    assert_eq!(
+        redis::cmd("MGET")
+            .arg(&["{x}key1", "{x}key2"])
+            .query(&mut con),
+        Ok(("foo".to_string(), b"bar".to_vec()))
+    );
+}
+
+#[test]
 fn test_cluster_eval() {
     let cluster = TestClusterContext::new(3, 0);
     let mut con = cluster.connection();


### PR DESCRIPTION
The current implementation does not handle the `"MOVED"` error properly. Therefore, throwing an update query to a `readonly` connection will result in an infinite loop. A `readonly` connection throws the query to a replica, but a replica can not handle the update query and returns `"MOVED"`. Calling `refresh_slots` does not complete the process, because it doesn't assign the query to the master node.

I don't know if it's correct to perform the update query on a `readonly` connection, but it is possible to complete the query on the node referred to by `MOVED`.

#285 tried to solve the same problem but did not merge. In this PR, we call the `refresh_slots` method even if the query is performed on a `MOVED` destination. Also, I add a test to reproduce the infinite loop(Actually, it retries the `CLUSTER SLOTS` command [16 times](https://github.com/mitsuhiko/redis-rs/blob/8a53e2699d7d7bd63f222de778ed6820b0a65665/src/cluster.rs#L458), then it returns the error response to the client).
