### PR TITLE
Refactor Pipeline logic into it's own file

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,9 +1,8 @@
 use std::{fmt, io};
 
 use crate::connection::ConnectionLike;
-use crate::types::{
-    from_redis_value, ErrorKind, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, Value,
-};
+use crate::pipeline::Pipeline;
+use crate::types::{from_redis_value, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs};
 
 /// An argument to a redis command
 #[derive(Clone)]
@@ -21,14 +20,6 @@ pub struct Cmd {
     // Arg::Simple contains the offset that marks the end of the argument
     args: Vec<Arg<usize>>,
     cursor: Option<u64>,
-    is_ignored: bool,
-}
-
-/// Represents a redis command pipeline.
-#[derive(Clone)]
-pub struct Pipeline {
-    commands: Vec<Cmd>,
-    transaction_mode: bool,
 }
 
 /// Represents a redis iterator.
@@ -166,7 +157,7 @@ where
     totlen
 }
 
-fn cmd_len(cmd: &Cmd) -> usize {
+pub(crate) fn cmd_len(cmd: &Cmd) -> usize {
     args_len(cmd.args_iter(), cmd.cursor.unwrap_or(0))
 }
 
@@ -213,34 +204,6 @@ where
         cmd.write_all(b"\r\n")?;
     }
     Ok(())
-}
-
-fn encode_pipeline(cmds: &[Cmd], atomic: bool) -> Vec<u8> {
-    let mut rv = vec![];
-    write_pipeline(&mut rv, cmds, atomic);
-    rv
-}
-
-fn write_pipeline(rv: &mut Vec<u8>, cmds: &[Cmd], atomic: bool) {
-    let cmds_len = cmds.iter().map(cmd_len).sum();
-
-    if atomic {
-        let multi = cmd("MULTI");
-        let exec = cmd("EXEC");
-        rv.reserve(cmd_len(&multi) + cmd_len(&exec) + cmds_len);
-
-        multi.write_packed_command_preallocated(rv);
-        for cmd in cmds {
-            cmd.write_packed_command_preallocated(rv);
-        }
-        exec.write_packed_command_preallocated(rv);
-    } else {
-        rv.reserve(cmds_len);
-
-        for cmd in cmds {
-            cmd.write_packed_command_preallocated(rv);
-        }
-    }
 }
 
 impl RedisWrite for Cmd {
@@ -296,7 +259,6 @@ impl Cmd {
             data: vec![],
             args: vec![],
             cursor: None,
-            is_ignored: false,
         }
     }
 
@@ -354,7 +316,7 @@ impl Cmd {
         write_command_to_vec(cmd, self.args_iter(), self.cursor.unwrap_or(0))
     }
 
-    fn write_packed_command_preallocated(&self, cmd: &mut Vec<u8>) {
+    pub(crate) fn write_packed_command_preallocated(&self, cmd: &mut Vec<u8>) {
         write_command(cmd, self.args_iter(), self.cursor.unwrap_or(0)).unwrap()
     }
 
@@ -502,281 +464,6 @@ impl Cmd {
 
             Arg::Cursor => Arg::Cursor,
         })
