### PR TITLE
fix: pin futures-util dependency to required version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ combine = { version = "4.6", default-features = false, features = ["std"] }
 
 # Only needed for AIO
 bytes = { version = "1", optional = true }
-futures-util = { version = "0.3.0", default-features = false, optional = true }
+futures-util = { version = "0.3.15", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", optional = true }
 tokio-util = { version = "0.6", optional = true }
 tokio = { version = "1", features = ["rt"], optional = true }


### PR DESCRIPTION
fixes #515:
> error[E0432]: unresolved import `futures_util::Stream`