### PR TITLE
Add a specific error type for parsing errors. 

### DIFF
--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -357,14 +357,14 @@ impl PubSubSink {
     ) -> RedisResult<T> {
         let cmd = cmd("PING").arg(message).get_packed_command();
         let response = self.send_recv(cmd).await?;
-        from_owned_redis_value(response)
+        Ok(from_owned_redis_value(response)?)
     }
 
     /// Sends a ping to the server
     pub async fn ping<T: FromRedisValue>(&mut self) -> RedisResult<T> {
         let cmd = cmd("PING").get_packed_command();
         let response = self.send_recv(cmd).await?;
-        from_owned_redis_value(response)
+        Ok(from_owned_redis_value(response)?)
     }
 }
 

--- a/redis/src/caching/cache_manager.rs
+++ b/redis/src/caching/cache_manager.rs
@@ -3,7 +3,7 @@ use super::sharded_lru::*;
 use super::{CacheConfig, CacheMode, CacheStatistics};
 use crate::cmd::{cmd_len, Cmd};
 use crate::commands::is_readonly_cmd;
-use crate::{Pipeline, PushKind, RedisResult, Value};
+use crate::{Pipeline, PushKind, Value};
 use std::cmp::min;
 use std::ops::Add;
 use std::sync::Arc;
