### PR TITLE
fix: Variable-length mget response

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -991,7 +991,9 @@ pub trait FromRedisValue: Sized {
 
     /// Convert bytes to a single element vector.
     fn from_byte_vec(_vec: &[u8]) -> Option<Vec<Self>> {
-        Self::from_redis_value(&Value::Data(_vec.into())).map(|rv| vec![rv]).ok()
+        Self::from_redis_value(&Value::Data(_vec.into()))
+            .map(|rv| vec![rv])
+            .ok()
     }
 }
 

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -74,6 +74,42 @@ fn test_vec() {
 }
 
 #[test]
+fn test_single_bool_vec() {
+    use redis::{FromRedisValue, Value};
+
+    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+
+    assert_eq!(v, Ok(vec![true]));
+}
+
+#[test]
+fn test_single_i32_vec() {
+    use redis::{FromRedisValue, Value};
+
+    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+
+    assert_eq!(v, Ok(vec![1i32]));
+}
+
+#[test]
+fn test_single_u32_vec() {
+    use redis::{FromRedisValue, Value};
+
+    let v = FromRedisValue::from_redis_value(&Value::Data("42".into()));
+
+    assert_eq!(v, Ok(vec![42u32]));
+}
+
+#[test]
+fn test_single_string_vec() {
+    use redis::{FromRedisValue, Value};
+
+    let v = FromRedisValue::from_redis_value(&Value::Data("1".into()));
+
+    assert_eq!(v, Ok(vec!["1".to_string()]));
+}
+
+#[test]
 fn test_tuple() {
     use redis::{FromRedisValue, Value};
 


### PR DESCRIPTION
## Summary

This PR fixes: #336.

I try to implement `FromRedisValue::from_byte_vec` which can convert `bytes` to a single element vector.
With this change, when user is using `let values: Vec<i32> = conn.get(keys)`, no matter how long the `keys` is, user should get the correct response.

This is my first contribution, please feel free to critique and thanks for your code review 😄 . 