### PR TITLE
Rework tls feature split to avoid unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,19 +85,27 @@ redis = { version = "0.25.3", features = ["async-std-native-tls-comp"] }
 To use `rustls`:
 
 ```
-redis = { version = "0.25.3", features = ["tls-rustls"] }
+redis = { version = "0.25.3", features = ["tls-rustls-native-certs"] }
+# or
+redis = { version = "0.25.3", features = ["tls-rustls-webpki-roots"] }
 
 # if you use tokio
-redis = { version = "0.25.3", features = ["tokio-rustls-comp"] }
+redis = { version = "0.25.3", features = ["tokio-rustls-native-certs-comp"] }
+# or
+redis = { version = "0.25.3", features = ["tokio-rustls-webpki-roots-comp"] }
 
 # if you use async-std
-redis = { version = "0.25.3", features = ["async-std-rustls-comp"] }
+redis = { version = "0.25.3", features = ["async-std-rustls-native-certs-comp"] }
+# or
+redis = { version = "0.25.3", features = ["async-std-rustls-webpki-roots-comp"] }
 ```
 
-With `rustls`, you can add the following feature flags on top of other feature flags to enable additional features:
+With `rustls`, you must choose between `native-certs` and `webpki-roots` variants of the tls features.
+The first ones rely on native root certificates (the one provided by your OS) while `webpki-roots` features use `webpki-roots` (Mozilla's root certificates) instead.
+
+With `rustls`, you can add the following feature flag on top of other feature flags to enable additional features:
 
 -   `tls-rustls-insecure`: Allow insecure TLS connections
--   `tls-rustls-webpki-roots`: Use `webpki-roots` (Mozilla's root certificates) instead of native root certificates
 
 then you should be able to connect to a redis instance using the `rediss://` URL scheme:
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -98,16 +98,6 @@ geospatial = []
 json = ["serde", "serde/derive", "serde_json"]
 cluster = ["crc16", "rand"]
 script = ["sha1_smol"]
-tls-native-tls = ["native-tls"]
-tls-rustls = ["rustls", "rustls-native-certs", "rustls-pemfile", "rustls-pki-types"]
-tls-rustls-insecure = ["tls-rustls"]
-tls-rustls-webpki-roots = ["tls-rustls", "webpki-roots"]
-async-std-comp = ["aio", "async-std"]
-async-std-native-tls-comp = ["async-std-comp", "async-native-tls", "tls-native-tls"]
-async-std-rustls-comp = ["async-std-comp", "futures-rustls", "tls-rustls"]
-tokio-comp = ["aio", "tokio/net"]
-tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
-tokio-rustls-comp = ["tokio-comp", "tls-rustls", "tokio-rustls"]
 connection-manager = ["futures", "aio", "tokio-retry"]
 streams = []
 cluster-async = ["cluster", "futures", "futures-util", "log"]
@@ -120,9 +110,39 @@ num-bigint = []
 uuid = ["dep:uuid"]
 disable-client-setinfo = []
 
+# tls related features
+# At most one should be needed
+tls-native-tls = ["native-tls"]
+tls-rustls-native-certs = ["tls-rustls-core", "rustls-native-certs"]
+tls-rustls-webpki-roots = ["tls-rustls-core", "webpki-roots"]
+
+# async-std related features
+# At most one should be needed
+async-std-comp = ["aio", "async-std"]
+async-std-native-tls-comp = ["async-std-comp", "async-native-tls", "tls-native-tls"]
+async-std-rustls-native-certs-comp = ["async-std-rustls-core", "tls-rustls-native-certs"]
+async-std-rustls-webpki-roots-comp = ["async-std-rustls-core", "tls-rustls-webpki-roots"]
+
+# tokio related features
+# At most one should be needed
+tokio-comp = ["aio", "tokio/net"]
+tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "tokio-native-tls"]
+tokio-rustls-native-certs-comp = ["tokio-rustls-core", "tls-rustls-native-certs"]
+tokio-rustls-webpki-roots-comp = ["tokio-rustls-core", "tls-rustls-webpki-roots"]
+
+# Can be combined with any other feature that enables rustls
+tls-rustls-insecure = ["tls-rustls-core"]
+# mostly meant for internal use
+tls-rustls-core = ["rustls", "rustls-pemfile", "rustls-pki-types"]
+async-std-rustls-core = ["tls-rustls-core", "async-std-comp", "futures-rustls"]
+tokio-rustls-core = ["tls-rustls-core", "tokio-comp", "tokio-rustls"]
+
 # Deprecated features
 tls = ["tls-native-tls"] # use "tls-native-tls" instead
 async-std-tls-comp = ["async-std-native-tls-comp"] # use "async-std-native-tls-comp" instead
+tls-rustls = ["tls-rustls-native-certs"] # use "tls-rustls-native-certs" instead
+async-std-rustls-comp = ["async-std-rustls-native-certs-comp"] # use "async-std-rustls-native-certs-comp" instead
+tokio-rustls-comp = ["tokio-rustls-native-certs-comp"] # use "tokio-rustls-native-certs-comp" instead
 
 [dev-dependencies]
 rand = "0.8"

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -1,6 +1,6 @@
 #[cfg(unix)]
 use std::path::Path;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use std::sync::Arc;
 use std::{
     future::Future,
@@ -13,12 +13,12 @@ use std::{
 use crate::aio::{AsyncStream, RedisRuntime};
 use crate::types::RedisResult;
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls-core")))]
 use async_native_tls::{TlsConnector, TlsStream};
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::connection::create_rustls_config;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use futures_rustls::{client::TlsStream, TlsConnector};
 
 use async_std::net::TcpStream;
@@ -49,10 +49,10 @@ async fn connect_tcp(addr: &SocketAddr) -> io::Result<TcpStream> {
         Ok(socket)
     }
 }
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::tls::TlsConnParams;
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls-core")))]
 use crate::connection::TlsConnParams;
 
 pin_project_lite::pin_project! {
@@ -120,7 +120,7 @@ pub enum AsyncStd {
     /// Represents an Async_std TLS encrypted TCP connection.
     #[cfg(any(
         feature = "async-std-native-tls-comp",
-        feature = "async-std-rustls-comp"
+        feature = "async-std-rustls-core"
     ))]
     TcpTls(AsyncStdWrapped<Box<TlsStream<TcpStream>>>),
     /// Represents an Async_std Unix connection.
@@ -138,7 +138,7 @@ impl AsyncWrite for AsyncStd {
             AsyncStd::Tcp(r) => Pin::new(r).poll_write(cx, buf),
             #[cfg(any(
                 feature = "async-std-native-tls-comp",
-                feature = "async-std-rustls-comp"
+                feature = "async-std-rustls-core"
             ))]
             AsyncStd::TcpTls(r) => Pin::new(r).poll_write(cx, buf),
             #[cfg(unix)]
