### PR TITLE
fix: Don't loop forever on shutdown of the multiplexed connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ url = "2.1"
 # We need this for script support
 sha1 = { version = ">= 0.2, < 0.7", optional = true }
 
-combine = { version = "4.5", default-features = false, features = ["std"] }
+combine = { version = "4.6", default-features = false, features = ["std"] }
 
 # Only needed for AIO
 bytes = { version = "1", optional = true }

--- a/src/aio.rs
+++ b/src/aio.rs
@@ -641,6 +641,10 @@ where
     // Read messages from the stream and send them back to the caller
     fn poll_read(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), ()>> {
         loop {
+            // No need to try reading a message if there is no message in flight
+            if self.in_flight.is_empty() {
+                return Poll::Ready(Ok(()));
+            }
             let item = match ready!(self.as_mut().project().sink_stream.poll_next(cx)) {
                 Some(Ok(item)) => Ok(item),
                 Some(Err(err)) => Err(err),


### PR DESCRIPTION
The async decoder would return unexpected end of input errors forever
instead of `None` to indicate that the stream was done. Since the
`MultiplexedConnection` would just drop these errors if there was no
in_flight requests, ending up in an infinite loop inside `poll_read` on
shutdown.

cc #488