-    }
-}
-
-impl Default for Pipeline {
-    fn default() -> Pipeline {
-        Pipeline::new()
-    }
-}
-
-/// A pipeline allows you to send multiple commands in one go to the
-/// redis server.  API wise it's very similar to just using a command
-/// but it allows multiple commands to be chained and some features such
-/// as iteration are not available.
-///
-/// Basic example:
-///
-/// ```rust,no_run
-/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-/// # let mut con = client.get_connection().unwrap();
-/// let ((k1, k2),) : ((i32, i32),) = redis::pipe()
-///     .cmd("SET").arg("key_1").arg(42).ignore()
-///     .cmd("SET").arg("key_2").arg(43).ignore()
-///     .cmd("MGET").arg(&["key_1", "key_2"]).query(&mut con).unwrap();
-/// ```
-///
-/// As you can see with `cmd` you can start a new command.  By default
-/// each command produces a value but for some you can ignore them by
-/// calling `ignore` on the command.  That way it will be skipped in the
-/// return value which is useful for `SET` commands and others, which
-/// do not have a useful return value.
-impl Pipeline {
-    /// Creates an empty pipeline.  For consistency with the `cmd`
-    /// api a `pipe` function is provided as alias.
-    pub fn new() -> Pipeline {
-        Self::with_capacity(0)
-    }
-
-    /// Creates an empty pipeline with pre-allocated capacity.
-    pub fn with_capacity(capacity: usize) -> Pipeline {
-        Pipeline {
-            commands: Vec::with_capacity(capacity),
-            transaction_mode: false,
-        }
-    }
-
-    /// Starts a new command.  Functions such as `arg` then become
-    /// available to add more arguments to that command.
-    #[inline]
-    pub fn cmd(&mut self, name: &str) -> &mut Pipeline {
-        self.commands.push(cmd(name));
-        self
-    }
-
-    /// Adds a command to the pipeline.
-    #[inline]
-    pub fn add_command(&mut self, cmd: Cmd) -> &mut Pipeline {
-        self.commands.push(cmd);
-        self
-    }
-
-    #[inline]
-    fn get_last_command(&mut self) -> &mut Cmd {
-        let idx = match self.commands.len() {
-            0 => panic!("No command on stack"),
-            x => x - 1,
-        };
-        &mut self.commands[idx]
-    }
-
-    /// Adds an argument to the last started command.  This works similar
-    /// to the `arg` method of the `Cmd` object.
-    ///
-    /// Note that this function fails the task if executed on an empty pipeline.
-    #[inline]
-    pub fn arg<T: ToRedisArgs>(&mut self, arg: T) -> &mut Pipeline {
-        {
-            let cmd = self.get_last_command();
-            cmd.arg(arg);
-        }
-        self
-    }
-
-    /// Instructs the pipeline to ignore the return value of this command.
-    /// It will still be ensured that it is not an error, but any successful
-    /// result is just thrown away.  This makes result processing through
-    /// tuples much easier because you do not need to handle all the items
-    /// you do not care about.
-    ///
-    /// Note that this function fails the task if executed on an empty pipeline.
-    #[inline]
-    pub fn ignore(&mut self) -> &mut Pipeline {
-        {
-            let cmd = self.get_last_command();
-            cmd.is_ignored = true;
-        }
-        self
-    }
-
-    /// This enables atomic mode.  In atomic mode the whole pipeline is
-    /// enclosed in `MULTI`/`EXEC`.  From the user's point of view nothing
-    /// changes however.  This is easier than using `MULTI`/`EXEC` yourself
-    /// as the format does not change.
-    ///
-    /// ```rust,no_run
-    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    /// # let mut con = client.get_connection().unwrap();
-    /// let (k1, k2) : (i32, i32) = redis::pipe()
-    ///     .atomic()
-    ///     .cmd("GET").arg("key_1")
-    ///     .cmd("GET").arg("key_2").query(&mut con).unwrap();
-    /// ```
-    #[inline]
-    pub fn atomic(&mut self) -> &mut Pipeline {
-        self.transaction_mode = true;
-        self
-    }
-
-    /// Returns an iterator over all the commands currently in this pipeline
-    pub fn cmd_iter(&self) -> impl Iterator<Item = &Cmd> {
-        self.commands.iter()
-    }
-
-    fn make_pipeline_results(&self, resp: Vec<Value>) -> Value {
-        let mut rv = vec![];
-        for (idx, result) in resp.into_iter().enumerate() {
-            if !self.commands[idx].is_ignored {
-                rv.push(result);
-            }
-        }
-        Value::Bulk(rv)
-    }
-
-    /// Returns the encoded pipeline commands.
-    pub fn get_packed_pipeline(&self) -> Vec<u8> {
-        encode_pipeline(&self.commands, self.transaction_mode)
-    }
-
-    #[cfg(feature = "aio")]
-    pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
-        write_pipeline(out, &self.commands, self.transaction_mode)
-    }
-
-    fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
-        Ok(self.make_pipeline_results(con.req_packed_commands(
-            &encode_pipeline(&self.commands, false),
-            0,
-            self.commands.len(),
-        )?))
-    }
-
-    fn execute_transaction(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
-        let mut resp = con.req_packed_commands(
-            &encode_pipeline(&self.commands, true),
-            self.commands.len() + 1,
-            1,
-        )?;
-        match resp.pop() {
-            Some(Value::Nil) => Ok(Value::Nil),
-            Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),
-            _ => fail!((
-                ErrorKind::ResponseError,
-                "Invalid response when parsing multi response"
-            )),
-        }
-    }
-
-    /// Executes the pipeline and fetches the return values.  Since most
-    /// pipelines return different types it's recommended to use tuple
-    /// matching to process the results:
-    ///
-    /// ```rust,no_run
-    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    /// # let mut con = client.get_connection().unwrap();
-    /// let (k1, k2) : (i32, i32) = redis::pipe()
-    ///     .cmd("SET").arg("key_1").arg(42).ignore()
-    ///     .cmd("SET").arg("key_2").arg(43).ignore()
-    ///     .cmd("GET").arg("key_1")
-    ///     .cmd("GET").arg("key_2").query(&mut con).unwrap();
-    /// ```
-    ///
-    /// NOTE: A Pipeline object may be reused after `query()` with all the commands as were inserted
-    ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
-    ///       it is necessary to call the `clear()` before inserting new commands.
-    #[inline]
-    pub fn query<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
-        if !con.supports_pipelining() {
-            fail!((
-                ErrorKind::ResponseError,
-                "This connection does not support pipelining."
-            ));
-        }
-        from_redis_value(
-            &(if self.commands.is_empty() {
-                Value::Bulk(vec![])
-            } else if self.transaction_mode {
-                self.execute_transaction(con)?
-            } else {
-                self.execute_pipelined(con)?
-            }),
-        )
-    }
-
-    /// Clear a Pipeline object internal data structure.
-    ///
-    /// This allows reusing a Pipeline object as a clear object while performing a minimal amount of
-    /// memory released/reallocated.
-    #[inline]
-    pub fn clear(&mut self) {
-        self.commands.clear();
-    }
-
-    #[cfg(feature = "aio")]
-    async fn execute_pipelined_async<C>(&self, con: &mut C) -> RedisResult<Value>
-    where
-        C: crate::aio::ConnectionLike,
-    {
-        let value = con
-            .req_packed_commands(self, 0, self.commands.len())
-            .await?;
-        Ok(self.make_pipeline_results(value))
-    }
-
-    #[cfg(feature = "aio")]
-    async fn execute_transaction_async<C>(&self, con: &mut C) -> RedisResult<Value>
-    where
-        C: crate::aio::ConnectionLike,
-    {
-        let mut resp = con
-            .req_packed_commands(self, self.commands.len() + 1, 1)
-            .await?;
-        match resp.pop() {
-            Some(Value::Nil) => Ok(Value::Nil),
-            Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),
-            _ => Err((
-                ErrorKind::ResponseError,
-                "Invalid response when parsing multi response",
-            )
-                .into()),
-        }
-    }
-
-    /// Async version of `query`.
-    #[inline]
-    #[cfg(feature = "aio")]
-    pub async fn query_async<C, T: FromRedisValue>(&self, con: &mut C) -> RedisResult<T>
-    where
-        C: crate::aio::ConnectionLike,
-    {
-        let v = if self.commands.is_empty() {
-            return from_redis_value(&Value::Bulk(vec![]));
-        } else if self.transaction_mode {
-            self.execute_transaction_async(con).await?
-        } else {
-            self.execute_pipelined_async(con).await?
-        };
-        from_redis_value(&v)
-    }
-
-    /// This is a shortcut to `query()` that does not return a value and
-    /// will fail the task if the query of the pipeline fails.
-    ///
-    /// This is equivalent to a call of query like this:
-    ///
-    /// ```rust,no_run
-    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-    /// # let mut con = client.get_connection().unwrap();
-    /// let _ : () = redis::pipe().cmd("PING").query(&mut con).unwrap();
-    /// ```
-    ///
-    /// NOTE: A Pipeline object may be reused after `query()` with all the commands as were inserted
-    ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
-    ///       it is necessary to call the `clear()` before inserting new commands.
-    #[inline]
-    pub fn execute(&self, con: &mut dyn ConnectionLike) {
-        self.query::<()>(con).unwrap();
     }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,8 @@
 // can't use rustfmt here because it screws up the file.
 #![cfg_attr(rustfmt, rustfmt_skip)]