@@ -151,7 +151,7 @@ impl AsyncWrite for AsyncStd {
             AsyncStd::Tcp(r) => Pin::new(r).poll_flush(cx),
             #[cfg(any(
                 feature = "async-std-native-tls-comp",
-                feature = "async-std-rustls-comp"
+                feature = "async-std-rustls-core"
             ))]
             AsyncStd::TcpTls(r) => Pin::new(r).poll_flush(cx),
             #[cfg(unix)]
@@ -164,7 +164,7 @@ impl AsyncWrite for AsyncStd {
             AsyncStd::Tcp(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(any(
                 feature = "async-std-native-tls-comp",
-                feature = "async-std-rustls-comp"
+                feature = "async-std-rustls-core"
             ))]
             AsyncStd::TcpTls(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(unix)]
@@ -183,7 +183,7 @@ impl AsyncRead for AsyncStd {
             AsyncStd::Tcp(r) => Pin::new(r).poll_read(cx, buf),
             #[cfg(any(
                 feature = "async-std-native-tls-comp",
-                feature = "async-std-rustls-comp"
+                feature = "async-std-rustls-core"
             ))]
             AsyncStd::TcpTls(r) => Pin::new(r).poll_read(cx, buf),
             #[cfg(unix)]
@@ -200,7 +200,7 @@ impl RedisRuntime for AsyncStd {
             .map(|con| Self::Tcp(AsyncStdWrapped::new(con)))?)
     }
 
