### PR TITLE
README: update TLS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ redis = { version = "0.17.0", features = ["async-std-comp"] }
 To enable TLS support, you need to use the relevant feature entry in your Cargo.toml.
 
 ```
-redis = { version = "0.17.0", features = ["tls"] }
+redis = { version = "0.19.0", features = ["tls"] }
 
 # if you use tokio
-redis = { version = "0.17.0", features = ["tls", "tokio-tls-comp"] }
+redis = { version = "0.19.0", features = ["tokio-native-tls-comp"] }
 
 # if you use async-std
-redis = { version = "0.17.0", features = ["tls", "async-std-tls-comp"] }
+redis = { version = "0.19.0", features = ["async-std-tls-comp"] }
 ```
 
 then you should be able to connect to a redis instance using the `rediss://` URL scheme:


### PR DESCRIPTION
Closes #387

Now redis 0.19.0 compiles with these features enabled.
I removed the "tls" feature for tokio and async-std because I think it is redundant.
Just to be clear, I haven't tested if it works, just that it compiles.