### PR TITLE
Add wildcard aio::ConnectionLike implementation for pointer types

### DIFF
--- a/src/aio.rs
+++ b/src/aio.rs
@@ -586,6 +586,31 @@ where
     }
 }
 
+impl<T> ConnectionLike for T
+where
+    T: AsRef<dyn ConnectionLike + Send + Sync> + AsMut<dyn ConnectionLike + Send + Sync>,
+{
+    fn req_packed_command<'a>(
+        &'a mut self,
+        cmd: &'a crate::Cmd,
+    ) -> crate::RedisFuture<'a, crate::Value> {
+        self.as_mut().req_packed_command(cmd)
+    }
+
+    fn req_packed_commands<'a>(
+        &'a mut self,
+        cmd: &'a crate::Pipeline,
+        offset: usize,
+        count: usize,
+    ) -> crate::RedisFuture<'a, Vec<crate::Value>> {
+        self.as_mut().req_packed_commands(cmd, offset, count)
+    }
+
+    fn get_db(&self) -> i64 {
+        self.as_ref().get_db()
+    }
+}
+
 // Senders which the result of a single request are sent through
 type PipelineOutput<O, E> = oneshot::Sender<Result<Vec<O>, E>>;
 


### PR DESCRIPTION
Currently, it is not possible to use types like `Box<dyn aio::ConnectionLike>` or `Arc<dyn ...>` (pointer types in general) with the connections provided by this crate.

In my scenario, I've been building a factory that provides connections appropriate for the context (e.g. a multiplexed instance, or a blocked one from a connection pool). However, as I implemented my own wrappers around the `ConnectionLike` implementations to handle some error cases, it makes sense to use pointer types and just pass the "consumer" of the factory whatever I want or need in that case.

While one *could* use generics all the way for this, it becomes quite cumbersome if not impossible when having a function in a trait that returns either a multiplexed or an owned connection. 

Correct me if I'm overlooking anything obvious, but I feel like this would be a neat little QoL addition (esp. since Rust disallows one to implement traits for objects from other crates and `Box<dyn ConnectionLike>` counts into that).

<img width="862" alt="image" src="https://user-images.githubusercontent.com/5037967/120907000-2ed70100-c65e-11eb-9d7d-c06b87d346f4.png">