-use crate::cmd::{cmd, Cmd, Iter, Pipeline};
+use crate::cmd::{cmd, Cmd, Iter};
 use crate::connection::{Connection, ConnectionLike, Msg};
+use crate::pipeline::Pipeline;
 use crate::types::{FromRedisValue, NumericBehavior, RedisResult, ToRedisArgs, RedisWrite};
 
 #[cfg(feature = "geospatial")]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,8 +5,9 @@ use std::path::PathBuf;
 use std::str::{from_utf8, FromStr};
 use std::time::Duration;
 
-use crate::cmd::{cmd, pipe, Pipeline};
+use crate::cmd::{cmd, pipe};
 use crate::parser::Parser;
+use crate::pipeline::Pipeline;
 use crate::types::{
     from_redis_value, ErrorKind, FromRedisValue, RedisError, RedisResult, ToRedisArgs, Value,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,13 +359,15 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 
 // public api
 pub use crate::client::Client;
-pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter, Pipeline};
+pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{Commands, ControlFlow, LposOptions, PubSubCommands};
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
     IntoConnectionInfo, Msg, PubSub,
 };
 pub use crate::parser::{parse_redis_value, Parser};
+pub use crate::pipeline::Pipeline;
+
 #[cfg(feature = "script")]
 #[cfg_attr(docsrs, doc(cfg(feature = "script")))]
 pub use crate::script::{Script, ScriptInvocation};
