### PR TITLE
Bumped arc-swap to v1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio-util = { version = "0.4", optional = true }
 tokio = { version = "0.3.4", features = ["rt"], optional = true }
 
 # Only needed for the connection manager
-arc-swap = { version = "0.4.4", optional = true }
+arc-swap = { version = "1.1.0", optional = true }
 futures = { version = "0.3.3", optional = true }
 
 # Only needed for the r2d2 feature

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -914,7 +914,7 @@ mod connection_manager {
         /// when the connection loss was detected.
         fn reconnect(
             &self,
-            current: arc_swap::Guard<'_, Arc<SharedRedisFuture<MultiplexedConnection>>>,
+            current: arc_swap::Guard<Arc<SharedRedisFuture<MultiplexedConnection>>>,
         ) {
             let client = self.client.clone();
             let new_connection: SharedRedisFuture<MultiplexedConnection> =


### PR DESCRIPTION
The version `0.4.4` of `arc-swap` has been yanked and prevent compiling `redis-rs`.