### PR TITLE
Fix clippy warn and errors

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -176,8 +176,7 @@ where
     ///
     /// The message itself is still generic and can be converted into an appropriate type through
     /// the helper methods on it.
-    #[allow(clippy::needless_lifetimes)]
-    pub fn on_message<'a>(&'a mut self) -> impl Stream<Item = Msg> + 'a {
+    pub fn on_message(&mut self) -> impl Stream<Item = Msg> + '_ {
         ValueCodec::default()
             .framed(&mut self.0.con)
             .into_stream()
@@ -220,8 +219,7 @@ where
     }
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection
-    #[allow(clippy::needless_lifetimes)]
-    pub fn on_message<'a, T: FromRedisValue>(&'a mut self) -> impl Stream<Item = T> + 'a {
+    pub fn on_message<T: FromRedisValue>(&mut self) -> impl Stream<Item = T> + '_ {
         ValueCodec::default()
             .framed(&mut self.0.con)
             .into_stream()

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -666,7 +666,7 @@ where
                         // Need to gather more response values
                         return;
                     }
-                    Ok(mem::replace(&mut entry.buffer, Vec::new()))
+                    Ok(mem::take(&mut entry.buffer))
                 }
                 // If we fail we must respond immediately
                 Err(err) => Err(err),

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -481,7 +481,7 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
 }
 
 fn get_socket_addrs(host: &str, port: u16) -> RedisResult<SocketAddr> {
-    let mut socket_addrs = (&host[..], port).to_socket_addrs()?;
+    let mut socket_addrs = (host, port).to_socket_addrs()?;
     match socket_addrs.next() {
         Some(socket_addr) => Ok(socket_addr),
         None => Err(RedisError::from((

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -176,6 +176,7 @@ where
     ///
     /// The message itself is still generic and can be converted into an appropriate type through
     /// the helper methods on it.
+    #[allow(clippy::needless_lifetimes)]
     pub fn on_message<'a>(&'a mut self) -> impl Stream<Item = Msg> + 'a {
         ValueCodec::default()
             .framed(&mut self.0.con)
@@ -219,6 +220,7 @@ where
     }
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection
+    #[allow(clippy::needless_lifetimes)]
     pub fn on_message<'a, T: FromRedisValue>(&'a mut self) -> impl Stream<Item = T> + 'a {
         ValueCodec::default()
             .framed(&mut self.0.con)

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,7 +46,7 @@ impl Client {
     /// (like unreachable host) so it's important that you handle those
     /// errors.
     pub fn get_connection(&self) -> RedisResult<Connection> {
-        Ok(connect(&self.connection_info, None)?)
+        connect(&self.connection_info, None)
     }
 
     /// Instructs the client to actually connect to redis with specified
@@ -55,7 +55,7 @@ impl Client {
     /// a variety of errors (like unreachable host) so it's important
     /// that you handle those errors.
     pub fn get_connection_with_timeout(&self, timeout: Duration) -> RedisResult<Connection> {
-        Ok(connect(&self.connection_info, Some(timeout))?)
+        connect(&self.connection_info, Some(timeout))
     }
 
     /// Returns a reference of client connection info object.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -23,13 +23,13 @@ static DEFAULT_PORT: u16 = 6379;
 /// This function takes a redis URL string and parses it into a URL
 /// as used by rust-url.  This is necessary as the default parser does
 /// not understand how redis URLs function.
-pub fn parse_redis_url(input: &str) -> Result<url::Url, ()> {
+pub fn parse_redis_url(input: &str) -> Option<url::Url> {
     match url::Url::parse(input) {
         Ok(result) => match result.scheme() {
-            "redis" | "rediss" | "redis+unix" | "unix" => Ok(result),
-            _ => Err(()),
+            "redis" | "rediss" | "redis+unix" | "unix" => Some(result),
+            _ => None,
         },
-        Err(_) => Err(()),
+        Err(_) => None,
     }
 }
 
@@ -127,8 +127,8 @@ impl IntoConnectionInfo for ConnectionInfo {
 impl<'a> IntoConnectionInfo for &'a str {
     fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
         match parse_redis_url(self) {
-            Ok(u) => u.into_connection_info(),
-            Err(_) => fail!((ErrorKind::InvalidClientConfig, "Redis URL did not parse")),
+            Some(u) => u.into_connection_info(),
+            None => fail!((ErrorKind::InvalidClientConfig, "Redis URL did not parse")),
         }
     }
 }
@@ -150,8 +150,8 @@ where
 impl IntoConnectionInfo for String {
     fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
         match parse_redis_url(&self) {
-            Ok(u) => u.into_connection_info(),
-            Err(_) => fail!((ErrorKind::InvalidClientConfig, "Redis URL did not parse")),
+            Some(u) => u.into_connection_info(),
+            None => fail!((ErrorKind::InvalidClientConfig, "Redis URL did not parse")),
         }
     }
 }
@@ -1099,7 +1099,7 @@ mod tests {
         for (url, expected) in cases.into_iter() {
             let res = parse_redis_url(&url);
             assert_eq!(
-                res.is_ok(),
+                res.is_some(),
                 expected,
                 "Parsed result of `{}` is not expected",
                 url,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -892,22 +892,22 @@ impl<'a> PubSub<'a> {
 
     /// Subscribes to a new channel.
     pub fn subscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        Ok(cmd("SUBSCRIBE").arg(channel).query(self.con)?)
+        cmd("SUBSCRIBE").arg(channel).query(self.con)
     }
 
     /// Subscribes to a new channel with a pattern.
     pub fn psubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        Ok(cmd("PSUBSCRIBE").arg(pchannel).query(self.con)?)
+        cmd("PSUBSCRIBE").arg(pchannel).query(self.con)
     }
 
     /// Unsubscribes from a channel.
     pub fn unsubscribe<T: ToRedisArgs>(&mut self, channel: T) -> RedisResult<()> {
-        Ok(cmd("UNSUBSCRIBE").arg(channel).query(self.con)?)
+        cmd("UNSUBSCRIBE").arg(channel).query(self.con)
     }
 
     /// Unsubscribes from a channel with a pattern.
     pub fn punsubscribe<T: ToRedisArgs>(&mut self, pchannel: T) -> RedisResult<()> {
-        Ok(cmd("PUNSUBSCRIBE").arg(pchannel).query(self.con)?)
+        cmd("PUNSUBSCRIBE").arg(pchannel).query(self.con)
     }
 
     /// Fetches the next message from the pubsub connection.  Blocks until

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -542,16 +542,15 @@ impl FromRedisValue for StreamPendingReply {
             result.start_id = start_id;
             result.end_id = end_id;
 
-            for cd in consumer_data {
-                if let Some((name, pending)) = cd {
-                    let mut info = StreamInfoConsumer::default();
-                    info.name = name;
-                    if let Ok(v) = pending.parse::<usize>() {
-                        info.pending = v;
-                    }
-                    result.consumers.push(info);
-                }
-            }
+            result.consumers = consumer_data
+                .into_iter()
+                .flatten()
+                .map(|(name, pending)| StreamInfoConsumer {
+                    name,
+                    pending: pending.parse().unwrap_or_default(),
+                    ..Default::default()
+                })
+                .collect();
 
             Ok(StreamPendingReply::Data(result))
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -420,6 +420,7 @@ impl RedisError {
     pub fn is_connection_refusal(&self) -> bool {
         match self.repr {
             ErrorRepr::IoError(ref err) => {
+                #[allow(clippy::match_like_matches_macro)]
                 match err.kind() {
                     io::ErrorKind::ConnectionRefused => true,
                     // if we connect to a unix socket and the file does not

--- a/tests/test_acl.rs
+++ b/tests/test_acl.rs
@@ -120,10 +120,7 @@ fn test_acl_cat() {
         "scripting",
     ];
     for cat in expects.iter() {
-        assert!(
-            res.contains(*cat),
-            format!("Category `{}` does not exist", cat)
-        );
+        assert!(res.contains(*cat), "Category `{}` does not exist", cat);
     }
 
     let expects = vec!["pfmerge", "pfcount", "pfselftest", "pfadd"];
@@ -131,10 +128,7 @@ fn test_acl_cat() {
         .acl_cat_categoryname("hyperloglog")
         .expect("Got commands of a category");
     for cmd in expects.iter() {
-        assert!(
-            res.contains(*cmd),
-            format!("Command `{}` does not exist", cmd)
-        );
+        assert!(res.contains(*cmd), "Command `{}` does not exist", cmd);
     }
 }
 

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -18,7 +18,7 @@ fn test_parse_redis_url() {
     let redis_url = "redis://127.0.0.1:1234/0".to_string();
     redis::parse_redis_url(&redis_url).unwrap();
     redis::parse_redis_url("unix:/var/run/redis/redis.sock").unwrap();
-    assert!(redis::parse_redis_url("127.0.0.1").is_err());
+    assert!(redis::parse_redis_url("127.0.0.1").is_none());
 }
 
 #[test]

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -784,8 +784,8 @@ fn test_nice_hash_api() {
     }
 
     assert_eq!(found.len(), 2);
-    assert_eq!(found.contains(&("f3".to_string(), 4)), true);
-    assert_eq!(found.contains(&("f4".to_string(), 8)), true);
+    assert!(found.contains(&("f3".to_string(), 4)));
+    assert!(found.contains(&("f4".to_string(), 8)));
 }
 
 #[test]
@@ -845,9 +845,9 @@ fn test_redis_server_down() {
 
     let ping = redis::cmd("PING").query::<String>(&mut con);
 
-    assert_eq!(ping.is_err(), true);
+    assert!(ping.is_err());
     eprintln!("{}", ping.unwrap_err());
-    assert_eq!(con.is_open(), false);
+    assert!(!con.is_open());
 }
 
 #[test]

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -134,7 +134,7 @@ fn test_set_ops() {
     redis::cmd("SADD").arg("foo").arg(3).execute(&mut con);
 
     let mut s: Vec<i32> = redis::cmd("SMEMBERS").arg("foo").query(&mut con).unwrap();
-    s.sort();
+    s.sort_unstable();
     assert_eq!(s.len(), 3);
     assert_eq!(&s, &[1, 2, 3]);
 
@@ -165,7 +165,7 @@ fn test_scan() {
         .arg(0)
         .query(&mut con)
         .unwrap();
-    s.sort();
+    s.sort_unstable();
     assert_eq!(cur, 0i32);
     assert_eq!(s.len(), 3);
     assert_eq!(&s, &[1, 2, 3]);

--- a/tests/test_streams.rs
+++ b/tests/test_streams.rs
@@ -146,9 +146,9 @@ fn test_assorted_1() {
     let _: RedisResult<String> = con.xadd_map("k3", "3000-0", map);
 
     let reply: StreamRangeReply = con.xrange_all("k3").unwrap();
-    assert_eq!(reply.ids[0].contains_key(&"ab"), true);
-    assert_eq!(reply.ids[0].contains_key(&"ef"), true);
-    assert_eq!(reply.ids[0].contains_key(&"ij"), true);
+    assert!(reply.ids[0].contains_key(&"ab"));
+    assert!(reply.ids[0].contains_key(&"ef"));
+    assert!(reply.ids[0].contains_key(&"ij"));
 
     // test xadd w/ maxlength below...
 
@@ -181,7 +181,7 @@ fn test_xgroup_create() {
 
     // no key exists... this call breaks the connection pipe for some reason
     let reply: RedisResult<StreamInfoStreamReply> = con.xinfo_stream("k10");
-    assert_eq!(reply.is_err(), true);
+    assert!(reply.is_err());
 
     // redo the connection because the above error
     con = ctx.connection();
@@ -194,11 +194,11 @@ fn test_xgroup_create() {
 
     // xgroup create (existing stream)
     let result: RedisResult<String> = con.xgroup_create("k1", "g1", "$");
-    assert_eq!(result.is_ok(), true);
+    assert!(result.is_ok());
 
     // xinfo groups (existing stream)
     let result: RedisResult<StreamInfoGroupsReply> = con.xinfo_groups("k1");
-    assert_eq!(result.is_ok(), true);
+    assert!(result.is_ok());
     let reply = result.unwrap();
     assert_eq!(&reply.groups.len(), &1);
     assert_eq!(&reply.groups[0].name, &"g1");
@@ -225,12 +225,12 @@ fn test_assorted_2() {
 
     // test xgroup create w/ mkstream @ 0
     let result: RedisResult<String> = con.xgroup_create_mkstream("k99", "g99", "0");
-    assert_eq!(result.is_ok(), true);
+    assert!(result.is_ok());
 
     // Since nothing exists on this stream yet,
     // it should have the defaults returned by the client
     let result: RedisResult<StreamInfoGroupsReply> = con.xinfo_groups("k99");
-    assert_eq!(result.is_ok(), true);
+    assert!(result.is_ok());
     let reply = result.unwrap();
     assert_eq!(&reply.groups.len(), &1);
     assert_eq!(&reply.groups[0].name, &"g99");
@@ -379,7 +379,7 @@ fn test_xclaim() {
 
     // create the group
     let result: RedisResult<String> = con.xgroup_create_mkstream("k1", "g1", "$");
-    assert_eq!(result.is_ok(), true);
+    assert!(result.is_ok());
 
     // add some keys
     xadd_keyrange(&mut con, "k1", 0, 10);
@@ -517,7 +517,7 @@ fn test_xgroup() {
 
     // test xgroup create w/ mkstream @ 0
     let result: RedisResult<String> = con.xgroup_create_mkstream("k1", "g1", "0");
-    assert_eq!(result.is_ok(), true);
+    assert!(result.is_ok());
 
     // destroy this new stream group
     let result: RedisResult<i32> = con.xgroup_destroy("k1", "g1");
@@ -528,7 +528,7 @@ fn test_xgroup() {
 
     // create the group again using an existing stream
     let result: RedisResult<String> = con.xgroup_create("k1", "g1", "0");
-    assert_eq!(result.is_ok(), true);
+    assert!(result.is_ok());
 
     // read from the group so we can register the consumer
     let reply: StreamReadReply = con

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -9,13 +9,14 @@ fn test_is_single_arg() {
     let twobytesslice: &[_] = &[bytes, bytes][..];
     let twobytesvec = vec![bytes, bytes];
 
-    assert_eq!("foo".is_single_arg(), true);
-    assert_eq!(sslice.is_single_arg(), true);
-    assert_eq!(nestslice.is_single_arg(), true);
-    assert_eq!(nestvec.is_single_arg(), true);
-    assert_eq!(bytes.is_single_arg(), true);
-    assert_eq!(twobytesslice.is_single_arg(), false);
-    assert_eq!(twobytesvec.is_single_arg(), false);
+    assert!("foo".is_single_arg());
+    assert!(sslice.is_single_arg());
+    assert!(nestslice.is_single_arg());
+    assert!(nestvec.is_single_arg());
+    assert!(bytes.is_single_arg());
+
+    assert!(!twobytesslice.is_single_arg());
+    assert!(!twobytesvec.is_single_arg());
 }
 
 #[test]


### PR DESCRIPTION
Apply clippy hints.

__Breaking change__: update return type for `parse_redis_url` from `Result<url::Url, ()>` to `Option<url::Url>`.
Previous error value (which was an empty tuple) has very little meaning.
So as clippy says `Option` is probably a better choice.

__Other changes__:

- Avoid  calling `Ok(...?)`
- Use `mem::take` instead of `mem::replace`
- Disable some clippy warns where clippy may be wrong
- Use `Iterator::flatten`
- Use `sort_unsable` for primitive types
- Use `assert!` macro where value has no real meaning

__Note__: benchmark API still use legacy API. So `make lint` will continue complaining.
I can provide update in a dedicated MR or update this one. It is up to repository maintainer.