### PR TITLE
CI: Only run builds after lints pass.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-test:
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -129,6 +130,7 @@ jobs:
           cargo check -p redis --no-default-features --features smol-comp
 
   examples:
+    needs: [lint, build-and-test]
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     strategy:
@@ -212,6 +214,7 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
 
   benchmark:
+    needs: lint
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     env:
@@ -246,6 +249,7 @@ jobs:
       - uses: actions/checkout@v4
 
   flag-frenzy:
+    needs: [lint, build-and-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -259,6 +263,7 @@ jobs:
           flag-frenzy --package redis
 
   windows-build:
+    needs: [lint, build-and-test, examples]
     runs-on: windows-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This is done in order to reduce the cost of CI on failures.