### PR TITLE
Add get_connection_info method to `Client` struct

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -57,6 +57,11 @@ impl Client {
     pub fn get_connection_with_timeout(&self, timeout: Duration) -> RedisResult<Connection> {
         Ok(connect(&self.connection_info, Some(timeout))?)
     }
+
+    /// Returns a clone of client connection info object.
+    pub fn get_connection_info(&self) -> ConnectionInfo {
+        self.connection_info.clone()
+    }
 }
 
 /// To enable async support you need to chose one of the supported runtimes and active its

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,9 +58,9 @@ impl Client {
         Ok(connect(&self.connection_info, Some(timeout))?)
     }
 
-    /// Returns a clone of client connection info object.
-    pub fn get_connection_info(&self) -> ConnectionInfo {
-        self.connection_info.clone()
+    /// Returns a reference of client connection info object.
+    pub fn get_connection_info(&self) -> &ConnectionInfo {
+        &self.connection_info
     }
 }
 


### PR DESCRIPTION
This allows consumers to peak into the `Client's` `connection_info` field. Here's an issue about the same: https://github.com/mitsuhiko/redis-rs/issues/480#issue-867822352

Fix: https://github.com/mitsuhiko/redis-rs/issues/480