### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ homepage = "https://github.com/mitsuhiko/redis-rs"
 repository = "https://github.com/mitsuhiko/redis-rs"
 documentation = "https://docs.rs/redis"
 license = "BSD-3-Clause"
-readme = "README.md"
 edition = "2018"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).