@@ -431,5 +433,6 @@ mod cmd;
 mod commands;
 mod connection;
 mod parser;
+mod pipeline;
 mod script;
 mod types;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,0 +1,315 @@
+use crate::cmd::{cmd, cmd_len, Cmd};
+use crate::connection::ConnectionLike;
+use crate::types::{from_redis_value, ErrorKind, FromRedisValue, RedisResult, ToRedisArgs, Value};
+use std::collections::HashSet;
+
+/// Represents a redis command pipeline.
+#[derive(Clone)]
+pub struct Pipeline {
+    commands: Vec<Cmd>,
+    transaction_mode: bool,
+    ignored_commands: HashSet<usize>,
+}
+
+/// A pipeline allows you to send multiple commands in one go to the
+/// redis server.  API wise it's very similar to just using a command
+/// but it allows multiple commands to be chained and some features such
+/// as iteration are not available.
+///
+/// Basic example:
+///
+/// ```rust,no_run
+/// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+/// # let mut con = client.get_connection().unwrap();
+/// let ((k1, k2),) : ((i32, i32),) = redis::pipe()
+///     .cmd("SET").arg("key_1").arg(42).ignore()
+///     .cmd("SET").arg("key_2").arg(43).ignore()
+///     .cmd("MGET").arg(&["key_1", "key_2"]).query(&mut con).unwrap();
+/// ```
+///
+/// As you can see with `cmd` you can start a new command.  By default
+/// each command produces a value but for some you can ignore them by
+/// calling `ignore` on the command.  That way it will be skipped in the
+/// return value which is useful for `SET` commands and others, which
+/// do not have a useful return value.
+impl Pipeline {
+    /// Creates an empty pipeline.  For consistency with the `cmd`
+    /// api a `pipe` function is provided as alias.
+    pub fn new() -> Pipeline {
+        Self::with_capacity(0)
+    }
+
+    /// Creates an empty pipeline with pre-allocated capacity.
+    pub fn with_capacity(capacity: usize) -> Pipeline {
+        Pipeline {
+            commands: Vec::with_capacity(capacity),
+            transaction_mode: false,
+            ignored_commands: HashSet::new(),
+        }
+    }
+
+    /// Starts a new command.  Functions such as `arg` then become
+    /// available to add more arguments to that command.
+    #[inline]
+    pub fn cmd(&mut self, name: &str) -> &mut Pipeline {
+        self.commands.push(cmd(name));
+        self
+    }
+
+    /// Adds a command to the pipeline.
+    #[inline]
+    pub fn add_command(&mut self, cmd: Cmd) -> &mut Pipeline {
+        self.commands.push(cmd);
+        self
+    }
+
+    #[inline]
+    fn get_last_command(&mut self) -> &mut Cmd {
+        let idx = match self.commands.len() {
+            0 => panic!("No command on stack"),
+            x => x - 1,
+        };
+        &mut self.commands[idx]
+    }
+
+    /// Adds an argument to the last started command.  This works similar
+    /// to the `arg` method of the `Cmd` object.
+    ///
+    /// Note that this function fails the task if executed on an empty pipeline.
+    #[inline]
+    pub fn arg<T: ToRedisArgs>(&mut self, arg: T) -> &mut Pipeline {
+        {
+            let cmd = self.get_last_command();
+            cmd.arg(arg);
+        }
+        self
+    }
+
+    /// Instructs the pipeline to ignore the return value of this command.
+    /// It will still be ensured that it is not an error, but any successful
+    /// result is just thrown away.  This makes result processing through
+    /// tuples much easier because you do not need to handle all the items
+    /// you do not care about.
+    #[inline]
+    pub fn ignore(&mut self) -> &mut Pipeline {
+        match self.commands.len() {
+            0 => true,
+            x => self.ignored_commands.insert(x - 1),
+        };
+        self
+    }
+
+    /// This enables atomic mode.  In atomic mode the whole pipeline is
+    /// enclosed in `MULTI`/`EXEC`.  From the user's point of view nothing
+    /// changes however.  This is easier than using `MULTI`/`EXEC` yourself
+    /// as the format does not change.
+    ///
+    /// ```rust,no_run
+    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    /// let (k1, k2) : (i32, i32) = redis::pipe()
+    ///     .atomic()
+    ///     .cmd("GET").arg("key_1")
+    ///     .cmd("GET").arg("key_2").query(&mut con).unwrap();
+    /// ```
+    #[inline]
+    pub fn atomic(&mut self) -> &mut Pipeline {
+        self.transaction_mode = true;
+        self
+    }
+
+    /// Returns an iterator over all the commands currently in this pipeline
+    pub fn cmd_iter(&self) -> impl Iterator<Item = &Cmd> {
+        self.commands.iter()
+    }
+
+    fn make_pipeline_results(&self, resp: Vec<Value>) -> Value {
+        let mut rv = vec![];
+        for (idx, result) in resp.into_iter().enumerate() {
+            if !self.ignored_commands.contains(&idx) {
+                rv.push(result);
+            }
+        }
+        Value::Bulk(rv)
+    }
+
+    /// Returns the encoded pipeline commands.
+    pub fn get_packed_pipeline(&self) -> Vec<u8> {
+        encode_pipeline(&self.commands, self.transaction_mode)
+    }
+
+    #[cfg(feature = "aio")]
+    pub(crate) fn write_packed_pipeline(&self, out: &mut Vec<u8>) {
+        write_pipeline(out, &self.commands, self.transaction_mode)
+    }
+
+    fn execute_pipelined(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
+        Ok(self.make_pipeline_results(con.req_packed_commands(
+            &encode_pipeline(&self.commands, false),
+            0,
+            self.commands.len(),
+        )?))
+    }
+
+    fn execute_transaction(&self, con: &mut dyn ConnectionLike) -> RedisResult<Value> {
+        let mut resp = con.req_packed_commands(
+            &encode_pipeline(&self.commands, true),
+            self.commands.len() + 1,
+            1,
+        )?;
+        match resp.pop() {
+            Some(Value::Nil) => Ok(Value::Nil),
+            Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),
+            _ => fail!((
+                ErrorKind::ResponseError,
+                "Invalid response when parsing multi response"
+            )),
+        }
+    }
+
+    /// Executes the pipeline and fetches the return values.  Since most
+    /// pipelines return different types it's recommended to use tuple
+    /// matching to process the results:
+    ///
+    /// ```rust,no_run
+    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    /// let (k1, k2) : (i32, i32) = redis::pipe()
+    ///     .cmd("SET").arg("key_1").arg(42).ignore()
+    ///     .cmd("SET").arg("key_2").arg(43).ignore()
+    ///     .cmd("GET").arg("key_1")
+    ///     .cmd("GET").arg("key_2").query(&mut con).unwrap();
+    /// ```
+    ///
+    /// NOTE: A Pipeline object may be reused after `query()` with all the commands as were inserted
+    ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
+    ///       it is necessary to call the `clear()` before inserting new commands.
+    #[inline]
+    pub fn query<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
+        if !con.supports_pipelining() {
+            fail!((
+                ErrorKind::ResponseError,
+                "This connection does not support pipelining."
+            ));
+        }
+        from_redis_value(
+            &(if self.commands.is_empty() {
+                Value::Bulk(vec![])
+            } else if self.transaction_mode {
+                self.execute_transaction(con)?
+            } else {
+                self.execute_pipelined(con)?
+            }),
+        )
+    }
+
+    /// Clear a Pipeline object internal data structure.
+    ///
+    /// This allows reusing a Pipeline object as a clear object while performing a minimal amount of
+    /// memory released/reallocated.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.commands.clear();
+        self.ignored_commands.clear();
+    }
+
+    #[cfg(feature = "aio")]
+    async fn execute_pipelined_async<C>(&self, con: &mut C) -> RedisResult<Value>
+    where
+        C: crate::aio::ConnectionLike,
+    {
+        let value = con
+            .req_packed_commands(self, 0, self.commands.len())
+            .await?;
+        Ok(self.make_pipeline_results(value))
+    }
+
+    #[cfg(feature = "aio")]
+    async fn execute_transaction_async<C>(&self, con: &mut C) -> RedisResult<Value>
+    where
+        C: crate::aio::ConnectionLike,
+    {
+        let mut resp = con
+            .req_packed_commands(self, self.commands.len() + 1, 1)
+            .await?;
+        match resp.pop() {
+            Some(Value::Nil) => Ok(Value::Nil),
+            Some(Value::Bulk(items)) => Ok(self.make_pipeline_results(items)),
+            _ => Err((
+                ErrorKind::ResponseError,
+                "Invalid response when parsing multi response",
+            )
+                .into()),
+        }
+    }
+
+    /// Async version of `query`.
+    #[inline]
+    #[cfg(feature = "aio")]
+    pub async fn query_async<C, T: FromRedisValue>(&self, con: &mut C) -> RedisResult<T>
+    where
+        C: crate::aio::ConnectionLike,
+    {
+        let v = if self.commands.is_empty() {
+            return from_redis_value(&Value::Bulk(vec![]));
+        } else if self.transaction_mode {
+            self.execute_transaction_async(con).await?
+        } else {
+            self.execute_pipelined_async(con).await?
+        };
+        from_redis_value(&v)
+    }
+
+    /// This is a shortcut to `query()` that does not return a value and
+    /// will fail the task if the query of the pipeline fails.
+    ///
+    /// This is equivalent to a call of query like this:
+    ///
+    /// ```rust,no_run
+    /// # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    /// let _ : () = redis::pipe().cmd("PING").query(&mut con).unwrap();
+    /// ```
+    ///
+    /// NOTE: A Pipeline object may be reused after `query()` with all the commands as were inserted
+    ///       to them. In order to clear a Pipeline object with minimal memory released/allocated,
+    ///       it is necessary to call the `clear()` before inserting new commands.
+    #[inline]
+    pub fn execute(&self, con: &mut dyn ConnectionLike) {
+        self.query::<()>(con).unwrap();
+    }
+}
+
+impl Default for Pipeline {
+    fn default() -> Pipeline {
+        Pipeline::new()
+    }
+}
+
+fn encode_pipeline(cmds: &[Cmd], atomic: bool) -> Vec<u8> {
+    let mut rv = vec![];
+    write_pipeline(&mut rv, cmds, atomic);
+    rv
+}
+
+fn write_pipeline(rv: &mut Vec<u8>, cmds: &[Cmd], atomic: bool) {
+    let cmds_len = cmds.iter().map(cmd_len).sum();
+
+    if atomic {
+        let multi = cmd("MULTI");
+        let exec = cmd("EXEC");
+        rv.reserve(cmd_len(&multi) + cmd_len(&exec) + cmds_len);
+
+        multi.write_packed_command_preallocated(rv);
+        for cmd in cmds {
+            cmd.write_packed_command_preallocated(rv);
+        }
+        exec.write_packed_command_preallocated(rv);
+    } else {
+        rv.reserve(cmds_len);
+
+        for cmd in cmds {
+            cmd.write_packed_command_preallocated(rv);
+        }
+    }
+}


### PR DESCRIPTION
Moves all logic related to Pipeline into a new file (pipeline.rs).

Main motivation for this is to reduce the size/bloat of my PR for implementing pipeline support in Cluster mode (#307).