### PR TITLE
Fix for changes to Framed in tokio-util 0.6.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",


### PR DESCRIPTION
Fixes #558

ValueCodec puts Redis protocol errors in `Decoder::Err`, but the new Framed updates in tokio-util 0.6.9 now cause a (simulated) end-of-stream when a decoder error is encountered. This fix puts protocol errors in `Decoder::Item` instead, by wrapping the Value in an additional RedisResult. This makes `Decoder::Err` contain exclusively parse errors.

This does mean two nested RedisResults, but I believe none of this API is public, so it's only ugly on the inside. 🙃