### PR TITLE
Add support for fallible high-level transactions

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -246,7 +246,7 @@
 //! # Transactions
 //!
 //! Transactions are available through atomic pipelines.  In order to use
-//! them in a more simple way you can use the `transaction` function of a
+//! them in a more simple way you can use the [`transaction`] function on a
 //! connection:
 //!
 //! ```rust,no_run
@@ -254,6 +254,7 @@
 //! use redis::Commands;
 //! # let client = redis::Client::open("redis://127.0.0.1/").unwrap();
 //! # let mut con = client.get_connection().unwrap();
+//!
 //! let key = "the_key";
 //! let (new_val,) : (isize,) = redis::transaction(&mut con, &[key], |con, pipe| {
 //!     let old_val : isize = con.get(key)?;
@@ -265,7 +266,12 @@
 //! # Ok(()) }
 //! ```
 //!
-//! For more information see the `transaction` function.
+//! On conflict, the [`transaction`] function will retry the transaction until
+//! it succeeds. If instead you want to attempt the transaction only once, and
+//! get back a `None` result if a `WATCH`ed key is modified by another
+//! connection, use [`transaction_opt`].
+//!
+//! For more information see [`transaction`] and [`transaction_opt`].
 //!
 //! # PubSub
 //!
@@ -365,8 +371,8 @@ pub use crate::client::Client;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{Commands, ControlFlow, Direction, LposOptions, PubSubCommands};
 pub use crate::connection::{
-    parse_redis_url, transaction, Connection, ConnectionAddr, ConnectionInfo, ConnectionLike,
-    IntoConnectionInfo, Msg, PubSub, RedisConnectionInfo,
+    parse_redis_url, transaction, transaction_opt, Connection, ConnectionAddr, ConnectionInfo,
+    ConnectionLike, IntoConnectionInfo, Msg, PubSub, RedisConnectionInfo,
 };
 pub use crate::parser::{parse_redis_value, Parser};
 pub use crate::pipeline::Pipeline;


### PR DESCRIPTION
Add a new `transaction_opt` function. This function allows running a high-level transaction _without_ automatic retry. Instead, `None` is returned if the transaction fails due to a conflict of a WATCHed key.

Additionally, transaction tests were improved and extended (previously there was no test that ensured that `WATCH` and automatic retry of `transaction` works as intended).