### PR TITLE
"Null Bulk String" as None for Option<T>.

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1266,10 +1266,11 @@ impl FromRedisValue for InfoDict {
 
 impl<T: FromRedisValue> FromRedisValue for Option<T> {
     fn from_redis_value(v: &Value) -> RedisResult<Option<T>> {
-        if let Value::Nil = *v {
-            return Ok(None);
+        match v {
+            Value::Nil => Ok(None),
+            Value::Bulk(bulk) if bulk == &[Value::Nil] => Ok(None),
+            _ => Ok(Some(from_redis_value(v)?)),
         }
-        Ok(Some(from_redis_value(v)?))
     }
 }
 

--- a/tests/test_types.rs
+++ b/tests/test_types.rs
@@ -227,3 +227,18 @@ fn test_types_to_redis_args() {
         .to_redis_args()
         .is_empty());
 }
+
+#[test]
+fn test_optional_types() {
+    use redis::{FromRedisValue, Value};
+
+    let i: Result<Option<i32>, _> = FromRedisValue::from_redis_value(&Value::Int(42));
+    assert_eq!(i, Ok(Some(42i32)));
+
+    let i: Result<Option<i32>, _> = FromRedisValue::from_redis_value(&Value::Nil);
+    assert_eq!(i, Ok(None));
+
+    let i: Result<Option<i32>, _> =
+        FromRedisValue::from_redis_value(&Value::Bulk(vec![Value::Nil]));
+    assert_eq!(i, Ok(None));
+}


### PR DESCRIPTION
Hello. I've found out one inconvenient thing. I had custom type implemented `FromRedisValue`. But I couldn't properly deserialize it from result of `GET` query when key not found into `Option<MyCustomType>`. This happen because absence of key is returned as `bulk(nil)` and default `FromRedisValue for Option<T>` calls to underlying converter for `bulk(nil)`.
 
[According to documentation](https://redis.io/topics/protocol#bulk-string-reply) `bulk(nil)` (Null Bulk String) should be deserialized as `nil/None/NULL/nullptr`:

> This is called a Null Bulk String. The client library API should not return an empty string, but a nil object, when the server replies with a Null Bulk String. For example a Ruby library should return 'nil' while a C library should return NULL (or set a special flag in the reply object), and so forth.