@@ -58,7 +58,7 @@ impl CacheManager {
         client_side_expire_time: Instant,
         server_side_ttl_value: &Value,
     ) {
-        let pttl: RedisResult<i64> = crate::FromRedisValue::from_redis_value(server_side_ttl_value);
+        let pttl: Result<i64, _> = crate::FromRedisValue::from_redis_value(server_side_ttl_value);
         let expire_time = match pttl {
             Ok(pttl) if pttl > 0 => {
                 let server_side_expire_time =

--- a/redis/src/cluster_pipeline.rs
+++ b/redis/src/cluster_pipeline.rs
@@ -118,11 +118,11 @@ impl ClusterPipeline {
             }
         }
 
-        from_owned_redis_value(if self.commands.is_empty() {
+        Ok(from_owned_redis_value(if self.commands.is_empty() {
             Value::Array(vec![])
         } else {
             self.make_pipeline_results(con.execute_pipeline(self)?)?
-        })
+        })?)
     }
 
     /// This is a shortcut to `query()` that does not return a value and

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -127,7 +127,7 @@ impl<T: FromRedisValue> Iterator for CheckedIter<'_, T> {
             let (cursor, batch) = match self
                 .con
                 .req_packed_command(&self.cmd.get_packed_command())
-                .and_then(from_owned_redis_value::<(u64, _)>)
+                .and_then(|val| Ok(from_owned_redis_value::<(u64, _)>(val)?))
             {
                 Ok((cursor, values)) => (cursor, T::from_each_owned_redis_values(values)),
                 Err(e) => return Some(Err(e)),
@@ -184,7 +184,7 @@ impl<'a, T: FromRedisValue + 'a> AsyncIterInner<'a, T> {
                 .con
                 .req_packed_command(&self.cmd)
                 .await
-                .and_then(from_owned_redis_value::<(u64, _)>)
+                .and_then(|val| Ok(from_owned_redis_value::<(u64, _)>(val)?))
             {
                 Ok((cursor, items)) => (cursor, T::from_each_owned_redis_values(items)),
                 Err(e) => return Some(Err(e)),
@@ -607,7 +607,7 @@ impl Cmd {
     #[inline]
     pub fn query<T: FromRedisValue>(&self, con: &mut dyn ConnectionLike) -> RedisResult<T> {
         match con.req_command(self) {
-            Ok(val) => from_owned_redis_value(val.extract_error()?),
+            Ok(val) => Ok(from_owned_redis_value(val.extract_error()?)?),
             Err(e) => Err(e),
         }
     }
@@ -620,7 +620,7 @@ impl Cmd {
         con: &mut impl crate::aio::ConnectionLike,
     ) -> RedisResult<T> {
         let val = con.req_packed_command(self).await?;
-        from_owned_redis_value(val.extract_error()?)
+        Ok(from_owned_redis_value(val.extract_error()?)?)
     }
 
     /// Sets the cursor and converts the passed value to a batch used by the

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1936,15 +1936,15 @@ impl<'a> PubSub<'a> {
 
     /// Sends a ping with a message to the server
     pub fn ping_message<T: FromRedisValue>(&mut self, message: impl ToRedisArgs) -> RedisResult<T> {
-        from_owned_redis_value(
+        Ok(from_owned_redis_value(
             self.cache_messages_until_received_response(cmd("PING").arg(message), false)?,
-        )
+        )?)
     }
     /// Sends a ping to the server
     pub fn ping<T: FromRedisValue>(&mut self) -> RedisResult<T> {
-        from_owned_redis_value(
+        Ok(from_owned_redis_value(
             self.cache_messages_until_received_response(&mut cmd("PING"), false)?,
-        )
+        )?)
     }
 
     /// Fetches the next message from the pubsub connection.  Blocks until
@@ -2047,7 +2047,7 @@ impl Msg {
 
     /// Returns the channel this message came on.
     pub fn get_channel<T: FromRedisValue>(&self) -> RedisResult<T> {
-        from_redis_value(&self.channel)
+        Ok(from_redis_value(&self.channel)?)
     }
 
     /// Convenience method to get a string version of the channel.  Unless
@@ -2063,7 +2063,7 @@ impl Msg {
 
     /// Returns the message's payload in a specific format.
     pub fn get_payload<T: FromRedisValue>(&self) -> RedisResult<T> {
-        from_redis_value(&self.payload)
+        Ok(from_redis_value(&self.payload)?)
     }
 
     /// Returns the bytes that are the message's payload.  This can be used
@@ -2088,10 +2088,10 @@ impl Msg {
     /// an `Option<String>` so that you do not need to use `from_pattern`
     /// to figure out if a pattern was set.
     pub fn get_pattern<T: FromRedisValue>(&self) -> RedisResult<T> {
-        match self.pattern {
+        Ok(match self.pattern {
             None => from_redis_value(&Value::Nil),
             Some(ref x) => from_redis_value(x),
-        }
+        }?)
     }
 }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -558,6 +558,7 @@ let primary = sentinel.get_async_connection().await.unwrap();
 //! # Upgrading to version 1
 //!
 //! * Iterators are now safe by default, without an opt-out. This means that the iterators return `RedisResult<Value>` instead of `Value` (see [this PR](https://github.com/redis-rs/redis-rs/pull/1641) for background). If you previously used the "safe_iterators" feature to opt-in to this behavior, just remove the feature declaration. Otherwise you will need to adjust your usage of iterators to account for potential conversion failures.
+//! * Parsing values using [FromRedisValue] no longer returns `RedisError` on failure, in order to save the users checking for various server & client errors in such scenarios. if you rely on the error type when using this trait, you'll need to adjust your error handling code. [ParsingError] should only be printed - it doesn't contain any user-actionable info outside of its error message.
 //!
 
 #![deny(non_camel_case_types)]
@@ -626,6 +627,7 @@ pub use crate::types::{
 	ValueType,
 
     // error and result types
+    ParsingError,
     RedisError,
     RedisResult,
     RedisWrite,

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -152,7 +152,7 @@ impl Pipeline {
             self.execute_pipelined(con)?
         };
 
-        from_owned_redis_value(value.extract_error()?)
+        Ok(from_owned_redis_value(value.extract_error()?)?)
     }
 
     #[cfg(feature = "aio")]
@@ -193,13 +193,13 @@ impl Pipeline {
         con: &mut impl crate::aio::ConnectionLike,
     ) -> RedisResult<T> {
         let value = if self.commands.is_empty() {
-            return from_owned_redis_value(Value::Array(vec![]));
+            return Ok(from_owned_redis_value(Value::Array(vec![]))?);
         } else if self.transaction_mode {
             self.execute_transaction_async(con).await?
         } else {
             self.execute_pipelined_async(con).await?
         };
-        from_owned_redis_value(value.extract_error()?)
+        Ok(from_owned_redis_value(value.extract_error()?)?)
     }
 
     /// This is a shortcut to `query()` that does not return a value and

--- a/redis/src/streams.rs
+++ b/redis/src/streams.rs
@@ -1,20 +1,10 @@
 //! Defines types to use with the streams commands.
 
 use crate::{
-    from_redis_value, types::HashMap, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, Value,
+    from_redis_value,
+    types::{invalid_type_error, HashMap, ParsingError},
+    FromRedisValue, RedisWrite, ToRedisArgs, Value,
 };
-
-use std::io::Error;
-
-macro_rules! invalid_type_error {
-    ($v:expr, $det:expr) => {{
-        fail!((
-            $crate::ErrorKind::TypeError,
-            "Response was of incompatible type",
-            format!("{:?} (response was {:?})", $det, $v)
-        ));
-    }};
-}
 
 // Stream Maxlen Enum
 
@@ -665,7 +655,7 @@ pub struct StreamId {
 
 impl StreamId {
     /// Converts a `Value::Array` into a `StreamId`.
-    fn from_array_value(v: &Value) -> RedisResult<Self> {
+    fn from_array_value(v: &Value) -> Result<Self, ParsingError> {
         let mut stream_id = StreamId::default();
         if let Value::Array(ref values) = *v {
             if let Some(v) = values.first() {
@@ -707,7 +697,7 @@ impl StreamId {
 type SACRows = Vec<HashMap<String, HashMap<String, Value>>>;
 
 impl FromRedisValue for StreamAutoClaimReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         match *v {
             Value::Array(ref items) => {
                 if let 2..=3 = items.len() {
@@ -760,7 +750,7 @@ impl FromRedisValue for StreamAutoClaimReply {
 
 type SRRows = Vec<HashMap<String, Vec<HashMap<String, HashMap<String, Value>>>>>;
 impl FromRedisValue for StreamReadReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let rows: SRRows = from_redis_value(v)?;
         let keys = rows
             .into_iter()
@@ -779,7 +769,7 @@ impl FromRedisValue for StreamReadReply {
 }
 
 impl FromRedisValue for StreamRangeReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let rows: Vec<HashMap<String, HashMap<String, Value>>> = from_redis_value(v)?;
         let ids: Vec<StreamId> = rows
             .into_iter()
@@ -790,7 +780,7 @@ impl FromRedisValue for StreamRangeReply {
 }
 
 impl FromRedisValue for StreamClaimReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let rows: Vec<HashMap<String, HashMap<String, Value>>> = from_redis_value(v)?;
         let ids: Vec<StreamId> = rows
             .into_iter()
@@ -807,7 +797,7 @@ type SPRInner = (
     Vec<Option<(String, String)>>,
 );
 impl FromRedisValue for StreamPendingReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let (count, start, end, consumer_data): SPRInner = from_redis_value(v)?;
 
         if count == 0 {
@@ -815,11 +805,13 @@ impl FromRedisValue for StreamPendingReply {
         } else {
             let mut result = StreamPendingData::default();
 
-            let start_id = start
-                .ok_or_else(|| Error::other("IllegalState: Non-zero pending expects start id"))?;
+            let start_id = start.ok_or_else(|| ParsingError {
+                description: "IllegalState: Non-zero pending expects start id".into(),
+            })?;
 
-            let end_id =
-                end.ok_or_else(|| Error::other("IllegalState: Non-zero pending expects end id"))?;
+            let end_id = end.ok_or_else(|| ParsingError {
+                description: "IllegalState: Non-zero pending expects end id".into(),
+            })?;
 
             result.count = count;
             result.start_id = start_id;
@@ -841,7 +833,7 @@ impl FromRedisValue for StreamPendingReply {
 }
 
 impl FromRedisValue for StreamPendingCountReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let mut reply = StreamPendingCountReply::default();
         match v {
             Value::Array(outer_tuple) => {
@@ -861,29 +853,26 @@ impl FromRedisValue for StreamPendingCountReply {
                                     times_delivered,
                                 });
                             }
-                            _ => fail!((
-                                crate::types::ErrorKind::TypeError,
-                                "Cannot parse redis data (3)"
-                            )),
+                            _ => fail!(ParsingError {
+                                description: "Cannot parse redis data (3)".into()
+                            }),
                         },
-                        _ => fail!((
-                            crate::types::ErrorKind::TypeError,
-                            "Cannot parse redis data (2)"
-                        )),
+                        _ => fail!(ParsingError {
+                            description: "Cannot parse redis data (2)".into()
+                        }),
                     }
                 }
             }
-            _ => fail!((
-                crate::types::ErrorKind::TypeError,
-                "Cannot parse redis data (1)"
-            )),
+            _ => fail!(ParsingError {
+                description: "Cannot parse redis data (1)".into()
+            }),
         };
         Ok(reply)
     }
 }
 
 impl FromRedisValue for StreamInfoStreamReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let map: HashMap<String, Value> = from_redis_value(v)?;
         let mut reply = StreamInfoStreamReply::default();
         if let Some(v) = &map.get("last-generated-id") {
@@ -909,7 +898,7 @@ impl FromRedisValue for StreamInfoStreamReply {
 }
 
 impl FromRedisValue for StreamInfoConsumersReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let consumers: Vec<HashMap<String, Value>> = from_redis_value(v)?;
         let mut reply = StreamInfoConsumersReply::default();
         for map in consumers {
@@ -931,7 +920,7 @@ impl FromRedisValue for StreamInfoConsumersReply {
 }
 
 impl FromRedisValue for StreamInfoGroupsReply {
-    fn from_redis_value(v: &Value) -> RedisResult<Self> {
+    fn from_redis_value(v: &Value) -> Result<Self, ParsingError> {
         let groups: Vec<HashMap<String, Value>> = from_redis_value(v)?;
         let mut reply = StreamInfoGroupsReply::default();
         for map in groups {
@@ -997,9 +986,7 @@ mod tests {
         fn short_response() {
             let value = Value::Array(vec![Value::BulkString("1713465536578-0".into())]);
 
-            let reply: RedisResult<StreamAutoClaimReply> = FromRedisValue::from_redis_value(&value);
-
-            assert!(reply.is_err());
+            StreamAutoClaimReply::from_redis_value(&value).unwrap_err();
         }
 
         #[test]
@@ -1010,11 +997,7 @@ mod tests {
                 Value::Array(vec![]),
             ]);
 
-            let reply: RedisResult<StreamAutoClaimReply> = FromRedisValue::from_redis_value(&value);
-
-            assert!(reply.is_ok());
-
-            let reply = reply.unwrap();
+            let reply: StreamAutoClaimReply = FromRedisValue::from_redis_value(&value).unwrap();
 
             assert_eq!(reply.next_stream_id.as_str(), "0-0");
             assert_eq!(reply.claimed.len(), 0);
@@ -1049,11 +1032,7 @@ mod tests {
                 Value::Array(vec![Value::BulkString("123456789-0".into())]),
             ]);
 
-            let reply: RedisResult<StreamAutoClaimReply> = FromRedisValue::from_redis_value(&value);
-
-            assert!(reply.is_ok());
-
-            let reply = reply.unwrap();
+            let reply: StreamAutoClaimReply = FromRedisValue::from_redis_value(&value).unwrap();
 
             assert_eq!(reply.next_stream_id.as_str(), "1713465536578-0");
             assert_eq!(reply.claimed.len(), 2);
@@ -1093,11 +1072,7 @@ mod tests {
                 // V6 and lower lack the deleted_ids array
             ]);
 
-            let reply: RedisResult<StreamAutoClaimReply> = FromRedisValue::from_redis_value(&value);
-
-            assert!(reply.is_ok());
-
-            let reply = reply.unwrap();
+            let reply: StreamAutoClaimReply = FromRedisValue::from_redis_value(&value).unwrap();
 
             assert_eq!(reply.next_stream_id.as_str(), "1713465536578-0");
             assert_eq!(reply.claimed.len(), 2);
@@ -1118,11 +1093,7 @@ mod tests {
                 Value::Array(vec![Value::BulkString("123456789-0".into())]),
             ]);
 
-            let reply: RedisResult<StreamAutoClaimReply> = FromRedisValue::from_redis_value(&value);
-
-            assert!(reply.is_ok());
-
-            let reply = reply.unwrap();
+            let reply: StreamAutoClaimReply = FromRedisValue::from_redis_value(&value).unwrap();
 
             assert_eq!(reply.next_stream_id.as_str(), "1713465536578-0");
             assert_eq!(reply.claimed.len(), 2);
@@ -1144,11 +1115,7 @@ mod tests {
                 // V6 and lower lack the deleted_ids array
             ]);
 
-            let reply: RedisResult<StreamAutoClaimReply> = FromRedisValue::from_redis_value(&value);
-
-            assert!(reply.is_ok());
-
-            let reply = reply.unwrap();
+            let reply: StreamAutoClaimReply = FromRedisValue::from_redis_value(&value).unwrap();
 
             assert_eq!(reply.next_stream_id.as_str(), "1713465536578-0");
             assert_eq!(reply.claimed.len(), 2);

--- a/redis/tests/test_bignum.rs
+++ b/redis/tests/test_bignum.rs
@@ -3,7 +3,7 @@
     feature = "bigdecimal",
     feature = "num-bigint"
 ))]
-use redis::{ErrorKind, FromRedisValue, RedisResult, ToRedisArgs, Value};
+use redis::{FromRedisValue, ToRedisArgs, Value};
 use std::str::FromStr;
 
 fn test<T>(content: &str)
@@ -16,24 +16,23 @@ where
         + std::fmt::Debug,
     <T as FromStr>::Err: std::fmt::Debug,
 {
-    let v: RedisResult<T> =
-        FromRedisValue::from_redis_value(&Value::BulkString(Vec::from(content)));
+    let v = T::from_redis_value(&Value::BulkString(Vec::from(content)));
     assert_eq!(v, Ok(T::from_str(content).unwrap()));
 
     let arg = ToRedisArgs::to_redis_args(&v.unwrap());
     assert_eq!(arg[0], Vec::from(content));
 
-    let v: RedisResult<T> = FromRedisValue::from_redis_value(&Value::Int(0));
+    let v = T::from_redis_value(&Value::Int(0));
     assert_eq!(v.unwrap(), T::from(0u32));
 
-    let v: RedisResult<T> = FromRedisValue::from_redis_value(&Value::Int(42));
+    let v = T::from_redis_value(&Value::Int(42));
     assert_eq!(v.unwrap(), T::from(42u32));
 
-    let v: RedisResult<T> = FromRedisValue::from_redis_value(&Value::Okay);
-    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+    let v = T::from_redis_value(&Value::Okay);
+    assert!(v.is_err());
 
-    let v: RedisResult<T> = FromRedisValue::from_redis_value(&Value::Nil);
-    assert_eq!(v.unwrap_err().kind(), ErrorKind::TypeError);
+    let v = T::from_redis_value(&Value::Nil);
+    assert!(v.is_err());
 }
 
 #[test]


### PR DESCRIPTION
This will save users who just want to parse some data from checking for client or server errors.