### PR TITLE
Support for requesting `Cmds` directly from a `Connection`

### DIFF
--- a/src/cluster_routing.rs
+++ b/src/cluster_routing.rs
@@ -1,4 +1,7 @@
-use super::{parse_redis_value, Value};
+use std::iter::Iterator;
+
+use crate::cmd::{Arg, Cmd};
+use crate::types::Value;
 
 pub(crate) const SLOT_SIZE: usize = 16384;
 
@@ -10,35 +13,12 @@ pub(crate) enum RoutingInfo {
     Slot(u16),
 }
 
-fn get_arg(values: &[Value], idx: usize) -> Option<&[u8]> {
-    match values.get(idx) {
-        Some(Value::Data(ref data)) => Some(&data[..]),
-        _ => None,
-    }
-}
-
-fn get_command_arg(values: &[Value], idx: usize) -> Option<Vec<u8>> {
-    get_arg(values, idx).map(|x| x.to_ascii_uppercase())
-}
-
-fn get_u64_arg(values: &[Value], idx: usize) -> Option<u64> {
-    get_arg(values, idx)
-        .and_then(|x| std::str::from_utf8(x).ok())
-        .and_then(|x| x.parse().ok())
-}
-
 impl RoutingInfo {
-    pub fn for_packed_command(cmd: &[u8]) -> Option<RoutingInfo> {
-        parse_redis_value(cmd).ok().and_then(RoutingInfo::for_value)
-    }
-
-    pub fn for_value(value: Value) -> Option<RoutingInfo> {
-        let args = match value {
-            Value::Bulk(args) => args,
-            _ => return None,
-        };
-
-        match &get_command_arg(&args, 0)?[..] {
+    pub(crate) fn for_routable<R>(r: &R) -> Option<RoutingInfo>
+    where
+        R: Routable + ?Sized,
+    {
+        match &r.command()?[..] {
             b"FLUSHALL" | b"FLUSHDB" | b"SCRIPT" => Some(RoutingInfo::AllMasters),
             b"ECHO" | b"CONFIG" | b"CLIENT" | b"SLOWLOG" | b"DBSIZE" | b"LASTSAVE" | b"PING"
             | b"INFO" | b"BGREWRITEAOF" | b"BGSAVE" | b"CLIENT LIST" | b"SAVE" | b"TIME"
@@ -46,22 +26,23 @@ impl RoutingInfo {
             b"SCAN" | b"CLIENT SETNAME" | b"SHUTDOWN" | b"SLAVEOF" | b"REPLICAOF"
             | b"SCRIPT KILL" | b"MOVE" | b"BITOP" => None,
             b"EVALSHA" | b"EVAL" => {
-                let key_count = get_u64_arg(&args, 2)?;
+                let key_count = r
+                    .arg_idx(2)
+                    .and_then(|x| std::str::from_utf8(x).ok())
+                    .and_then(|x| x.parse::<u64>().ok())?;
                 if key_count == 0 {
                     Some(RoutingInfo::Random)
                 } else {
-                    get_arg(&args, 3).and_then(RoutingInfo::for_key)
+                    r.arg_idx(3).and_then(RoutingInfo::for_key)
                 }
             }
-            b"XGROUP" | b"XINFO" => get_arg(&args, 2).and_then(RoutingInfo::for_key),
+            b"XGROUP" | b"XINFO" => r.arg_idx(2).and_then(RoutingInfo::for_key),
             b"XREAD" | b"XREADGROUP" => {
-                let streams_position = args.iter().position(|a| match a {
-                    Value::Data(a) => a.eq_ignore_ascii_case(b"STREAMS"),
-                    _ => false,
-                })?;
-                get_arg(&args, streams_position + 1).and_then(RoutingInfo::for_key)
+                let streams_position = r.position(b"STREAMS")?;
+                r.arg_idx(streams_position + 1)
+                    .and_then(RoutingInfo::for_key)
             }
-            _ => match get_arg(&args, 1) {
+            _ => match r.arg_idx(1) {
                 Some(key) => RoutingInfo::for_key(key),
                 None => Some(RoutingInfo::Random),
             },
@@ -76,6 +57,55 @@ impl RoutingInfo {
         Some(RoutingInfo::Slot(
             crc16::State::<crc16::XMODEM>::calculate(key) % SLOT_SIZE as u16,
         ))
+    }
+}
+
+pub(crate) trait Routable {
+    // Convenience function to return ascii uppercase version of the
+    // the first argument (i.e., the command).
+    fn command(&self) -> Option<Vec<u8>> {
+        self.arg_idx(0).map(|x| x.to_ascii_uppercase())
+    }
+
+    // Returns a reference to the data for the argument at `idx`.
+    fn arg_idx(&self, idx: usize) -> Option<&[u8]>;
+
+    // Returns index of argument that matches `candidate`, if it exists
+    fn position(&self, candidate: &[u8]) -> Option<usize>;
+}
+
+impl Routable for Cmd {
+    fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
+        self.arg_idx(idx)
+    }
+
+    fn position(&self, candidate: &[u8]) -> Option<usize> {
+        self.args_iter().position(|a| match a {
+            Arg::Simple(d) => d.eq_ignore_ascii_case(candidate),
+            _ => false,
+        })
+    }
+}
+
+impl Routable for Value {
+    fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
+        match self {
+            Value::Bulk(args) => match args.get(idx) {
+                Some(Value::Data(ref data)) => Some(&data[..]),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn position(&self, candidate: &[u8]) -> Option<usize> {
+        match self {
+            Value::Bulk(args) => args.iter().position(|a| match a {
+                Value::Data(d) => d.eq_ignore_ascii_case(candidate),
+                _ => false,
+            }),
+            _ => None,
+        }
     }
 }
 
@@ -139,7 +169,7 @@ fn get_hashtag(key: &[u8]) -> Option<&[u8]> {
 #[cfg(test)]
 mod tests {
     use super::{get_hashtag, RoutingInfo};
-    use crate::cmd;
+    use crate::{cmd, parser::parse_redis_value};
 
     #[test]
     fn test_get_hashtag() {
@@ -157,16 +187,69 @@ mod tests {
         lower.arg("streams").arg("foo").arg(0);
 
         assert_eq!(
-            RoutingInfo::for_packed_command(&upper.get_packed_command()).unwrap(),
-            RoutingInfo::for_packed_command(&lower.get_packed_command()).unwrap()
+            RoutingInfo::for_routable(&upper).unwrap(),
+            RoutingInfo::for_routable(&lower).unwrap()
         );
 
         let mut mixed = cmd("xReAd");
         mixed.arg("StReAmS").arg("foo").arg(0);
 
         assert_eq!(
-            RoutingInfo::for_packed_command(&lower.get_packed_command()).unwrap(),
-            RoutingInfo::for_packed_command(&mixed.get_packed_command()).unwrap()
+            RoutingInfo::for_routable(&lower).unwrap(),
+            RoutingInfo::for_routable(&mixed).unwrap()
         );
+    }
+
+    #[test]
+    fn test_routing_info() {
+        let mut test_cmds = vec![];
+
+        // RoutingInfo::AllMasters
+        let mut test_cmd = cmd("FLUSHALL");
+        test_cmd.arg("");
+        test_cmds.push(test_cmd);
+
+        // RoutingInfo::AllNodes
+        test_cmd = cmd("ECHO");
+        test_cmd.arg("");
+        test_cmds.push(test_cmd);
+
+        // Routing key is 2nd arg ("42")
+        test_cmd = cmd("SET");
+        test_cmd.arg("42");
+        test_cmds.push(test_cmd);
+
+        // Routing key is 3rd arg ("FOOBAR")
+        test_cmd = cmd("XINFO");
+        test_cmd.arg("GROUPS").arg("FOOBAR");
+        test_cmds.push(test_cmd);
+
+        // Routing key is 3rd or 4th arg (3rd = "0" == RoutingInfo::Random)
+        test_cmd = cmd("EVAL");
+        test_cmd.arg("FOO").arg("0").arg("BAR");
+        test_cmds.push(test_cmd);
+
+        // Routing key is 3rd or 4th arg (3rd != "0" == RoutingInfo::Slot)
+        test_cmd = cmd("EVAL");
+        test_cmd.arg("FOO").arg("4").arg("BAR");
+        test_cmds.push(test_cmd);
+
+        // Routing key position is variable, 3rd arg
+        test_cmd = cmd("XREAD");
+        test_cmd.arg("STREAMS").arg("4");
+        test_cmds.push(test_cmd);
+
+        // Routing key position is variable, 4th arg
+        test_cmd = cmd("XREAD");
+        test_cmd.arg("FOO").arg("STREAMS").arg("4");
+        test_cmds.push(test_cmd);
+
+        for cmd in test_cmds {
+            let value = parse_redis_value(&cmd.get_packed_command()).unwrap();
+            assert_eq!(
+                RoutingInfo::for_routable(&value).unwrap(),
+                RoutingInfo::for_routable(&cmd).unwrap(),
+            );
+        }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::str::{from_utf8, FromStr};
 use std::time::Duration;
 
-use crate::cmd::{cmd, pipe};
+use crate::cmd::{cmd, pipe, Cmd};
 use crate::parser::Parser;
 use crate::pipeline::Pipeline;
 use crate::types::{
@@ -615,6 +615,12 @@ pub trait ConnectionLike {
         offset: usize,
         count: usize,
     ) -> RedisResult<Vec<Value>>;
+
+    /// Sends a [Cmd](Cmd) into the TCP socket and reads a single response from it.
+    fn req_command(&mut self, cmd: &Cmd) -> RedisResult<Value> {
+        let pcmd = cmd.get_packed_command();
+        self.req_packed_command(&pcmd)
+    }
 
     /// Returns the database this connection is bound to.  Note that this
     /// information might be unreliable because it's initially cached and


### PR DESCRIPTION
Adds a new function to the `ConnectionLike` trait that accepts a reference to a `Cmd`. This allows different connections to handle the `Cmd` as necessary. For a single Redis instance, there is no difference, but for Redis Cluster it allows the `Cmd` to be routed without needing to first parse it back into a `Value`.

This results in a *slight* performance increase when issuing commands with a `ClusterConnection`, with the performance benefits becoming more prominent with more commands. With the upcoming work to add pipeline support with Redis Cluster (#307), I observed a 42% reduction in execution time when issuing a pipeline query with 100 elements.

For backwards compatability, a new trait `Routable` is introduced and the code that determines which node(s) should handle a
particular command is made generic over said trait.