### PR TITLE
Add new list commands

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -545,6 +545,44 @@ implement_commands! {
     }
 
     // list operations
+    
+    /// Pop an element from the front of a list, push it to the front of another list
+    /// and return it; or block until one is available
+    fn blmove_left_to_left<K: ToRedisArgs>(srckey: K, dstkey: K, timeout: usize) {
+        cmd("BLMOVE").arg(srckey).arg(dstkey).arg("LEFT").arg("LEFT").arg(timeout)
+    }
+
+    /// Pop an element from the front of a list, push it to the end of another list
+    /// and return it; or block until one is available
+    fn blmove_left_to_right<K: ToRedisArgs>(srckey: K, dstkey: K, timeout: usize) {
+        cmd("BLMOVE").arg(srckey).arg(dstkey).arg("LEFT").arg("RIGHT").arg(timeout)
+    }
+
+    /// Pop an element from the end of a list, push it to the front of another list
+    /// and return it; or block until one is available
+    fn blmove_right_to_left<K: ToRedisArgs>(srckey: K, dstkey: K, timeout: usize) {
+        cmd("BLMOVE").arg(srckey).arg(dstkey).arg("RIGHT").arg("LEFT").arg(timeout)
+    }
+
+    /// Pop an element from the end of a list, push it to the end of another list
+    /// and return it; or block until one is available
+    fn blmove_right_to_right<K: ToRedisArgs>(srckey: K, dstkey: K, timeout: usize) {
+        cmd("BLMOVE").arg(srckey).arg(dstkey).arg("RIGHT").arg("RIGHT").arg(timeout)
+    }
+
+    /// Pops `count` elements from the start of the first non-empty list key from the list of 
+    /// provided key names - defaults to 1 element if count not defined. Or blocks
+    /// until one is available.
+    fn blmpop_left<K: ToRedisArgs>(timeout: usize, numkeys: usize, key: K, count: Option<core::num::NonZeroUsize>) {
+        cmd("BLMPOP").arg(timeout).arg(numkeys).arg(key).arg("LEFT").arg("COUNT").arg(count)
+    }
+
+    /// Pops `count` elements from the end of the first non-empty list key from the list of 
+    /// provided key names - defaults to 1 element if count not defined. Or blocks
+    /// until one is available.
+    fn blmpop_right<K: ToRedisArgs>(timeout: usize, numkeys: usize, key: K, count: Option<core::num::NonZeroUsize>) {
+        cmd("BLMPOP").arg(timeout).arg(numkeys).arg(key).arg("RIGHT").arg("COUNT").arg(count)
+    }
 
     /// Remove and get the first element in a list, or block until one is available.
     fn blpop<K: ToRedisArgs>(key: K, timeout: usize) {
@@ -582,6 +620,42 @@ implement_commands! {
     /// Returns the length of the list stored at key.
     fn llen<K: ToRedisArgs>(key: K) {
         cmd("LLEN").arg(key)
+    }
+
+    /// Pop an element from the front of a list, push it to the front of another list
+    /// and return it
+    fn lmove_left_to_left<K: ToRedisArgs>(srckey: K, dstkey: K) {
+        cmd("LMOVE").arg(srckey).arg(dstkey).arg("LEFT").arg("LEFT")
+    }
+
+    /// Pop an element from the front of a list, push it to the end of another list
+    /// and return it
+    fn lmove_left_to_right<K: ToRedisArgs>(srckey: K, dstkey: K) {
+        cmd("LMOVE").arg(srckey).arg(dstkey).arg("LEFT").arg("RIGHT")
+    }
+
+    /// Pop an element from the end of a list, push it to the front of another list
+    /// and return it
+    fn lmove_right_to_left<K: ToRedisArgs>(srckey: K, dstkey: K) {
+        cmd("LMOVE").arg(srckey).arg(dstkey).arg("RIGHT").arg("LEFT")
+    }
+
+    /// Pop an element from the end of a list, push it to the end of another list
+    /// and return it
+    fn lmove_right_to_right<K: ToRedisArgs>(srckey: K, dstkey: K) {
+        cmd("LMOVE").arg(srckey).arg(dstkey).arg("RIGHT").arg("RIGHT")
+    }
+
+    /// Pops `count` elements from the start of the first non-empty list key from the list of 
+    /// provided key names - defaults to 1 element if count not defined
+    fn lmpop_left<K: ToRedisArgs>( numkeys: usize, key: K, count: Option<core::num::NonZeroUsize>) {
+        cmd("LMPOP").arg(numkeys).arg(key).arg("LEFT").arg("COUNT").arg(count)
+    }
+
+    /// Pops `count` elements from the end of the first non-empty list key from the list of 
+    /// provided key names - defaults to 1 element if count not defined
+    fn lmpop_right<K: ToRedisArgs>( numkeys: usize, key: K, count: Option<core::num::NonZeroUsize>) {
+        cmd("LMPOP").arg(numkeys).arg(key).arg("RIGHT").arg("COUNT").arg(count)
     }
 
     /// Removes and returns the up to `count` first elements of the list stored at key.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2175,7 +2175,7 @@ impl ToRedisArgs for Direction {
     where
         W: ?Sized + RedisWrite,
     {
-        let s = match self {
+        let s: &[u8] = match self {
             Direction::Left => b"LEFT",
             Direction::Right => b"RIGHT",
         };

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2175,13 +2175,10 @@ impl ToRedisArgs for Direction {
     where
         W: ?Sized + RedisWrite,
     {
-        match self {
-            Direction::Left => {
-                out.write_arg(b"LEFT")
-            },
-            Direction::Right => {
-                out.write_arg(b"RIGHT")
-            },
-        }
+        let s = match self {
+            Direction::Left => b"LEFT",
+            Direction::Right => b"RIGHT",
+        };
+        out.write_arg(s);
     }
 }


### PR DESCRIPTION
This PR aims to add the following new list commands:

From v6.2.0:

1. [BLMOVE](https://redis.io/commands/blmove)
2. [LMOVE](https://redis.io/commands/lmove)

From v7.0.0:

1. [BLMPOP](https://redis.io/commands/blmpop)
2. [LMPOP](https://redis.io/commands/lmpop)

As this is my first contribution please let me know if anything needs amending about the PR. Looking for guidance in some areas as I am unfamiliar with the code but will comment on the code in these areas.