### PR TITLE
Add basic benchmark for Redis Cluster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,11 @@ name = "bench_basic"
 harness = false
 required-features = ["tokio-comp"]
 
+[[bench]]
+name = "bench_cluster"
+harness = false
+required-features = ["cluster"]
+
 [[example]]
 name = "async-multiplexed"
 required-features = ["tokio-comp"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test:
 test-single: test
 
 bench:
-	cargo bench --all-features --test-threads=1
+	cargo bench --all-features
 
 docs:
 	@RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --no-deps

--- a/benches/bench_basic.rs
+++ b/benches/bench_basic.rs
@@ -25,7 +25,7 @@ fn bench_simple_getsetdel(b: &mut Bencher) {
 
 fn bench_simple_getsetdel_async(b: &mut Bencher) {
     let client = get_client();
-    let mut runtime = current_thread_runtime();
+    let runtime = current_thread_runtime();
     let con = client.get_async_connection();
     let mut con = runtime.block_on(con).unwrap();
 
@@ -112,7 +112,7 @@ fn bench_long_pipeline(b: &mut Bencher) {
 
 fn bench_async_long_pipeline(b: &mut Bencher) {
     let client = get_client();
-    let mut runtime = current_thread_runtime();
+    let runtime = current_thread_runtime();
     let mut con = runtime.block_on(client.get_async_connection()).unwrap();
 
     let pipe = long_pipeline();
@@ -126,7 +126,7 @@ fn bench_async_long_pipeline(b: &mut Bencher) {
 
 fn bench_multiplexed_async_long_pipeline(b: &mut Bencher) {
     let client = get_client();
-    let mut runtime = current_thread_runtime();
+    let runtime = current_thread_runtime();
     let mut con = runtime
         .block_on(client.get_multiplexed_tokio_connection())
         .unwrap();
@@ -142,7 +142,7 @@ fn bench_multiplexed_async_long_pipeline(b: &mut Bencher) {
 
 fn bench_multiplexed_async_implicit_pipeline(b: &mut Bencher) {
     let client = get_client();
-    let mut runtime = current_thread_runtime();
+    let runtime = current_thread_runtime();
     let con = runtime
         .block_on(client.get_multiplexed_tokio_connection())
         .unwrap();

--- a/benches/bench_cluster.rs
+++ b/benches/bench_cluster.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "cluster")]
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use support::*;
+
+#[path = "../tests/support/mod.rs"]
+mod support;
+
+fn bench_set_get_and_del(c: &mut Criterion) {
+    let cluster = TestClusterContext::new(6, 1);
+    cluster.wait_for_cluster_up();
+    let mut con = cluster.connection();
+    let key = "test_key";
+
+    let mut group = c.benchmark_group("cluster_basic");
+
+    group.bench_function("set", |b| {
+        b.iter(|| black_box(redis::cmd("SET").arg(key).arg(42).execute(&mut con)))
+    });
+
+    group.bench_function("get", |b| {
+        b.iter(|| black_box(redis::cmd("GET").arg(key).query::<isize>(&mut con).unwrap()))
+    });
+
+    let mut set_and_del = || {
+        redis::cmd("SET").arg(key).arg(42).execute(&mut con);
+        redis::cmd("DEL").arg(key).execute(&mut con);
+    };
+    group.bench_function("set_and_del", |b| b.iter(|| black_box(set_and_del())));
+
+    group.finish();
+}
+
+criterion_group!(cluster_bench, bench_set_get_and_del);
+criterion_main!(cluster_bench);

--- a/tests/support/cluster.rs
+++ b/tests/support/cluster.rs
@@ -147,4 +147,21 @@ impl TestClusterContext {
     pub fn connection(&self) -> redis::cluster::ClusterConnection {
         self.client.get_connection().unwrap()
     }
+
+    pub fn wait_for_cluster_up(&self) {
+        let mut con = self.connection();
+        let mut c = redis::cmd("CLUSTER");
+        c.arg("INFO");
+
+        for _ in 0..100 {
+            let r: String = c.query::<String>(&mut con).unwrap();
+            if r.starts_with("cluster_state:ok") {
+                return;
+            }
+
+            sleep(Duration::from_millis(25));
+        }
+
+        panic!("failed waiting for cluster to be ready");
+    }
 }


### PR DESCRIPTION
Adds a minimal benchmark for the basic operations against Redis Cluster. The benchmark harness will spin up a 6 node Cluster (3
primary, 3 secondary) in the way the test harness does.

Also includes fixes for:
* Makefile bench target (removes unknown "--test-threads=1" flag)
* Fixes compiler warning about unnecessary "mut" in bench_basic.rs