### PR TITLE
AUTH cmd fallback

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -352,6 +352,30 @@ where
         }
         match command.arg(passwd).query_async(con).await {
             Ok(Value::Okay) => (),
+            Err(e) => {
+                let err_msg = e.detail().ok_or((
+                    ErrorKind::AuthenticationFailed,
+                    "Password authentication failed",
+                ))?;
+
+                if !err_msg.contains("wrong number of arguments for 'auth' command") {
+                    fail!((
+                        ErrorKind::AuthenticationFailed,
+                        "Password authentication failed",
+                    ));
+                }
+
+                let mut command = cmd("AUTH");
+                match command.arg(passwd).query_async(con).await {
+                    Ok(Value::Okay) => (),
+                    _ => {
+                        fail!((
+                            ErrorKind::AuthenticationFailed,
+                            "Password authentication failed"
+                        ));
+                    }
+                }
+            }
             _ => {
                 fail!((
                     ErrorKind::AuthenticationFailed,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -742,11 +742,10 @@ impl Connection {
         };
         // shutdown connection on protocol error
         if let Err(e) = &result {
-            let shutdown = e.kind() == ErrorKind::ResponseError
-                || match e.as_io_error() {
-                    Some(e) => e.kind() == io::ErrorKind::UnexpectedEof,
-                    None => false,
-                };
+            let shutdown = match e.as_io_error() {
+                Some(e) => e.kind() == io::ErrorKind::UnexpectedEof,
+                None => false,
+            };
             if shutdown {
                 match self.con {
                     ActualConnection::Tcp(ref mut connection) => {


### PR DESCRIPTION
When connecting to redis v5 server, with uri containing username, connection
fails with an error:

  wrong number of arguments for 'auth' command

library can do better and try AUTH again without username.

Signed-off-by: Nikola Pajkovsky <nikola@pajkovsky.cz>