### PR TITLE
Replace deprecated crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ criterion = "0.3"
 partial-io = { version = "0.3", features = ["tokio", "quickcheck"] }
 quickcheck = "0.6"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
-tempdir = "0.3"
+tempfile = "3.2"
 
 [[test]]
 name = "test_async"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ streams = []
 
 [dev-dependencies]
 rand = "0.8"
-net2 = "0.2"
+socket2 = "0.3"
 assert_approx_eq = "1.0"
 fnv = "1.0.5"
 futures = "0.3"

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -50,7 +50,7 @@ enum ServerType {
 pub struct RedisServer {
     pub process: process::Child,
     stunnel_process: Option<process::Child>,
-    tempdir: Option<tempdir::TempDir>,
+    tempdir: Option<tempfile::TempDir>,
     addr: redis::ConnectionAddr,
 }
 
@@ -114,7 +114,10 @@ impl RedisServer {
         redis_cmd
             .stdout(process::Stdio::null())
             .stderr(process::Stdio::null());
-        let tempdir = tempdir::TempDir::new("redis").expect("failed to create tempdir");
+        let tempdir = tempfile::Builder::new()
+            .prefix("redis")
+            .tempdir()
+            .expect("failed to create tempdir");
         match addr {
             redis::ConnectionAddr::Tcp(ref bind, server_port) => {
                 redis_cmd


### PR DESCRIPTION
Resolve these two RustSec advisories:

- [RUSTSEC-2018-0017](https://rustsec.org/advisories/RUSTSEC-2018-0017.html)
- [RUSTSEC-2020-0016](https://rustsec.org/advisories/RUSTSEC-2020-0016.html)