### PR TITLE
refactor: Split up the connection and redis connection information

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -385,12 +385,12 @@ async fn authenticate<C>(connection_info: &RedisConnectionInfo, con: &mut C) -> 
 where
     C: ConnectionLike,
 {
-    if let Some(passwd) = &connection_info.passwd {
+    if let Some(password) = &connection_info.password {
         let mut command = cmd("AUTH");
         if let Some(username) = &connection_info.username {
             command.arg(username);
         }
-        match command.arg(passwd).query_async(con).await {
+        match command.arg(password).query_async(con).await {
             Ok(Value::Okay) => (),
             Err(e) => {
                 let err_msg = e.detail().ok_or((
@@ -406,7 +406,7 @@ where
                 }
 
                 let mut command = cmd("AUTH");
-                match command.arg(passwd).query_async(con).await {
+                match command.arg(password).query_async(con).await {
                     Ok(Value::Okay) => (),
                     _ => {
                         fail!((

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -279,7 +279,7 @@ where
     C: Unpin + AsyncRead + AsyncWrite + Send,
 {
     /// Constructs a new `Connection` out of a `AsyncRead + AsyncWrite` object
-    /// and a `ConnectionInfo`
+    /// and a `RedisConnectionInfo`
     pub async fn new(connection_info: &RedisConnectionInfo, con: C) -> RedisResult<Self> {
         let mut rv = Connection {
             con,
@@ -370,6 +370,19 @@ where
         // Finally, the connection is back in its normal state since all subscriptions were
         // cancelled *and* all unsubscribe messages were received.
         Ok(())
+    }
+}
+
+#[cfg(feature = "async-std-comp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-std-comp")))]
+impl<C> Connection<async_std::AsyncStdWrapped<C>>
+where
+    C: Unpin + ::async_std::io::Read + ::async_std::io::Write + Send,
+{
+    /// Constructs a new `Connection` out of a `async_std::io::AsyncRead + async_std::io::AsyncWrite` object
+    /// and a `RedisConnectionInfo`
+    pub async fn new_async_std(connection_info: &RedisConnectionInfo, con: C) -> RedisResult<Self> {
+        Connection::new(connection_info, async_std::AsyncStdWrapped::new(con)).await
     }
 }
 

--- a/src/aio/async_std.rs
+++ b/src/aio/async_std.rs
@@ -26,7 +26,7 @@ pin_project_lite::pin_project! {
 }
 
 impl<T> AsyncStdWrapped<T> {
-    fn new(inner: T) -> Self {
+    pub(super) fn new(inner: T) -> Self {
         Self { inner }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -85,7 +85,7 @@ impl Client {
             }
         };
 
-        crate::aio::Connection::new(&self.connection_info, con).await
+        crate::aio::Connection::new(&self.connection_info.redis, con).await
     }
 
     /// Returns an async connection from the client.
@@ -235,7 +235,7 @@ impl Client {
         T: crate::aio::RedisRuntime,
     {
         let con = self.get_simple_async_connection::<T>().await?;
-        crate::aio::MultiplexedConnection::new(&self.connection_info, con).await
+        crate::aio::MultiplexedConnection::new(&self.connection_info.redis, con).await
     }
 
     async fn get_simple_async_connection<T>(
@@ -274,7 +274,7 @@ impl ConnectionLike for Client {
     }
 
     fn get_db(&self) -> i64 {
-        self.connection_info.db
+        self.connection_info.redis.db
     }
 
     fn check_connection(&mut self) -> bool {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -652,7 +652,7 @@ where
     T: std::fmt::Debug,
 {
     let mut connection_info = info.into_connection_info()?;
-    connection_info.redis.passwd = password;
+    connection_info.redis.password = password;
     let client = super::Client::open(connection_info)?;
 
     let mut con = client.get_connection()?;

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -164,7 +164,7 @@ impl ClusterConnection {
         let mut connections = HashMap::with_capacity(initial_nodes.len());
 
         for info in initial_nodes.iter() {
-            let addr = match *info.addr {
+            let addr = match info.addr {
                 ConnectionAddr::Tcp(ref host, port) => format!("redis://{}:{}", host, port),
                 _ => panic!("No reach."),
             };
@@ -652,7 +652,7 @@ where
     T: std::fmt::Debug,
 {
     let mut connection_info = info.into_connection_info()?;
-    connection_info.passwd = password;
+    connection_info.redis.passwd = password;
     let client = super::Client::open(connection_info)?;
 
     let mut con = client.get_connection()?;

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -91,15 +91,15 @@ impl ClusterClient {
         let mut connection_info_password = None::<String>;
 
         for (index, info) in initial_nodes.into_iter().enumerate() {
-            if let ConnectionAddr::Unix(_) = *info.addr {
+            if let ConnectionAddr::Unix(_) = info.addr {
                 return Err(RedisError::from((ErrorKind::InvalidClientConfig,
                                              "This library cannot use unix socket because Redis's cluster command returns only cluster's IP and port.")));
             }
 
             if builder.password.is_none() {
                 if index == 0 {
-                    connection_info_password = info.passwd.clone();
-                } else if connection_info_password != info.passwd {
+                    connection_info_password = info.redis.passwd.clone();
+                } else if connection_info_password != info.redis.passwd {
                     return Err(RedisError::from((
                         ErrorKind::InvalidClientConfig,
                         "Cannot use different password among initial nodes.",

--- a/src/cluster_client.rs
+++ b/src/cluster_client.rs
@@ -98,8 +98,8 @@ impl ClusterClient {
 
             if builder.password.is_none() {
                 if index == 0 {
-                    connection_info_password = info.redis.passwd.clone();
-                } else if connection_info_password != info.redis.passwd {
+                    connection_info_password = info.redis.password.clone();
+                } else if connection_info_password != info.redis.password {
                     return Err(RedisError::from((
                         ErrorKind::InvalidClientConfig,
                         "Cannot use different password among initial nodes.",

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -107,7 +107,7 @@ pub struct RedisConnectionInfo {
     /// Optionally a username that should be used for connection.
     pub username: Option<String>,
     /// Optionally a password that should be used for connection.
-    pub passwd: Option<String>,
+    pub password: Option<String>,
 }
 
 impl FromStr for ConnectionInfo {
@@ -218,7 +218,7 @@ fn url_to_tcp_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
                     )),
                 }
             },
-            passwd: match url.password() {
+            password: match url.password() {
                 Some(pw) => match percent_encoding::percent_decode(pw.as_bytes()).decode_utf8() {
                     Ok(decoded) => Some(decoded.into_owned()),
                     Err(_) => fail!((
@@ -249,7 +249,7 @@ fn url_to_unix_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
                 None => 0,
             },
             username: query.get("user").map(|username| username.to_string()),
-            passwd: query.get("pass").map(|password| password.to_string()),
+            password: query.get("pass").map(|password| password.to_string()),
         },
     })
 }
@@ -536,8 +536,8 @@ fn connect_auth(con: &mut Connection, connection_info: &RedisConnectionInfo) -> 
     if let Some(username) = &connection_info.username {
         command.arg(username);
     }
-    let passwd = connection_info.passwd.as_ref().unwrap();
-    let err = match command.arg(passwd).query::<Value>(con) {
+    let password = connection_info.password.as_ref().unwrap();
+    let err = match command.arg(password).query::<Value>(con) {
         Ok(Value::Okay) => return Ok(()),
         Ok(_) => {
             fail!((
@@ -560,7 +560,7 @@ fn connect_auth(con: &mut Connection, connection_info: &RedisConnectionInfo) -> 
 
     // fallback to AUTH version <= 5
     let mut command = cmd("AUTH");
-    match command.arg(passwd).query::<Value>(con) {
+    match command.arg(password).query::<Value>(con) {
         Ok(Value::Okay) => Ok(()),
         _ => fail!((
             ErrorKind::AuthenticationFailed,
@@ -588,7 +588,7 @@ fn setup_connection(
         pubsub: false,
     };
 
-    if connection_info.passwd.is_some() {
+    if connection_info.password.is_some() {
         connect_auth(&mut rv, connection_info)?;
     }
 
@@ -1133,7 +1133,7 @@ mod tests {
                     addr: Box::new(ConnectionAddr::Tcp("127.0.0.1".to_string(), 6379)),
                     db: 0,
                     username: None,
-                    passwd: None,
+                    password: None,
                 },
             ),
             (
@@ -1142,7 +1142,7 @@ mod tests {
                     addr: Box::new(ConnectionAddr::Tcp("example.com".to_string(), 6379)),
                     db: 2,
                     username: Some("%johndoe%".to_string()),
-                    passwd: Some("#@<>$".to_string()),
+                    password: Some("#@<>$".to_string()),
                 },
             ),
         ];
@@ -1156,8 +1156,8 @@ mod tests {
                 url
             );
             assert_eq!(
-                res.passwd, expected.passwd,
-                "passwd of {} is not expected",
+                res.password, expected.password,
+                "password of {} is not expected",
                 url
             );
         }
@@ -1207,7 +1207,7 @@ mod tests {
                     addr: Box::new(ConnectionAddr::Unix("/var/run/redis.sock".into())),
                     db: 0,
                     username: None,
-                    passwd: None,
+                    password: None,
                 },
             ),
             (
@@ -1216,7 +1216,7 @@ mod tests {
                     addr: Box::new(ConnectionAddr::Unix("/var/run/redis.sock".into())),
                     db: 1,
                     username: None,
-                    passwd: None,
+                    password: None,
                 },
             ),
             (
@@ -1228,7 +1228,7 @@ mod tests {
                     addr: Box::new(ConnectionAddr::Unix("/example.sock".into())),
                     db: 2,
                     username: Some("%johndoe%".to_string()),
-                    passwd: Some("#@<>$".to_string()),
+                    password: Some("#@<>$".to_string()),
                 },
             ),
             (
@@ -1240,7 +1240,7 @@ mod tests {
                     addr: Box::new(ConnectionAddr::Unix("/example.sock".into())),
                     db: 2,
                     username: Some("%johndoe%".to_string()),
-                    passwd: Some("&?= *+".to_string()),
+                    password: Some("&?= *+".to_string()),
                 },
             ),
         ];
@@ -1260,8 +1260,8 @@ mod tests {
                 url
             );
             assert_eq!(
-                res.passwd, expected.passwd,
-                "passwd of {} is not expected",
+                res.password, expected.password,
+                "password of {} is not expected",
                 url
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! * URL objects from the redis-url crate.
 //! * `ConnectionInfo` objects.
 //!
-//! The URL format is `redis://[<username>][:<passwd>@]<hostname>[:port][/<db>]`
+//! The URL format is `redis://[<username>][:<password>@]<hostname>[:port][/<db>]`
 //!
 //! If Unix socket support is available you can use a unix URL in this format:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,7 +363,7 @@ pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{Commands, ControlFlow, LposOptions, PubSubCommands};
 pub use crate::connection::{
     parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
-    IntoConnectionInfo, Msg, PubSub,
+    IntoConnectionInfo, Msg, PubSub, RedisConnectionInfo,
 };
 pub use crate::parser::{parse_redis_value, Parser};
 pub use crate::pipeline::Pipeline;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -259,10 +259,8 @@ impl TestContext {
         let server = RedisServer::new();
 
         let client = redis::Client::open(redis::ConnectionInfo {
-            addr: Box::new(server.get_client_addr().clone()),
-            db: 0,
-            username: None,
-            passwd: None,
+            addr: server.get_client_addr().clone(),
+            redis: Default::default(),
         })
         .unwrap();
         let mut con;

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -430,7 +430,7 @@ async fn invalid_password_issue_343() {
         redis: redis::RedisConnectionInfo {
             db: 0,
             username: None,
-            passwd: Some("asdcasc".to_string()),
+            password: Some("asdcasc".to_string()),
         },
     };
     let client = redis::Client::open(coninfo).unwrap();

--- a/tests/test_async.rs
+++ b/tests/test_async.rs
@@ -426,10 +426,12 @@ async fn io_error_on_kill_issue_320() {
 async fn invalid_password_issue_343() {
     let ctx = TestContext::new();
     let coninfo = redis::ConnectionInfo {
-        addr: Box::new(ctx.server.get_client_addr().clone()),
-        db: 0,
-        username: None,
-        passwd: Some("asdcasc".to_string()),
+        addr: ctx.server.get_client_addr().clone(),
+        redis: redis::RedisConnectionInfo {
+            db: 0,
+            username: None,
+            passwd: Some("asdcasc".to_string()),
+        },
     };
     let client = redis::Client::open(coninfo).unwrap();
     let err = client


### PR DESCRIPTION
By doing this split we allow users to just pass an already established
connection plus a `RedisConnectionInfo` object to initialize a `Client`,
thus bypassing the need to construct a full `ConnectionInfo` object.

BREAKING CHANGE

The redis specific fields of `ConnectionInfo` has been moved under a
`redis` field.

Some signatures now only take `RedisConnectionInfo` instead of a full
`ConnectionInfo`