### PR TITLE
remove stunnel as a dep, use redis native tls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,6 @@ jobs:
       if: steps.cache-redis.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update
-        sudo apt-get install stunnel -y
         wget https://github.com/redis/redis/archive/${{ env.REDIS_VERSION }}.tar.gz;
         tar -xzvf ${{ env.REDIS_VERSION }}.tar.gz;
         pushd redis-${{ env.REDIS_VERSION }} && BUILD_TLS=yes make && sudo mv src/redis-server src/redis-cli /usr/bin/ && popd;


### PR DESCRIPTION
Fixes #532 

The `openssl` code is more involved, but it is a direct translation of the [gen-test-certs.sh](https://github.com/redis/redis/blob/8c291b97b95f2e011977b522acf77ead23e26f55/utils/gen-test-certs.sh) from the redis repo used for testing. I'm betting it could be stripped down a bit but I'm not great with `openssl` so I just used what they did.

When I put up my PR for cluster mode + TLS, I'll likely factor the `openssl` code out into a separate function that can be called from the `tests/support/cluster.rs` module, but for now I've left it all inline.

I've verified it works locally on my macos machine and on github actions. Happy to incorporate any feedback you may have, my next day I'll definitely be able to work on this is Oct 8, though I may have some time before then.