### PR TITLE
Fix #436: Read remaining responses in case of an error

### DIFF
--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -108,7 +108,7 @@ fn test_pipeline_transaction_with_errors() {
         let _: () = con.set("x", 42).await.unwrap();
 
         // Make Redis a replica of a nonexistent master, thereby making it read-only.
-        let _: () = redis::cmd("replicaof")
+        let _: () = redis::cmd("slaveof")
             .arg("1.1.1.1")
             .arg("1")
             .query_async(&mut con)

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -97,6 +97,44 @@ fn test_pipeline_transaction() {
     .unwrap();
 }
 
+#[test]
+fn test_pipeline_transaction_with_errors() {
+    use redis::RedisError;
+    let ctx = TestContext::new();
+
+    block_on_all(async move {
+        let mut con = ctx.async_connection().await?;
+
+        let _: () = con.set("x", 42).await.unwrap();
+
+        // Make Redis a replica of a nonexistent master, thereby making it read-only.
+        let _: () = redis::cmd("replicaof")
+            .arg("1.1.1.1")
+            .arg("1")
+            .query_async(&mut con)
+            .await
+            .unwrap();
+
+        // Ensure that a write command fails with a READONLY error
+        let err: RedisResult<()> = redis::pipe()
+            .atomic()
+            .set("x", 142)
+            .ignore()
+            .get("x")
+            .query_async(&mut con)
+            .await;
+
+        assert_eq!(err.unwrap_err().code(), Some("READONLY"));
+
+        let x: i32 = con.get("x").await.unwrap();
+        assert_eq!(x, 42);
+
+        Ok(())
+    })
+    .map_err(|err: RedisError| err)
+    .unwrap();
+}
+
 fn test_cmd(con: &MultiplexedConnection, i: i32) -> impl Future<Output = RedisResult<()>> + Send {
     let mut con = con.clone();
     async move {

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::let_unit_value)]
 
-use redis::{Commands, ConnectionInfo, ConnectionLike, ControlFlow, PubSubCommands};
+use redis::{Commands, ConnectionInfo, ConnectionLike, ControlFlow, PubSubCommands, RedisResult};
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::collections::{HashMap, HashSet};
@@ -299,6 +299,34 @@ fn test_pipeline_transaction() {
 
     assert_eq!(k1, 42);
     assert_eq!(k2, 43);
+}
+
+#[test]
+fn test_pipeline_transaction_with_errors() {
+    let ctx = TestContext::new();
+    let mut con = ctx.connection();
+
+    let _: () = con.set("x", 42).unwrap();
+
+    // Make Redis a replica of a nonexistent master, thereby making it read-only.
+    let _: () = redis::cmd("replicaof")
+        .arg("1.1.1.1")
+        .arg("1")
+        .query(&mut con)
+        .unwrap();
+
+    // Ensure that a write command fails with a READONLY error
+    let err: RedisResult<()> = redis::pipe()
+        .atomic()
+        .set("x", 142)
+        .ignore()
+        .get("x")
+        .query(&mut con);
+
+    assert_eq!(err.unwrap_err().code(), Some("READONLY"));
+
+    let x: i32 = con.get("x").unwrap();
+    assert_eq!(x, 42);
 }
 
 #[test]

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -309,7 +309,7 @@ fn test_pipeline_transaction_with_errors() {
     let _: () = con.set("x", 42).unwrap();
 
     // Make Redis a replica of a nonexistent master, thereby making it read-only.
-    let _: () = redis::cmd("replicaof")
+    let _: () = redis::cmd("slaveof")
         .arg("1.1.1.1")
         .arg("1")
         .query(&mut con)


### PR DESCRIPTION
When a `MULTI/EXEC` transaction fails due to errors, the remaining responses should be read instead of returning early. This fixes #436.