### PR TITLE
add support for converting binary data to bytes::Bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ tokio-comp = ["aio", "tokio", "tokio/net"]
 tokio-native-tls-comp = ["tls", "tokio-native-tls"]
 connection-manager = ["arc-swap", "futures", "aio"]
 streams = []
+bytes-comp = ["bytes"]
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ tokio-comp = ["aio", "tokio", "tokio/net"]
 tokio-native-tls-comp = ["tls", "tokio-native-tls"]
 connection-manager = ["arc-swap", "futures", "aio"]
 streams = []
-bytes-comp = ["bytes"]
 
 
 [dev-dependencies]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1242,7 +1242,7 @@ impl<T: FromRedisValue> FromRedisValue for Option<T> {
     }
 }
 
-#[cfg(feature = "bytes-comp")]
+#[cfg(feature = "bytes")]
 impl FromRedisValue for bytes::Bytes {
     fn from_redis_value(v: &Value) -> RedisResult<Self> {
         match v {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1242,6 +1242,16 @@ impl<T: FromRedisValue> FromRedisValue for Option<T> {
     }
 }
 
+#[cfg(feature = "bytes-comp")]
+impl FromRedisValue for bytes::Bytes {
+    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+        match v {
+            Value::Data(bytes_vec) => Ok(bytes::Bytes::copy_from_slice(bytes_vec.as_ref())),
+            _ => invalid_type_error!(v, "Not binary data"),
+        }
+    }
+}
+
 /// A shortcut function to invoke `FromRedisValue::from_redis_value`
 /// to make the API slightly nicer.
 pub fn from_redis_value<T: FromRedisValue>(v: &Value) -> RedisResult<T> {

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -163,7 +163,7 @@ fn test_bool() {
     assert_eq!(v, Ok(true));
 }
 
-#[cfg(feature = "bytes-comp")]
+#[cfg(feature = "bytes")]
 #[test]
 fn test_bytes() {
     use bytes::Bytes;

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -163,6 +163,35 @@ fn test_bool() {
     assert_eq!(v, Ok(true));
 }
 
+#[cfg(feature = "bytes-comp")]
+#[test]
+fn test_bytes() {
+    use bytes::Bytes;
+    use redis::{ErrorKind, FromRedisValue, RedisResult, Value};
+
+    let content: &[u8] = b"\x01\x02\x03\x04";
+    let content_vec: Vec<u8> = Vec::from(content);
+    let content_bytes = Bytes::from_static(content);
+
+    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Data(content_vec));
+    assert_eq!(v, Ok(content_bytes));
+
+    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Status("garbage".into()));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Okay);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Nil);
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Int(0));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+
+    let v: RedisResult<Bytes> = FromRedisValue::from_redis_value(&Value::Int(42));
+    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+}
+
 #[test]
 fn test_types_to_redis_args() {
     use redis::ToRedisArgs;


### PR DESCRIPTION
Add an implementation of `FromRedisValue` for converting `Value::Data` to `bytes::Bytes`. This is behind a `bytes-comp` feature.