### PR TITLE
Switch from sha1 to sha1_smol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
  "quickcheck",
  "r2d2",
  "rand 0.8.4",
- "sha1",
+ "sha1_smol",
  "socket2 0.3.19",
  "tempfile",
  "tokio",
@@ -1367,10 +1367,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
+name = "sha1_smol"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ percent-encoding = "2.1"
 url = "2.1"
 
 # We need this for script support
-sha1 = { version = ">= 0.2, < 0.7", optional = true }
+sha1_smol = { version = "1.0", optional = true }
 
 combine = { version = "4.6", default-features = false, features = ["std"] }
 
@@ -64,7 +64,7 @@ acl = []
 aio = ["bytes", "pin-project-lite", "futures-util", "futures-util/alloc", "futures-util/sink", "tokio/io-util", "tokio-util", "tokio-util/codec", "tokio/sync", "combine/tokio"]
 geospatial = []
 cluster = ["crc16", "rand"]
-script = ["sha1"]
+script = ["sha1_smol"]
 tls = ["native-tls"]
 async-std-comp = ["aio", "async-std"]
 async-std-tls-comp = ["async-std-comp", "async-native-tls", "tls"]

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "script")]
-use sha1::Sha1;
+use sha1_smol::Sha1;
 
 use crate::cmd::cmd;
 use crate::connection::ConnectionLike;


### PR DESCRIPTION
I renamed the `sha1` crate used here to `sha1_smol`. `sha1` now refers to a different and much heavier implementation.

See also https://github.com/mitsuhiko/sha1-smol/issues/42