### PR TITLE
docs: add "connection-manager" cfg attr to aio

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -1095,4 +1095,5 @@ mod connection_manager {
 }
 
 #[cfg(feature = "connection-manager")]
+#[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
 pub use connection_manager::ConnectionManager;


### PR DESCRIPTION
It's very unclear in the docs that this is not just enabled by the "aio" feature, but rather the "connection-manager" feature.