-    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls-core")))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -222,7 +222,7 @@ impl RedisRuntime for AsyncStd {
             .map(|con| Self::TcpTls(AsyncStdWrapped::new(Box::new(con))))?)
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -259,7 +259,7 @@ impl RedisRuntime for AsyncStd {
             AsyncStd::Tcp(x) => Box::pin(x),
             #[cfg(any(
                 feature = "async-std-native-tls-comp",
-                feature = "async-std-rustls-comp"
+                feature = "async-std-rustls-core"
             ))]
             AsyncStd::TcpTls(x) => Box::pin(x),
             #[cfg(unix)]

--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -449,7 +449,7 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             select_ok(socket_addrs.map(<T>::connect_tcp)).await?.0
         }
 
-        #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
+        #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls-core"))]
         ConnectionAddr::TcpTls {
             ref host,
             port,
@@ -466,7 +466,7 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             .0
         }
 
-        #[cfg(not(any(feature = "tls-native-tls", feature = "tls-rustls")))]
+        #[cfg(not(any(feature = "tls-native-tls", feature = "tls-rustls-core")))]
         ConnectionAddr::TcpTls { .. } => {
             fail!((
                 ErrorKind::InvalidClientConfig,

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -16,10 +16,10 @@ use std::pin::Pin;
 #[cfg_attr(docsrs, doc(cfg(feature = "async-std-comp")))]
 pub mod async_std;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::tls::TlsConnParams;
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls-core")))]
 use crate::connection::TlsConnParams;
 
 /// Enables the tokio compatibility
@@ -34,7 +34,7 @@ pub(crate) trait RedisRuntime: AsyncStream + Send + Sync + Sized + 'static {
     async fn connect_tcp(socket_addr: SocketAddr) -> RedisResult<Self>;
 
     // Performs a TCP TLS connection
-    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
+    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls-core"))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -13,23 +13,23 @@ use tokio::{
     net::TcpStream as TcpStreamTokio,
 };
 
-#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+#[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls-core")))]
 use native_tls::TlsConnector;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::connection::create_rustls_config;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use std::sync::Arc;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use tokio_rustls::{client::TlsStream, TlsConnector};
 
-#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tokio-rustls-comp")))]
+#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tokio-rustls-core")))]
 use tokio_native_tls::TlsStream;
 
-#[cfg(feature = "tokio-rustls-comp")]
+#[cfg(feature = "tokio-rustls-core")]
 use crate::tls::TlsConnParams;
 
-#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tls-rustls")))]
+#[cfg(all(feature = "tokio-native-tls-comp", not(feature = "tls-rustls-core")))]
 use crate::connection::TlsConnParams;
 
 #[cfg(unix)]
@@ -61,7 +61,7 @@ pub(crate) enum Tokio {
     /// Represents a Tokio TCP connection.
     Tcp(TcpStreamTokio),
     /// Represents a Tokio TLS encrypted TCP connection
-    #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
+    #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-core"))]
     TcpTls(Box<TlsStream<TcpStreamTokio>>),
     /// Represents a Tokio Unix connection.
     #[cfg(unix)]
@@ -76,7 +76,7 @@ impl AsyncWrite for Tokio {
     ) -> Poll<io::Result<usize>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_write(cx, buf),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-core"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_write(cx, buf),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_write(cx, buf),
@@ -86,7 +86,7 @@ impl AsyncWrite for Tokio {
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_flush(cx),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-core"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_flush(cx),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_flush(cx),
@@ -96,7 +96,7 @@ impl AsyncWrite for Tokio {
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_shutdown(cx),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-core"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_shutdown(cx),
@@ -112,7 +112,7 @@ impl AsyncRead for Tokio {
     ) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_read(cx, buf),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-core"))]
             Tokio::TcpTls(r) => Pin::new(r).poll_read(cx, buf),
             #[cfg(unix)]
             Tokio::Unix(r) => Pin::new(r).poll_read(cx, buf),
@@ -126,7 +126,7 @@ impl RedisRuntime for Tokio {
         Ok(connect_tcp(&socket_addr).await.map(Tokio::Tcp)?)
     }
 
-    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls")))]
+    #[cfg(all(feature = "tls-native-tls", not(feature = "tls-rustls-core")))]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -149,7 +149,7 @@ impl RedisRuntime for Tokio {
             .map(|con| Tokio::TcpTls(Box::new(con)))?)
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     async fn connect_tcp_tls(
         hostname: &str,
         socket_addr: SocketAddr,
@@ -186,7 +186,7 @@ impl RedisRuntime for Tokio {
     fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {
         match self {
             Tokio::Tcp(x) => Box::pin(x),
-            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
+            #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-core"))]
             Tokio::TcpTls(x) => Box::pin(x),
             #[cfg(unix)]
             Tokio::Unix(x) => Box::pin(x),

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
 #[cfg(feature = "aio")]
 use std::pin::Pin;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::tls::{inner_build_with_tls, TlsCertificates};
 
 /// The client type.
@@ -667,7 +667,7 @@ impl Client {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     pub fn build_with_tls<C: IntoConnectionInfo>(
         conn_info: C,
         tls_certs: TlsCertificates,

--- a/redis/src/cluster.rs
+++ b/redis/src/cluster.rs
@@ -62,10 +62,10 @@ use rand::{seq::IteratorRandom, thread_rng, Rng};
 pub use crate::cluster_client::{ClusterClient, ClusterClientBuilder};
 pub use crate::cluster_pipeline::{cluster_pipe, ClusterPipeline};
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::tls::TlsConnParams;
 
-#[cfg(not(feature = "tls-rustls"))]
+#[cfg(not(feature = "tls-rustls-core"))]
 use crate::connection::TlsConnParams;
 
 #[derive(Clone)]

--- a/redis/src/cluster_client.rs
+++ b/redis/src/cluster_client.rs
@@ -4,16 +4,16 @@ use crate::{cluster, cluster::TlsMode};
 use rand::Rng;
 use std::time::Duration;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::tls::TlsConnParams;
 
-#[cfg(not(feature = "tls-rustls"))]
+#[cfg(not(feature = "tls-rustls-core"))]
 use crate::connection::TlsConnParams;
 
 #[cfg(feature = "cluster-async")]
 use crate::cluster_async;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use crate::tls::{retrieve_tls_certificates, TlsCertificates};
 
 /// Parameters specific to builder, so that
@@ -25,7 +25,7 @@ struct BuilderParams {
     username: Option<String>,
     read_from_replicas: bool,
     tls: Option<TlsMode>,
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     certs: Option<TlsCertificates>,
     retries_configuration: RetryParams,
     connection_timeout: Option<Duration>,
@@ -89,10 +89,10 @@ pub(crate) struct ClusterParams {
 
 impl ClusterParams {
     fn from(value: BuilderParams) -> RedisResult<Self> {
-        #[cfg(not(feature = "tls-rustls"))]
+        #[cfg(not(feature = "tls-rustls-core"))]
         let tls_params = None;
 
-        #[cfg(feature = "tls-rustls")]
+        #[cfg(feature = "tls-rustls-core")]
         let tls_params = {
             let retrieved_tls_params = value.certs.clone().map(retrieve_tls_certificates);
 
@@ -259,7 +259,7 @@ impl ClusterClientBuilder {
     /// Sets TLS mode for the new ClusterClient.
     ///
     /// It is extracted from the first node of initial_nodes if not set.
-    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
+    #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls-core"))]
     pub fn tls(mut self, tls: TlsMode) -> ClusterClientBuilder {
         self.builder_params.tls = Some(tls);
         self
@@ -280,7 +280,7 @@ impl ClusterClientBuilder {
     ///
     /// If `ClientTlsConfig` ( cert+key pair ) is not provided, then client-side authentication is not enabled.
     /// If `root_cert` is not provided, then system root certificates are used instead.
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     pub fn certs(mut self, certificates: TlsCertificates) -> ClusterClientBuilder {
         self.builder_params.tls = Some(TlsMode::Secure);
         self.builder_params.certs = Some(certificates);

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -489,10 +489,10 @@ pub mod cluster_async;
 #[cfg(feature = "sentinel")]
 pub mod sentinel;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 mod tls;
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 pub use crate::tls::{ClientTlsConfig, TlsCertificates};
 
 mod client;

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -682,7 +682,7 @@ impl From<native_tls::Error> for RedisError {
     }
 }
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 impl From<rustls::Error> for RedisError {
     fn from(err: rustls::Error) -> RedisError {
         RedisError {
@@ -695,7 +695,7 @@ impl From<rustls::Error> for RedisError {
     }
 }
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 impl From<rustls_pki_types::InvalidDnsNameError> for RedisError {
     fn from(err: rustls_pki_types::InvalidDnsNameError) -> RedisError {
         RedisError {

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -19,7 +19,7 @@ use tempfile::TempDir;
 use crate::support::{build_keys_and_certs_for_tls, Module};
 
 use super::get_random_available_port;
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use super::{build_single_client, load_certs_from_file};
 
 use super::use_protocol;
@@ -319,11 +319,11 @@ impl RedisCluster {
                 conn_info.addr
             );
 
-            #[cfg(feature = "tls-rustls")]
+            #[cfg(feature = "tls-rustls-core")]
             let client =
                 build_single_client(server.connection_info(), &self.tls_paths, _mtls_enabled)
                     .unwrap();
-            #[cfg(not(feature = "tls-rustls"))]
+            #[cfg(not(feature = "tls-rustls-core"))]
             let client = redis::Client::open(server.connection_info()).unwrap();
 
             let mut con = client.get_connection().unwrap();
@@ -430,7 +430,7 @@ impl TestClusterContext {
         let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes.clone())
             .use_protocol(use_protocol());
 
-        #[cfg(feature = "tls-rustls")]
+        #[cfg(feature = "tls-rustls-core")]
         if mtls_enabled {
             if let Some(tls_file_paths) = &cluster.tls_paths {
                 builder = builder.certs(load_certs_from_file(tls_file_paths));
@@ -490,14 +490,14 @@ impl TestClusterContext {
 
     pub fn disable_default_user(&self) {
         for server in &self.cluster.servers {
-            #[cfg(feature = "tls-rustls")]
+            #[cfg(feature = "tls-rustls-core")]
             let client = build_single_client(
                 server.connection_info(),
                 &self.cluster.tls_paths,
                 self.mtls_enabled,
             )
             .unwrap();
-            #[cfg(not(feature = "tls-rustls"))]
+            #[cfg(not(feature = "tls-rustls-core"))]
             let client = redis::Client::open(server.connection_info()).unwrap();
 
             let mut con = client.get_connection().unwrap();

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -396,7 +396,10 @@ pub struct TestContext {
 }
 
 pub(crate) fn is_tls_enabled() -> bool {
-    cfg!(all(feature = "tls-rustls-core", not(feature = "tls-native-tls")))
+    cfg!(all(
+        feature = "tls-rustls-core",
+        not(feature = "tls-native-tls")
+    ))
 }
 
 impl TestContext {

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -5,7 +5,7 @@ use std::{
     env, fs, io, net::SocketAddr, net::TcpListener, path::PathBuf, process, thread::sleep,
     time::Duration,
 };
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use std::{
     fs::File,
     io::{BufReader, Read},
@@ -15,7 +15,7 @@ use std::{
 use futures::Future;
 use redis::{ConnectionAddr, InfoDict, Pipeline, ProtocolVersion, RedisConnectionInfo, Value};
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 use redis::{ClientTlsConfig, TlsCertificates};
 
 use socket2::{Domain, Socket, Type};
@@ -169,7 +169,7 @@ impl RedisServer {
         RedisServer::with_modules(&[], false)
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     pub fn new_with_mtls() -> RedisServer {
         RedisServer::with_modules(&[], true)
     }
@@ -396,7 +396,7 @@ pub struct TestContext {
 }
 
 pub(crate) fn is_tls_enabled() -> bool {
-    cfg!(all(feature = "tls-rustls", not(feature = "tls-native-tls")))
+    cfg!(all(feature = "tls-rustls-core", not(feature = "tls-native-tls")))
 }
 
 impl TestContext {
@@ -404,7 +404,7 @@ impl TestContext {
         TestContext::with_modules(&[], false)
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     pub fn new_with_mtls() -> TestContext {
         Self::with_modules(&[], true)
     }
@@ -425,10 +425,10 @@ impl TestContext {
             },
         );
 
-        #[cfg(feature = "tls-rustls")]
+        #[cfg(feature = "tls-rustls-core")]
         let client =
             build_single_client(server.connection_info(), &server.tls_paths, mtls_enabled).unwrap();
-        #[cfg(not(feature = "tls-rustls"))]
+        #[cfg(not(feature = "tls-rustls-core"))]
         let client = redis::Client::open(server.connection_info()).unwrap();
 
         let mut con;
@@ -466,10 +466,10 @@ impl TestContext {
     pub fn with_modules(modules: &[Module], mtls_enabled: bool) -> TestContext {
         let server = RedisServer::with_modules(modules, mtls_enabled);
 
-        #[cfg(feature = "tls-rustls")]
+        #[cfg(feature = "tls-rustls-core")]
         let client =
             build_single_client(server.connection_info(), &server.tls_paths, mtls_enabled).unwrap();
-        #[cfg(not(feature = "tls-rustls"))]
+        #[cfg(not(feature = "tls-rustls-core"))]
         let client = redis::Client::open(server.connection_info()).unwrap();
 
         let mut con;
@@ -769,7 +769,7 @@ pub fn is_version(expected_major_minor: (u16, u16), version: Version) -> bool {
         || (expected_major_minor.0 == version.0 && expected_major_minor.1 <= version.1)
 }
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
     let ca_file = File::open(&tls_file_paths.ca_crt).expect("Cannot open CA cert file");
     let mut root_cert_vec = Vec::new();
@@ -798,7 +798,7 @@ fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
     }
 }
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
     connection_info: T,
     tls_file_params: &Option<TlsFilePaths>,
@@ -818,7 +818,7 @@ pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
     }
 }
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "tls-rustls-core")]
 pub(crate) mod mtls_test {
     use super::*;
     use redis::{cluster::ClusterClient, ConnectionInfo, RedisError};

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -994,7 +994,7 @@ mod basic_async {
         .unwrap();
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     mod mtls_test {
         use super::*;
 

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -924,7 +924,7 @@ mod cluster {
         assert!(res.is_ok());
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     mod mtls_test {
         use super::*;
         use crate::support::mtls_test::create_cluster_client_from_cluster;

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -356,7 +356,7 @@ mod cluster_async {
                 for server in env.cluster.iter_servers() {
                     let addr = server.client_addr();
 
-                    #[cfg(feature = "tls-rustls")]
+                    #[cfg(feature = "tls-rustls-core")]
                     let client = build_single_client(
                         server.connection_info(),
                         &server.tls_paths,
@@ -364,7 +364,7 @@ mod cluster_async {
                     )
                     .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
 
-                    #[cfg(not(feature = "tls-rustls"))]
+                    #[cfg(not(feature = "tls-rustls-core"))]
                     let client = redis::Client::open(server.connection_info())
                         .unwrap_or_else(|e| panic!("Failed to connect to '{addr}': {e}"));
 
@@ -1863,7 +1863,7 @@ mod cluster_async {
         assert_eq!(ping_attempts.load(Ordering::Acquire), 5);
     }
 
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "tls-rustls-core")]
     mod mtls_test {
         use crate::support::mtls_test::create_cluster_client_from_cluster;
         use redis::ConnectionInfo;


### PR DESCRIPTION
This is an attempt to rework the way tls related features are split in order to avoid depending on `rustls-native-certs` even when it is not actually used.

Fixes #1155 