### PR TITLE
Impl futures_util::Stream for redis::cmd::AsyncIter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,10 @@ name = "async-pub-sub"
 required-features = ["aio"]
 
 [[example]]
+name = "async-scan"
+required-features = ["aio"]
+
+[[example]]
 name = "async-connection-loss"
 required-features = ["connection-manager"]
 

--- a/examples/async-scan.rs
+++ b/examples/async-scan.rs
@@ -1,0 +1,22 @@
+use futures::stream::StreamExt;
+use redis::{AsyncCommands, AsyncIter};
+
+#[tokio::main]
+async fn main() -> redis::RedisResult<()> {
+    let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+    let mut con = client.get_async_connection().await?;
+
+    con.set("async-key1", b"foo").await?;
+    con.set("async-key2", b"foo").await?;
+
+    let iter: AsyncIter<String> = con.scan().await?;
+    let mut keys: Vec<_> = iter.collect().await;
+
+    keys.sort();
+
+    assert_eq!(
+        keys,
+        vec!["async-key1".to_string(), "async-key2".to_string()]
+    );
+    Ok(())
+}


### PR DESCRIPTION
This allow user to use `futures_util::StreamExt`, so all the functions like map / collect / filter / etc becames availables for scans commands.

See [StreamExt API](https://docs.rs/futures-util/0.3.15/futures_util/stream/trait.StreamExt.html).