### PR TITLE
Groundwork for pipelining with Redis Cluster

### DIFF
--- a/benches/bench_cluster.rs
+++ b/benches/bench_cluster.rs
@@ -1,35 +1,72 @@
 #![cfg(feature = "cluster")]
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use redis::cluster::cluster_pipe;
 
 use support::*;
 
 #[path = "../tests/support/mod.rs"]
 mod support;
 
-fn bench_set_get_and_del(c: &mut Criterion) {
-    let cluster = TestClusterContext::new(6, 1);
-    cluster.wait_for_cluster_up();
-    let mut con = cluster.connection();
+const PIPELINE_QUERIES: usize = 100;
+
+fn bench_set_get_and_del(c: &mut Criterion, con: &mut redis::cluster::ClusterConnection) {
     let key = "test_key";
 
     let mut group = c.benchmark_group("cluster_basic");
 
     group.bench_function("set", |b| {
-        b.iter(|| black_box(redis::cmd("SET").arg(key).arg(42).execute(&mut con)))
+        b.iter(|| black_box(redis::cmd("SET").arg(key).arg(42).execute(con)))
     });
 
     group.bench_function("get", |b| {
-        b.iter(|| black_box(redis::cmd("GET").arg(key).query::<isize>(&mut con).unwrap()))
+        b.iter(|| black_box(redis::cmd("GET").arg(key).query::<isize>(con).unwrap()))
     });
 
     let mut set_and_del = || {
-        redis::cmd("SET").arg(key).arg(42).execute(&mut con);
-        redis::cmd("DEL").arg(key).execute(&mut con);
+        redis::cmd("SET").arg(key).arg(42).execute(con);
+        redis::cmd("DEL").arg(key).execute(con);
     };
     group.bench_function("set_and_del", |b| b.iter(|| black_box(set_and_del())));
 
     group.finish();
 }
 
-criterion_group!(cluster_bench, bench_set_get_and_del);
+fn bench_pipeline(c: &mut Criterion, con: &mut redis::cluster::ClusterConnection) {
+    let mut group = c.benchmark_group("cluster_pipeline");
+    group.throughput(Throughput::Elements(PIPELINE_QUERIES as u64));
+
+    let mut queries = Vec::new();
+    for i in 0..PIPELINE_QUERIES {
+        queries.push(format!("foo{}", i));
+    }
+
+    let build_pipeline = || {
+        let mut pipe = cluster_pipe();
+        for q in &queries {
+            pipe.set(q, "bar").ignore();
+        }
+    };
+    group.bench_function("build_pipeline", |b| b.iter(|| black_box(build_pipeline())));
+
+    let mut pipe = cluster_pipe();
+    for q in &queries {
+        pipe.set(q, "bar").ignore();
+    }
+    group.bench_function("query_pipeline", |b| {
+        b.iter(|| black_box(pipe.query::<()>(con).unwrap()))
+    });
+
+    group.finish();
+}
+
+fn bench_cluster_setup(c: &mut Criterion) {
+    let cluster = TestClusterContext::new(6, 1);
+    cluster.wait_for_cluster_up();
+
+    let mut con = cluster.connection();
+    bench_set_get_and_del(c, &mut con);
+    bench_pipeline(c, &mut con);
+}
+
+criterion_group!(cluster_bench, bench_cluster_setup);
 criterion_main!(cluster_bench);

--- a/src/cluster_pipeline.rs
+++ b/src/cluster_pipeline.rs
@@ -1,0 +1,155 @@
+use crate::cluster::ClusterConnection;
+use crate::cmd::{cmd, Cmd};
+use crate::types::{from_redis_value, ErrorKind, FromRedisValue, RedisResult, ToRedisArgs, Value};
+use std::collections::HashSet;
+
+pub(crate) const UNROUTABLE_ERROR: (ErrorKind, &str) = (
+    ErrorKind::ClientError,
+    "This command cannot be safely routed in cluster mode",
+);
+
+fn is_illegal_cmd(cmd: &str) -> bool {
+    matches!(
+        cmd,
+        "BGREWRITEAOF" | "BGSAVE" | "BITOP" | "BRPOPLPUSH" |
+        // All commands that start with "CLIENT"
+        "CLIENT" | "CLIENT GETNAME" | "CLIENT KILL" | "CLIENT LIST" | "CLIENT SETNAME" |
+        // All commands that start with "CONFIG"
+        "CONFIG" | "CONFIG GET" | "CONFIG RESETSTAT" | "CONFIG REWRITE" | "CONFIG SET" |
+        "DBSIZE" |
+        "ECHO" | "EVALSHA" |
+        "FLUSHALL" | "FLUSHDB" |
+        "INFO" |
+        "KEYS" |
+        "LASTSAVE" |
+        "MGET" | "MOVE" | "MSET" | "MSETNX" |
+        "PFMERGE" | "PFCOUNT" | "PING" | "PUBLISH" |
+        "RANDOMKEY" | "RENAME" | "RENAMENX" | "RPOPLPUSH" |
+        "SAVE" | "SCAN" |
+        // All commands that start with "SCRIPT"
+        "SCRIPT" | "SCRIPT EXISTS" | "SCRIPT FLUSH" | "SCRIPT KILL" | "SCRIPT LOAD" |
+        "SDIFF" | "SDIFFSTORE" |
+        // All commands that start with "SENTINEL"
+        "SENTINEL" | "SENTINEL GET MASTER ADDR BY NAME" | "SENTINEL MASTER" | "SENTINEL MASTERS" |
+        "SENTINEL MONITOR" | "SENTINEL REMOVE" | "SENTINEL SENTINELS" | "SENTINEL SET" |
+        "SENTINEL SLAVES" | "SHUTDOWN" | "SINTER" | "SINTERSTORE" | "SLAVEOF" |
+        // All commands that start with "SLOWLOG"
+        "SLOWLOG" | "SLOWLOG GET" | "SLOWLOG LEN" | "SLOWLOG RESET" |
+        "SMOVE" | "SORT" | "SUNION" | "SUNIONSTORE" |
+        "TIME"
+    )
+}
+
+/// Represents a Redis Cluster command pipeline.
+#[derive(Clone)]
+pub struct ClusterPipeline {
+    commands: Vec<Cmd>,
+    ignored_commands: HashSet<usize>,
+}
+
+/// A cluster pipeline is almost identical to a normal [Pipeline](Pipeline), with two exceptions:
+/// * It does not support transactions
+/// * The following commands can not be used in a cluster pipeline:
+/// ```text
+/// BGREWRITEAOF, BGSAVE, BITOP, BRPOPLPUSH
+/// CLIENT GETNAME, CLIENT KILL, CLIENT LIST, CLIENT SETNAME, CONFIG GET,
+/// CONFIG RESETSTAT, CONFIG REWRITE, CONFIG SET
+/// DBSIZE
+/// ECHO, EVALSHA
+/// FLUSHALL, FLUSHDB
+/// INFO
+/// KEYS
+/// LASTSAVE
+/// MGET, MOVE, MSET, MSETNX
+/// PFMERGE, PFCOUNT, PING, PUBLISH
+/// RANDOMKEY, RENAME, RENAMENX, RPOPLPUSH
+/// SAVE, SCAN, SCRIPT EXISTS, SCRIPT FLUSH, SCRIPT KILL, SCRIPT LOAD, SDIFF, SDIFFSTORE,
+/// SENTINEL GET MASTER ADDR BY NAME, SENTINEL MASTER, SENTINEL MASTERS, SENTINEL MONITOR,
+/// SENTINEL REMOVE, SENTINEL SENTINELS, SENTINEL SET, SENTINEL SLAVES, SHUTDOWN, SINTER,
+/// SINTERSTORE, SLAVEOF, SLOWLOG GET, SLOWLOG LEN, SLOWLOG RESET, SMOVE, SORT, SUNION, SUNIONSTORE
+/// TIME
+/// ```
+impl ClusterPipeline {
+    /// Create an empty pipeline.
+    pub fn new() -> ClusterPipeline {
+        Self::with_capacity(0)
+    }
+
+    /// Creates an empty pipeline with pre-allocated capacity.
+    pub fn with_capacity(capacity: usize) -> ClusterPipeline {
+        ClusterPipeline {
+            commands: Vec::with_capacity(capacity),
+            ignored_commands: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn commands(&self) -> &Vec<Cmd> {
+        &self.commands
+    }
+
+    /// Executes the pipeline and fetches the return values:
+    ///
+    /// ```rust,no_run
+    /// # let nodes = vec!["redis://127.0.0.1:6379/"];
+    /// # let client = redis::cluster::ClusterClient::open(nodes).unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    /// let mut pipe = redis::cluster::cluster_pipe();
+    /// let (k1, k2) : (i32, i32) = pipe
+    ///     .cmd("SET").arg("key_1").arg(42).ignore()
+    ///     .cmd("SET").arg("key_2").arg(43).ignore()
+    ///     .cmd("GET").arg("key_1")
+    ///     .cmd("GET").arg("key_2").query(&mut con).unwrap();
+    /// ```
+    #[inline]
+    pub fn query<T: FromRedisValue>(&self, con: &mut ClusterConnection) -> RedisResult<T> {
+        for cmd in &self.commands {
+            let cmd_name = std::str::from_utf8(cmd.arg_idx(0).unwrap_or(b""))
+                .unwrap_or("")
+                .trim()
+                .to_ascii_uppercase();
+
+            if is_illegal_cmd(&cmd_name) {
+                fail!((
+                    UNROUTABLE_ERROR.0,
+                    UNROUTABLE_ERROR.1,
+                    format!(
+                        "Command '{}' can't be executed in a cluster pipeline.",
+                        cmd_name
+                    )
+                ))
+            }
+        }
+
+        from_redis_value(
+            &(if self.commands.is_empty() {
+                Value::Bulk(vec![])
+            } else {
+                self.make_pipeline_results(con.execute_pipeline(self)?)
+            }),
+        )
+    }
+
+    /// This is a shortcut to `query()` that does not return a value and
+    /// will fail the task if the query of the pipeline fails.
+    ///
+    /// This is equivalent to a call to query like this:
+    ///
+    /// ```rust,no_run
+    /// # let nodes = vec!["redis://127.0.0.1:6379/"];
+    /// # let client = redis::cluster::ClusterClient::open(nodes).unwrap();
+    /// # let mut con = client.get_connection().unwrap();
+    /// let mut pipe = redis::cluster::cluster_pipe();
+    /// let _ : () = pipe.cmd("SET").arg("key_1").arg(42).ignore().query(&mut con).unwrap();
+    /// ```
+    #[inline]
+    pub fn execute(&self, con: &mut ClusterConnection) {
+        self.query::<()>(con).unwrap();
+    }
+}
+
+/// Shortcut for creating a new cluster pipeline.
+pub fn cluster_pipe() -> ClusterPipeline {
+    ClusterPipeline::new()
+}
+
+implement_pipeline_commands!(ClusterPipeline);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -5,6 +5,9 @@ use crate::connection::{Connection, ConnectionLike, Msg};
 use crate::pipeline::Pipeline;
 use crate::types::{FromRedisValue, NumericBehavior, RedisResult, ToRedisArgs, RedisWrite};
 
+#[cfg(feature = "cluster")]
+use crate::cluster_pipeline::ClusterPipeline;
+
 #[cfg(feature = "geospatial")]
 use crate::geo;
 
@@ -259,6 +262,23 @@ macro_rules! implement_commands {
         /// commands trait, this returns the pipeline rather than a result
         /// directly.  Other than that it works the same however.
         impl Pipeline {
+            $(
+                $(#[$attr])*
+                #[inline]
+                #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+                pub fn $name<$lifetime, $($tyargs: $ty),*>(
+                    &mut self $(, $argname: $argty)*
+                ) -> &mut Self {
+                    self.add_command(::std::mem::replace($body, Cmd::new()))
+                }
+            )*
+        }
+
+        // Implements common redis commands for cluster pipelines.  Unlike the regular
+        // commands trait, this returns the cluster pipeline rather than a result
+        // directly.  Other than that it works the same however.
+        #[cfg(feature = "cluster")]
+        impl ClusterPipeline {
             $(
                 $(#[$attr])*
                 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,7 @@ pub use crate::{
 };
 
 mod macros;
+mod pipeline;
 
 #[cfg(feature = "acl")]
 #[cfg_attr(docsrs, doc(cfg(feature = "acl")))]
@@ -424,6 +425,9 @@ pub mod cluster;
 mod cluster_client;
 
 #[cfg(feature = "cluster")]
+mod cluster_pipeline;
+
+#[cfg(feature = "cluster")]
 mod cluster_routing;
 
 #[cfg(feature = "r2d2")]
@@ -439,6 +443,5 @@ mod cmd;
 mod commands;
 mod connection;
 mod parser;
-mod pipeline;
 mod script;
 mod types;


### PR DESCRIPTION
Introduces a new pipeline type (`ClusterPipeline`) that allows pipelining commands to a Redis Cluster. The current implementation is **very basic and inefficient** - each command in the pipeline is serially and synchronously issued to the proper backing Redis node. However, it lays the groundwork to introduce efficient pipelining in #307.

A `ClusterPipeline` and `Pipeline` share most of the same functionality, so all common methods have been refactored into a macro to avoid code duplication. I opted to do this instead of using a trait to avoid making this a breaking change (otherwise any existing code using `Pipeline` would fail to compile until the new trait was brought into scope).