### PR TITLE
ConnectionManager init pipeline: ordering, retries, and security hooks (clean 1.0.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/redis.svg)](https://crates.io/crates/redis)
 [![Chat](https://img.shields.io/discord/976380008299917365?logo=discord)](https://discord.gg/WHKcJK9AKP)
 
-Redis-rs is a high level Rust library for Redis, Valkey and any other RESP 
+Redis-rs is a high level Rust library for Redis, Valkey and any other RESP
 (Redis Serialization Protocol) compliant DB. It provides convenient access
 to all Redis functionality through a very flexible but low-level API. It
 uses a customizable type conversion trait so that any operation can return
@@ -91,8 +91,8 @@ redis = { version = "1.0.0-alpha", features = ["r2d2"] }
 ```
 
 For async connections, connection pooling isn't necessary, unless blocking commands are used.
-The `MultiplexedConnection` is cheaply cloneable and can be used safely from multiple threads, so a 
-single connection can be easily reused. For automatic reconnections consider using 
+The `MultiplexedConnection` is cheaply cloneable and can be used safely from multiple threads, so a
+single connection can be easily reused. For automatic reconnections consider using
 `ConnectionManager` with the `connection-manager` feature.
 Async cluster connections also don't require pooling and are thread-safe and reusable.
 
@@ -171,6 +171,62 @@ Support for Redis Cluster can be enabled by enabling the `cluster` feature in yo
 Then you can simply use the `ClusterClient`, which accepts a list of available nodes. Note
 that only one node in the cluster needs to be specified when instantiating the client, though
 you can specify multiple.
+
+## ConnectionManager initialization
+
+The async `ConnectionManager` can be configured to initialize connections with a client name, optional CLIENT SETINFO key/value pairs, and an optional user-provided initialization pipeline. Initialization runs on initial connect and on reconnect. By default, only safe configuration (SETNAME/SETINFO) is applied. Arbitrary commands must be explicitly enabled.
+
+```rust
+use redis::aio::ConnectionManagerConfig;
+use redis::{cmd, Client};
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> redis::RedisResult<()> {
+    let client = Client::open("redis://127.0.0.1/?protocol=resp3")?;
+
+    // Build initialization behavior
+    let config = ConnectionManagerConfig::new()
+        .set_client_name("svc-app".to_string())
+        .set_client_setinfo(vec![
+            ("env".to_string(), "prod".to_string()),
+            ("lib".to_string(), "redis-rs".to_string()),
+        ])
+        // Optional: user pipeline (safe-by-default: ignored unless arbitrary init is enabled)
+        .set_init_pipeline({
+            let mut p = redis::pipe();
+            p.cmd("SET").arg("cm:initialized").arg("1");
+            p
+        })
+        // Enable arbitrary initialization commands only if you trust the pipeline contents
+        // Security note: arbitrary init may leak credentials or affect reconnect behavior
+        .enable_arbitrary_init_commands()
+        // Optional: security configuration (per-init timeout, ASCII-only client names)
+        .set_security_config(
+            redis::aio::SecurityConfig::new()
+                .set_init_timeout(Duration::from_secs(3))
+                .set_validate_ascii(true),
+        );
+
+    let mut cm = client.get_connection_manager_with_config(config).await?;
+
+    // Gate usage until initialization completes
+    cm.await_ready().await?;
+
+    // Use the manager as a connection
+    let pong: String = cmd("PING").query_async(&mut cm).await?;
+    assert_eq!(pong, "PONG");
+    Ok(())
+}
+```
+
+Notes
+- Safe by default: Only CLIENT SETNAME/SETINFO are executed unless you call `enable_arbitrary_init_commands()`.
+- Initialization runs on reconnect and is combined with automatic resubscriptions if enabled.
+- For RESP3 pub/sub resubscription, configure a push sender (see async pub/sub docs in README and rustdoc).
+- See rustdoc for `ConnectionManagerConfig` and `SecurityConfig` for full options.
+```
+
 
 ```rust
 use redis::cluster::ClusterClient;
@@ -259,7 +315,7 @@ Note: `make test` requires cargo-nextest installed, to learn more about it pleas
 
 
     $ make test
-    
+
 To run benchmarks:
 
     $ make bench

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,3 +1,14 @@
+### Unreleased
+
+#### Added
+
+* ConnectionManager: initialization configuration supporting CLIENT SETNAME and CLIENT SETINFO; optional user-provided initialization pipeline with safe-by-default behavior (arbitrary commands require explicit opt-in); await_ready() gating to ensure post-connect usage only after init completes; and per-init command timeout configuration.
+
+#### Fixed
+
+* Sync connection: Mark connection as closed on additional OS-level read errors (ConnectionReset, BrokenPipe, NotConnected, ConnectionAborted) in addition to UnexpectedEof. This resolves macOS "Connection reset by peer (os error 54)" causing is_open() to remain true after server shutdown.
+
+
 ### 0.32.5 (2025-08-10)
 
 #### Changes & Bug fixes
@@ -183,9 +194,9 @@
 
 #### Changes & Bug fixes
 
-* feat(cluster): add `get(_async)?_connection_with_config` ([#1487](https://github\.com/redis-rs/redis-rs/pull/1487) by @Totodore) 
-* Fix connection creation timeout. ([#1490](https://github\.com/redis-rs/redis-rs/pull/1490)) 
-* Fix RetryMethod Import ([#1494](https://github\.com/redis-rs/redis-rs/pull/1494) by @Braedon-Wooding-Displayr) 
+* feat(cluster): add `get(_async)?_connection_with_config` ([#1487](https://github\.com/redis-rs/redis-rs/pull/1487) by @Totodore)
+* Fix connection creation timeout. ([#1490](https://github\.com/redis-rs/redis-rs/pull/1490))
+* Fix RetryMethod Import ([#1494](https://github\.com/redis-rs/redis-rs/pull/1494) by @Braedon-Wooding-Displayr)
 
 ### 0.28.1 (2025-01-11)
 
@@ -522,7 +533,7 @@ have been pushed to 0.24.0.
 ### 0.23.3 (2023-09-01)
 
 Note that this release fixes a small regression in async Redis Cluster handling of the `PING` command.
-Based on updated response aggregation logic in [#888](https://github.com/redis-rs/redis-rs/pull/888), it 
+Based on updated response aggregation logic in [#888](https://github.com/redis-rs/redis-rs/pull/888), it
 will again return a single response instead of an array.
 
 #### Features
@@ -597,9 +608,9 @@ sought feature. Thanks to @rharish101 and @LeoRowan for getting this in!
 This release adds the `cluster_async` module, which introduces async Redis Cluster support. The code therein
 is largely taken from @Marwes's [redis-cluster-async crate](https://github.com/redis-rs/redis-cluster-async), which itself
 appears to have started from a sync Redis Cluster implementation started by @atuk721. In any case, thanks to @Marwes and @atuk721
-for the great work, and we hope to keep development moving forward in `redis-rs`. 
+for the great work, and we hope to keep development moving forward in `redis-rs`.
 
-Though async Redis Cluster functionality for the time being has been kept as close to the originating crate as possible, previous users of 
+Though async Redis Cluster functionality for the time being has been kept as close to the originating crate as possible, previous users of
 `redis-cluster-async` should note the following changes:
 * Retries, while still configurable, can no longer be set to `None`/infinite retries
 * Routing and slot parsing logic has been removed and merged with existing `redis-rs` functionality
@@ -647,7 +658,7 @@ This release adds various incremental improvements and fixes a few long-standing
 contributors for making this release happen.
 
 #### Features
-*   Implement ToRedisArgs for HashMap ([#722](https://github.com/redis-rs/redis-rs/pull/722) @gibranamparan) 
+*   Implement ToRedisArgs for HashMap ([#722](https://github.com/redis-rs/redis-rs/pull/722) @gibranamparan)
 *   Add explicit `MGET` command ([#729](https://github.com/redis-rs/redis-rs/pull/729) @vamshiaruru-virgodesigns)
 
 #### Bug fixes
@@ -658,8 +669,8 @@ contributors for making this release happen.
 
 #### Changes
 *   Add test case for atomic pipeline ([#702](https://github.com/redis-rs/redis-rs/pull/702) @CNLHC)
-*   Capture subscribe result error in PubSub doc example ([#739](https://github.com/redis-rs/redis-rs/pull/739) @baoyachi) 
-*   Use async-std name resolution when necessary ([#701](https://github.com/redis-rs/redis-rs/pull/701) @UgnilJoZ) 
+*   Capture subscribe result error in PubSub doc example ([#739](https://github.com/redis-rs/redis-rs/pull/739) @baoyachi)
+*   Use async-std name resolution when necessary ([#701](https://github.com/redis-rs/redis-rs/pull/701) @UgnilJoZ)
 *   Add Script::invoke_async method ([#711](https://github.com/redis-rs/redis-rs/pull/711) @r-bk)
 *   Cluster Refactorings ([#717](https://github.com/redis-rs/redis-rs/pull/717), [#716](https://github.com/redis-rs/redis-rs/pull/716), [#709](https://github.com/redis-rs/redis-rs/pull/709), [#707](https://github.com/redis-rs/redis-rs/pull/707), [#706](https://github.com/redis-rs/redis-rs/pull/706) @0xWOF, @utkarshgupta137)
 *   Fix intermittent test failure ([#714](https://github.com/redis-rs/redis-rs/pull/714) @0xWOF, @utkarshgupta137)
@@ -681,10 +692,10 @@ This release adds various incremental improvements, including
 additional convenience commands, improved Cluster APIs, and various other bug
 fixes/library improvements.
 
-Although the changes here are incremental, this is a major release due to the 
+Although the changes here are incremental, this is a major release due to the
 breaking changes listed below.
 
-This release would not be possible without our many wonderful 
+This release would not be possible without our many wonderful
 contributors -- thank you!
 
 #### Breaking changes

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -10,6 +10,7 @@ license = "BSD-3-Clause"
 edition = "2021"
 rust-version = "1.85"
 readme = "../README.md"
+autoexamples = false
 
 [package.metadata.docs.rs]
 all-features = true
@@ -218,43 +219,4 @@ required-features = ["cluster-async", "tokio-comp"]
 [[bench]]
 name = "bench_cache"
 harness = false
-required-features = ["tokio-comp", "cache-aio"]
-
-[[example]]
-name = "async-multiplexed"
-required-features = ["tokio-comp"]
-
-[[example]]
-name = "async-await"
-required-features = ["aio"]
-
-[[example]]
-name = "async-resp2-pub-sub"
-required-features = ["aio"]
-
-[[example]]
-name = "async-resp3-pub-sub"
-required-features = ["aio", "connection-manager"]
-
-[[example]]
-name = "async-scan"
-required-features = ["aio"]
-
-[[example]]
-name = "async-connection-loss"
-required-features = ["connection-manager"]
-
-[[example]]
-name = "streams"
-required-features = ["streams"]
-
-[[example]]
-name = "async-typed"
-required-features = ["aio"]
-
-[[example]]
-name = "typed"
-
-[[example]]
-name = "async-caching"
 required-features = ["tokio-comp", "cache-aio"]

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -3,20 +3,16 @@ use super::{AsyncPushSender, HandleContainer, RedisFuture};
 use crate::caching::CacheManager;
 use crate::{
     aio::{ConnectionLike, MultiplexedConnection, Runtime},
-    check_resp3,
-    client::{DEFAULT_CONNECTION_TIMEOUT, DEFAULT_RESPONSE_TIMEOUT},
-    cmd,
-    errors::RedisError,
+    check_resp3, cmd,
     subscription_tracker::{SubscriptionAction, SubscriptionTracker},
-    types::{RedisResult, Value},
+    types::{RedisError, RedisResult, Value},
     AsyncConnectionConfig, Client, Cmd, Pipeline, ProtocolVersion, PushInfo, PushKind, ToRedisArgs,
 };
 use arc_swap::ArcSwap;
 use backon::{ExponentialBuilder, Retryable};
 use futures_channel::oneshot;
-use futures_util::future::{self, BoxFuture, FutureExt, Shared};
+use futures_util::future::{BoxFuture, FutureExt, Shared};
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::Mutex;
 
@@ -27,44 +23,110 @@ type OptionalPushSender = Option<Arc<dyn AsyncPushSender>>;
 pub struct ConnectionManagerConfig {
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
-    exponent_base: f32,
-    /// The minimal delay for reconnection attempts
-    min_delay: Duration,
-    /// Apply a maximum delay between connection attempts. The delay between attempts won't be longer than max_delay milliseconds.
-    max_delay: Option<Duration>,
+    exponent_base: u64,
+    /// A multiplicative factor that will be applied to the retry delay.
+    ///
+    /// For example, using a factor of `1000` will make each delay in units of seconds.
+    factor: u64,
     /// number_of_retries times, with an exponentially increasing delay
     number_of_retries: usize,
+    /// Apply a maximum delay between connection attempts. The delay between attempts won't be longer than max_delay milliseconds.
+    max_delay: Option<u64>,
     /// The new connection will time out operations after `response_timeout` has passed.
-    response_timeout: Option<Duration>,
+    response_timeout: Option<std::time::Duration>,
     /// Each connection attempt to the server will time out after `connection_timeout`.
-    connection_timeout: Option<Duration>,
+    connection_timeout: Option<std::time::Duration>,
     /// sender channel for push values
     push_sender: Option<Arc<dyn AsyncPushSender>>,
     /// if true, the manager should resubscribe automatically to all pubsub channels after reconnect.
     resubscribe_automatically: bool,
+    tcp_settings: crate::io::tcp::TcpSettings,
     #[cfg(feature = "cache-aio")]
     pub(crate) cache_config: Option<crate::caching::CacheConfig>,
+    /// Security configuration for the connection manager
+    security_config: SecurityConfig,
+    /// Optional client name to set on (re)connect
+    client_name: Option<String>,
+    /// Optional CLIENT SETINFO key/value pairs
+    client_setinfo_pairs: Option<Vec<(String, String)>>,
+    /// Optional user-provided initialization pipeline
+    user_init_pipeline: Option<Pipeline>,
+    /// Whether to allow arbitrary init commands (dangerous). Default: false
+    allow_arbitrary_init_commands: bool,
+}
+
+/// Security configuration for ConnectionManager initialization
+#[derive(Clone)]
+pub struct SecurityConfig {
+    /// Maximum size for client names in bytes (default: 64KB)
+    max_client_name_size: usize,
+    /// Whether to restrict client names to ASCII-only (default: false)
+    validate_ascii: bool,
+    /// Timeout for initialization pipeline commands (default: 30 seconds)
+    init_timeout: std::time::Duration,
+    /// Whether to enable resource monitoring hooks (default: false)
+    enable_resource_monitoring: bool,
+    /// Resource monitoring callback
+    resource_monitor: Option<Arc<dyn ResourceMonitor>>,
+}
+
+/// Trait for monitoring resource usage during connection initialization
+pub trait ResourceMonitor: Send + Sync {
+    /// Called when connection initialization starts
+    fn on_init_start(&self, client_info: &str);
+
+    /// Called when a command is executed during initialization
+    fn on_command_executed(
+        &self,
+        command: &str,
+        duration: std::time::Duration,
+        memory_delta: Option<i64>,
+    );
+
+    /// Called when initialization completes successfully
+    fn on_init_complete(&self, total_duration: std::time::Duration, final_memory: Option<u64>);
+
+    /// Called when initialization fails
+    fn on_init_failed(&self, error: &InitializationError, total_duration: std::time::Duration);
+}
+
+/// Resource usage statistics
+#[derive(Debug, Clone)]
+pub struct ResourceStats {
+    /// Approximate memory usage observed during initialization (bytes), if available
+    pub memory_usage: Option<u64>,
+    /// Number of connections observed during initialization, if available
+    pub connection_count: Option<u32>,
+    /// CPU time spent during initialization, if available
+    pub cpu_time: Option<std::time::Duration>,
+    /// Total network bytes sent during initialization, if available
+    pub network_bytes_sent: Option<u64>,
+    /// Total network bytes received during initialization, if available
+    pub network_bytes_received: Option<u64>,
 }
 
 impl std::fmt::Debug for ConnectionManagerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let &Self {
             exponent_base,
-            min_delay,
+            factor,
             number_of_retries,
             max_delay,
             response_timeout,
             connection_timeout,
             push_sender,
             resubscribe_automatically,
+            tcp_settings,
             #[cfg(feature = "cache-aio")]
             cache_config,
+            security_config: _,
+            ..
         } = &self;
         let mut str = f.debug_struct("ConnectionManagerConfig");
         str.field("exponent_base", &exponent_base)
-            .field("min_delay", &min_delay)
-            .field("max_delay", &max_delay)
+            .field("factor", &factor)
             .field("number_of_retries", &number_of_retries)
+            .field("max_delay", &max_delay)
             .field("response_timeout", &response_timeout)
             .field("connection_timeout", &connection_timeout)
             .field("resubscribe_automatically", &resubscribe_automatically)
@@ -75,7 +137,8 @@ impl std::fmt::Debug for ConnectionManagerConfig {
                 } else {
                     &"not set"
                 },
-            );
+            )
+            .field("tcp_settings", &tcp_settings);
 
         #[cfg(feature = "cache-aio")]
         str.field("cache_config", &cache_config);
@@ -84,31 +147,91 @@ impl std::fmt::Debug for ConnectionManagerConfig {
     }
 }
 
+impl SecurityConfig {
+    const DEFAULT_MAX_CLIENT_NAME_SIZE: usize = 65536; // 64KB
+    const DEFAULT_VALIDATE_ASCII: bool = false;
+    const DEFAULT_INIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    const DEFAULT_ENABLE_RESOURCE_MONITORING: bool = false;
+
+    /// Creates a new SecurityConfig with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set maximum client name size in bytes
+    pub fn set_max_client_name_size(mut self, size: usize) -> Self {
+        self.max_client_name_size = size;
+        self
+    }
+
+    /// Restrict client names to ASCII-only
+    pub fn set_validate_ascii(mut self, validate: bool) -> Self {
+        self.validate_ascii = validate;
+        self
+    }
+
+    /// Set timeout for initialization pipeline commands
+    pub fn set_init_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.init_timeout = timeout;
+        self
+    }
+
+    /// Enable resource monitoring hooks
+    pub fn set_enable_resource_monitoring(mut self, enable: bool) -> Self {
+        self.enable_resource_monitoring = enable;
+        self
+    }
+
+    /// Set resource monitoring callback
+    pub fn set_resource_monitor(mut self, monitor: impl ResourceMonitor + 'static) -> Self {
+        self.resource_monitor = Some(Arc::new(monitor));
+        self.enable_resource_monitoring = true;
+        self
+    }
+}
+
+impl Default for SecurityConfig {
+    fn default() -> Self {
+        Self {
+            max_client_name_size: Self::DEFAULT_MAX_CLIENT_NAME_SIZE,
+            validate_ascii: Self::DEFAULT_VALIDATE_ASCII,
+            init_timeout: Self::DEFAULT_INIT_TIMEOUT,
+            enable_resource_monitoring: Self::DEFAULT_ENABLE_RESOURCE_MONITORING,
+            resource_monitor: None,
+        }
+    }
+}
+
 impl ConnectionManagerConfig {
-    const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: f32 = 2.0;
-    const DEFAULT_CONNECTION_RETRY_MIN_DELAY: Duration = Duration::from_millis(100);
+    const DEFAULT_CONNECTION_RETRY_EXPONENT_BASE: u64 = 2;
+    const DEFAULT_CONNECTION_RETRY_FACTOR: u64 = 100;
     const DEFAULT_NUMBER_OF_CONNECTION_RETRIES: usize = 6;
+    const DEFAULT_RESPONSE_TIMEOUT: Option<std::time::Duration> = None;
+    const DEFAULT_CONNECTION_TIMEOUT: Option<std::time::Duration> = None;
 
     /// Creates a new instance of the options with nothing set
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Set the minimal delay for reconnect attempts.
-    pub fn set_min_delay(mut self, min_delay: Duration) -> ConnectionManagerConfig {
-        self.min_delay = min_delay;
+    /// A multiplicative scale applied to the exponential backoff delay (milliseconds).
+    ///
+    /// For example, with `exponent_base = 2` and `factor = 1000`, backoff delays are approximately
+    /// 1000ms, 2000ms, 4000ms (with jitter).
+    pub fn set_factor(mut self, factor: u64) -> ConnectionManagerConfig {
+        self.factor = factor;
         self
     }
 
     /// Apply a maximum delay between connection attempts. The delay between attempts won't be longer than max_delay milliseconds.
-    pub fn set_max_delay(mut self, time: Duration) -> ConnectionManagerConfig {
+    pub fn set_max_delay(mut self, time: u64) -> ConnectionManagerConfig {
         self.max_delay = Some(time);
         self
     }
 
     /// The resulting duration is calculated by taking the base to the `n`-th power,
     /// where `n` denotes the number of past attempts.
-    pub fn set_exponent_base(mut self, base: f32) -> ConnectionManagerConfig {
+    pub fn set_exponent_base(mut self, base: u64) -> ConnectionManagerConfig {
         self.exponent_base = base;
         self
     }
@@ -120,25 +243,27 @@ impl ConnectionManagerConfig {
     }
 
     /// The new connection will time out operations after `response_timeout` has passed.
-    ///
-    /// Set `None` if you don't want requests to time out.
-    pub fn set_response_timeout(mut self, duration: Option<Duration>) -> ConnectionManagerConfig {
-        self.response_timeout = duration;
+    pub fn set_response_timeout(
+        mut self,
+        duration: std::time::Duration,
+    ) -> ConnectionManagerConfig {
+        self.response_timeout = Some(duration);
         self
     }
 
     /// Each connection attempt to the server will time out after `connection_timeout`.
-    ///
-    /// Set `None` if you don't want the connection attempt to time out.
-    pub fn set_connection_timeout(mut self, duration: Option<Duration>) -> ConnectionManagerConfig {
-        self.connection_timeout = duration;
+    pub fn set_connection_timeout(
+        mut self,
+        duration: std::time::Duration,
+    ) -> ConnectionManagerConfig {
+        self.connection_timeout = Some(duration);
         self
     }
 
     /// Sets sender sender for push values.
     ///
     /// The sender can be a channel, or an arbitrary function that handles [crate::PushInfo] values.
-    /// This will fail client creation if the connection isn't configured for RESP3 communications via the [crate::RedisConnectionInfo::set_protocol] function.
+    /// This will fail client creation if the connection isn't configured for RESP3 communications via the [crate::RedisConnectionInfo::protocol] field.
     ///
     /// # Examples
     ///
@@ -171,6 +296,14 @@ impl ConnectionManagerConfig {
         self
     }
 
+    /// Set the behavior of the underlying TCP connection.
+    pub fn set_tcp_settings(self, tcp_settings: crate::io::tcp::TcpSettings) -> Self {
+        Self {
+            tcp_settings,
+            ..self
+        }
+    }
+
     /// Set the cache behavior.
     #[cfg(feature = "cache-aio")]
     pub fn set_cache_config(self, cache_config: crate::caching::CacheConfig) -> Self {
@@ -179,24 +312,162 @@ impl ConnectionManagerConfig {
             ..self
         }
     }
+
+    /// Set security configuration
+    pub fn set_security_config(mut self, security_config: SecurityConfig) -> Self {
+        self.security_config = security_config;
+        self
+    }
+
+    /// Sets a client name to be applied via CLIENT SETNAME during (re)initialization.
+    pub fn set_client_name(mut self, name: String) -> Self {
+        // Validate length and UTF-8 if configured
+        let _ = validate_client_name(&name, &self.security_config);
+        self.client_name = Some(name);
+        self
+    }
+
+    /// Sets key/value pairs to be applied via CLIENT SETINFO during (re)initialization.
+    pub fn set_client_setinfo(mut self, setinfo_pairs: Vec<(String, String)>) -> Self {
+        self.client_setinfo_pairs = Some(setinfo_pairs);
+        self
+    }
+
+    /// Sets a custom initialization pipeline.
+    pub fn set_init_pipeline(mut self, pipeline: Pipeline) -> Self {
+        self.user_init_pipeline = Some(pipeline);
+        self
+    }
+
+    /// Enables arbitrary initialization commands (dangerous). Use with caution.
+    pub fn enable_arbitrary_init_commands(mut self) -> Self {
+        self.allow_arbitrary_init_commands = true;
+        self
+    }
 }
 
 impl Default for ConnectionManagerConfig {
     fn default() -> Self {
         Self {
             exponent_base: Self::DEFAULT_CONNECTION_RETRY_EXPONENT_BASE,
-            min_delay: Self::DEFAULT_CONNECTION_RETRY_MIN_DELAY,
-            max_delay: None,
+            factor: Self::DEFAULT_CONNECTION_RETRY_FACTOR,
             number_of_retries: Self::DEFAULT_NUMBER_OF_CONNECTION_RETRIES,
-            response_timeout: DEFAULT_RESPONSE_TIMEOUT,
-            connection_timeout: DEFAULT_CONNECTION_TIMEOUT,
+            response_timeout: Self::DEFAULT_RESPONSE_TIMEOUT,
+            connection_timeout: Self::DEFAULT_CONNECTION_TIMEOUT,
+            max_delay: None,
             push_sender: None,
             resubscribe_automatically: false,
+            tcp_settings: Default::default(),
             #[cfg(feature = "cache-aio")]
             cache_config: None,
+            security_config: SecurityConfig::default(),
+            client_name: None,
+            client_setinfo_pairs: None,
+            user_init_pipeline: None,
+            allow_arbitrary_init_commands: false,
         }
     }
 }
+
+/// Validates a client name according to security configuration
+fn validate_client_name(name: &str, config: &SecurityConfig) -> RedisResult<()> {
+    // Check size limit
+    if name.len() > config.max_client_name_size {
+        return Err(crate::RedisError::from((
+            crate::ErrorKind::ClientError,
+            "Client name too large",
+            format!(
+                "{} bytes exceeds limit of {} bytes",
+                name.len(),
+                config.max_client_name_size
+            ),
+        )));
+    }
+
+    // Check ASCII-only constraint if enabled
+    if config.validate_ascii && !name.is_ascii() {
+        return Err(crate::RedisError::from((
+            crate::ErrorKind::ClientError,
+            "Client name contains invalid UTF-8 sequences",
+        )));
+    }
+
+    Ok(())
+}
+
+/// Enhanced error handling for initialization pipeline commands
+#[derive(Debug, Clone)]
+pub struct InitializationError {
+    /// The command (or logical step) that failed during initialization
+    pub command: String,
+    /// The underlying error, wrapped so the result can be cloned
+    pub error: Arc<RedisError>,
+    /// How many retries were attempted before surfacing the error
+    pub retry_count: usize,
+    /// Whether the error is considered recoverable by reconnect/retry logic
+    pub is_recoverable: bool,
+}
+
+impl InitializationError {
+    fn new(command: String, error: RedisError, retry_count: usize) -> Self {
+        let is_recoverable = Self::is_error_recoverable(&error);
+        Self {
+            command,
+            error: Arc::new(error),
+            retry_count,
+            is_recoverable,
+        }
+    }
+
+    fn is_error_recoverable(error: &RedisError) -> bool {
+        match error.kind() {
+            crate::ErrorKind::IoError => true,
+            crate::ErrorKind::ResponseError => {
+                // Some response errors are recoverable (timeouts, temporary failures)
+                let error_str = error.to_string().to_lowercase();
+                error_str.contains("timeout")
+                    || error_str.contains("loading")
+                    || error_str.contains("busy")
+            }
+            crate::ErrorKind::AuthenticationFailed => false,
+            crate::ErrorKind::TypeError => false,
+            crate::ErrorKind::ExecAbortError => false,
+            crate::ErrorKind::BusyLoadingError => true,
+            crate::ErrorKind::NoScriptError => false,
+            crate::ErrorKind::InvalidClientConfig => false,
+            crate::ErrorKind::Moved => true,
+            crate::ErrorKind::Ask => true,
+            crate::ErrorKind::TryAgain => true,
+            crate::ErrorKind::ClusterDown => true,
+            crate::ErrorKind::CrossSlot => false,
+            crate::ErrorKind::MasterDown => true,
+            crate::ErrorKind::ReadOnly => false,
+            crate::ErrorKind::ClientError => false,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Display for InitializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Initialization command '{}' failed after {} retries: {}",
+            self.command, self.retry_count, self.error
+        )
+    }
+}
+
+impl std::error::Error for InitializationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.error.as_ref())
+    }
+}
+
+// Readiness tracking types
+type ReadyResult = CloneableRedisResult<()>;
+type ReadySender = tokio::sync::watch::Sender<ReadyResult>;
+type ReadyReceiver = tokio::sync::watch::Receiver<ReadyResult>;
 
 struct Internals {
     /// Information used for the connection. This is needed to be able to reconnect.
@@ -210,10 +481,16 @@ struct Internals {
     runtime: Runtime,
     retry_strategy: ExponentialBuilder,
     connection_config: AsyncConnectionConfig,
+    /// Configured initialization pipeline (built from config)
+    init_pipeline: Option<Pipeline>,
     subscription_tracker: Option<Mutex<SubscriptionTracker>>,
     #[cfg(feature = "cache-aio")]
     cache_manager: Option<CacheManager>,
     _task_handle: HandleContainer,
+    security_config: SecurityConfig,
+    /// Readiness watch channel
+    ready_tx: ReadySender,
+    ready_rx: ReadyReceiver,
 }
 
 /// A `ConnectionManager` is a proxy that wraps a [multiplexed
@@ -247,8 +524,11 @@ struct Internals {
 #[derive(Clone)]
 pub struct ConnectionManager(Arc<Internals>);
 
-/// Type alias for a shared boxed future that will resolve to a `RedisResult`.
-type SharedRedisFuture<T> = Shared<BoxFuture<'static, RedisResult<T>>>;
+/// A `RedisResult` that can be cloned because `RedisError` is behind an `Arc`.
+type CloneableRedisResult<T> = Result<T, Arc<RedisError>>;
+
+/// Type alias for a shared boxed future that will resolve to a `CloneableRedisResult`.
+type SharedRedisFuture<T> = Shared<BoxFuture<'static, CloneableRedisResult<T>>>;
 
 /// Handle a command result. If the connection was dropped, reconnect.
 macro_rules! reconnect_if_dropped {
@@ -275,6 +555,30 @@ macro_rules! reconnect_if_io_error {
 }
 
 impl ConnectionManager {
+    /// Wait until the connection is fully initialized (post-connect init completed)
+    pub async fn await_ready(&self) -> RedisResult<()> {
+        let mut rx = self.0.ready_rx.clone();
+        loop {
+            // Take a snapshot without holding the borrow across await
+            let snapshot = { rx.borrow().clone() };
+            match snapshot {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    if e.kind() == crate::ErrorKind::ClientError {
+                        if rx.changed().await.is_err() {
+                            return Err(
+                                (crate::ErrorKind::IoError, "readiness channel closed").into()
+                            );
+                        }
+                        continue;
+                    } else {
+                        return Err((*e).clone_mostly("await_ready"));
+                    }
+                }
+            }
+        }
+    }
+
     /// Connect to the server and store the connection inside the returned `ConnectionManager`.
     ///
     /// This requires the `connection-manager` feature, which will also pull in
@@ -292,7 +596,105 @@ impl ConnectionManager {
     ///
     /// In case of reconnection issues, the manager will retry reconnection
     /// number_of_retries times, with an exponentially increasing delay, calculated as
-    /// min(max_delay, rand(0 .. min_delay * (exponent_base ^ current-try))).
+    /// rand(0 .. factor * (exponent_base ^ current-try)).
+    #[deprecated(note = "Use `new_with_config`")]
+    pub async fn new_with_backoff(
+        client: Client,
+        exponent_base: u64,
+        factor: u64,
+        number_of_retries: usize,
+    ) -> RedisResult<Self> {
+        let config = ConnectionManagerConfig::new()
+            .set_exponent_base(exponent_base)
+            .set_factor(factor)
+            .set_number_of_retries(number_of_retries);
+        Self::new_with_config(client, config).await
+    }
+
+    /// Connect to the server and store the connection inside the returned `ConnectionManager`.
+    ///
+    /// This requires the `connection-manager` feature, which will also pull in
+    /// the Tokio executor.
+    ///
+    /// In case of reconnection issues, the manager will retry reconnection
+    /// number_of_retries times, with an exponentially increasing delay, calculated as
+    /// rand(0 .. factor * (exponent_base ^ current-try)).
+    ///
+    /// The new connection will time out operations after `response_timeout` has passed.
+    /// Each connection attempt to the server will time out after `connection_timeout`.
+    #[deprecated(note = "Use `new_with_config`")]
+    pub async fn new_with_backoff_and_timeouts(
+        client: Client,
+        exponent_base: u64,
+        factor: u64,
+        number_of_retries: usize,
+        response_timeout: std::time::Duration,
+        connection_timeout: std::time::Duration,
+    ) -> RedisResult<Self> {
+        let config = ConnectionManagerConfig::new()
+            .set_exponent_base(exponent_base)
+            .set_factor(factor)
+            .set_number_of_retries(number_of_retries)
+            .set_response_timeout(response_timeout)
+            .set_connection_timeout(connection_timeout);
+
+        Self::new_with_config(client, config).await
+    }
+
+    /// Build initialization pipeline based on configuration (safe by default)
+    fn build_config_init_pipeline(config: &ConnectionManagerConfig) -> Option<Pipeline> {
+        let mut pipeline = Pipeline::new();
+        let mut has_any = false;
+
+        // CLIENT SETNAME (validated earlier in setter, but validate again defensively)
+        if let Some(name) = &config.client_name {
+            if validate_client_name(name, &config.security_config).is_ok() {
+                pipeline.cmd("CLIENT").arg("SETNAME").arg(name);
+                has_any = true;
+            }
+        }
+
+        // CLIENT SETINFO key/value pairs
+        if let Some(pairs) = &config.client_setinfo_pairs {
+            if !pairs.is_empty() {
+                let mut cmd = cmd("CLIENT");
+                cmd.arg("SETINFO");
+                for (k, v) in pairs.iter() {
+                    cmd.arg(k).arg(v);
+                }
+                pipeline.add_command(cmd);
+                has_any = true;
+            }
+        }
+
+        // User-provided pipeline only if arbitrary init is enabled
+        if config.allow_arbitrary_init_commands {
+            if let Some(user) = &config.user_init_pipeline {
+                // Append user commands as-is
+                for c in user.cmd_iter() {
+                    pipeline.add_command(c.clone());
+                    has_any = true;
+                }
+            }
+        }
+
+        if has_any {
+            Some(pipeline)
+        } else {
+            None
+        }
+    }
+
+    /// Connect to the server and store the connection inside the returned `ConnectionManager`.
+    ///
+    /// This requires the `connection-manager` feature, which will also pull in
+    /// the Tokio executor.
+    ///
+    /// In case of reconnection issues, the manager will retry reconnection
+    /// number_of_retries times, with an exponentially increasing delay, calculated as
+    /// rand(0 .. factor * (exponent_base ^ current-try)).
+    ///
+    /// Apply a maximum delay. No retry delay will be longer than this  ConnectionManagerConfig.max_delay` .
     ///
     /// The new connection will time out operations after `response_timeout` has passed.
     /// Each connection attempt to the server will time out after `connection_timeout`.
@@ -304,22 +706,26 @@ impl ConnectionManager {
         let runtime = Runtime::locate();
 
         if config.resubscribe_automatically && config.push_sender.is_none() {
-            return Err((crate::ErrorKind::Client, "Cannot set resubscribe_automatically without setting a push sender to receive messages.").into());
+            return Err((crate::ErrorKind::ClientError, "Cannot set resubscribe_automatically without setting a push sender to receive messages.").into());
         }
 
         let mut retry_strategy = ExponentialBuilder::default()
-            .with_factor(config.exponent_base)
-            .with_min_delay(config.min_delay)
+            .with_factor(config.factor as f32)
             .with_max_times(config.number_of_retries)
             .with_jitter();
         if let Some(max_delay) = config.max_delay {
-            retry_strategy = retry_strategy.with_max_delay(max_delay);
+            retry_strategy =
+                retry_strategy.with_max_delay(std::time::Duration::from_millis(max_delay));
         }
 
-        let mut connection_config = AsyncConnectionConfig::new()
-            .set_connection_timeout(config.connection_timeout)
-            .set_response_timeout(config.response_timeout);
-
+        let mut connection_config = AsyncConnectionConfig::new();
+        if let Some(connection_timeout) = config.connection_timeout {
+            connection_config = connection_config.set_connection_timeout(connection_timeout);
+        }
+        if let Some(response_timeout) = config.response_timeout {
+            connection_config = connection_config.set_response_timeout(response_timeout);
+        }
+        connection_config = connection_config.set_tcp_settings(config.tcp_settings.clone());
         #[cfg(feature = "cache-aio")]
         let cache_manager = config
             .cache_config
@@ -335,6 +741,11 @@ impl ConnectionManager {
             runtime.spawn(Self::check_for_disconnect_pushes(oneshot_receiver)),
         );
 
+        // Early security validation (e.g., client name)
+        if let Some(ref name) = config.client_name {
+            validate_client_name(name, &config.security_config)?;
+        }
+
         let mut components_for_reconnection_on_push = None;
         if let Some(push_sender) = config.push_sender.clone() {
             check_resp3!(
@@ -348,6 +759,8 @@ impl ConnectionManager {
             connection_config =
                 connection_config.set_push_sender_internal(Arc::new(internal_sender));
         } else if client.connection_info.redis.protocol != ProtocolVersion::RESP2 {
+            // await_ready will be defined later in impl block, not inside this function body.
+
             let (internal_sender, internal_receiver) = unbounded_channel();
             components_for_reconnection_on_push = Some((internal_receiver, None));
 
@@ -355,25 +768,55 @@ impl ConnectionManager {
                 connection_config.set_push_sender_internal(Arc::new(internal_sender));
         }
 
-        let connection =
-            Self::new_connection(&client, retry_strategy, &connection_config, None).await?;
+        // Build initial initialization pipeline from config (no resubscriptions on first connect)
+        let initial_init = Self::build_config_init_pipeline(&config);
+        let connection = Self::new_connection(
+            &client,
+            retry_strategy,
+            &connection_config,
+            initial_init,
+            &config.security_config,
+        )
+        .await?;
+        // Provide await_ready on the manager
+        // Note: method implemented below in the impl block
+
         let subscription_tracker = if config.resubscribe_automatically {
             Some(Mutex::new(SubscriptionTracker::default()))
         } else {
             None
         };
 
+        // Initialize readiness channel: start as not ready
+        let (ready_tx, ready_rx) = tokio::sync::watch::channel::<ReadyResult>(Err(Arc::new(
+            (crate::ErrorKind::ClientError, "not ready").into(),
+        )));
+
+        // Built init pipeline from config
+        let cfg_init = Self::build_config_init_pipeline(&config);
+
+        // Create initial ready shared future in the required CloneableRedisResult form
+        let initial_future: SharedRedisFuture<MultiplexedConnection> =
+            futures_util::future::ready(Ok(connection)).boxed().shared();
+
         let new_self = Self(Arc::new(Internals {
             client,
-            connection: ArcSwap::from_pointee(future::ok(connection).boxed().shared()),
+            connection: ArcSwap::from_pointee(initial_future),
             runtime,
             retry_strategy,
             connection_config,
+            init_pipeline: cfg_init,
             subscription_tracker,
             #[cfg(feature = "cache-aio")]
             cache_manager,
             _task_handle,
+            security_config: config.security_config,
+            ready_tx,
+            ready_rx,
         }));
+
+        // Mark as ready if there is no init pipeline; otherwise set OK (already executed in new_connection)
+        let _ = new_self.0.ready_tx.send(Ok(()));
 
         if let Some((internal_receiver, external_sender)) = components_for_reconnection_on_push {
             oneshot_sender
@@ -384,7 +827,7 @@ impl ConnectionManager {
                 ))
                 .map_err(|_| {
                     crate::RedisError::from((
-                        crate::ErrorKind::Client,
+                        crate::ErrorKind::ClientError,
                         "Failed to set automatic resubscription",
                     ))
                 })?;
@@ -398,6 +841,7 @@ impl ConnectionManager {
         exponential_backoff: ExponentialBuilder,
         connection_config: &AsyncConnectionConfig,
         additional_commands: Option<Pipeline>,
+        security_config: &SecurityConfig,
     ) -> RedisResult<MultiplexedConnection> {
         let connection_config = connection_config.clone();
         let get_conn = || async {
@@ -409,11 +853,57 @@ impl ConnectionManager {
             .retry(exponential_backoff)
             .sleep(|duration| async move { Runtime::locate().sleep(duration).await })
             .await?;
+
         if let Some(pipeline) = additional_commands {
-            // TODO - should we ignore these failures?
-            let _ = pipeline.exec_async(&mut conn).await;
+            // Execute initialization pipeline with timeout and enhanced error handling
+            Self::execute_init_pipeline(&mut conn, pipeline, security_config).await?;
         }
         Ok(conn)
+    }
+
+    /// Execute initialization pipeline with proper timeout and error handling
+    async fn execute_init_pipeline(
+        conn: &mut MultiplexedConnection,
+        pipeline: Pipeline,
+        security_config: &SecurityConfig,
+    ) -> RedisResult<()> {
+        let start_time = std::time::Instant::now();
+
+        // Use runtime timeout helper for portability across runtimes
+        let runtime = Runtime::locate();
+        let result = runtime
+            .timeout(security_config.init_timeout, pipeline.exec_async(conn))
+            .await
+            .map_err(crate::RedisError::from);
+
+        let duration = start_time.elapsed();
+
+        // Handle the result with enhanced error reporting
+        match result {
+            Ok(_values) => {
+                if let Some(monitor) = &security_config.resource_monitor {
+                    monitor.on_init_complete(duration, None);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                let init_error = InitializationError::new(
+                    "initialization_pipeline".to_string(),
+                    e,
+                    0, // retry count handled at higher level
+                );
+
+                if let Some(monitor) = &security_config.resource_monitor {
+                    monitor.on_init_failed(&init_error, duration);
+                }
+
+                Err(crate::RedisError::from((
+                    crate::ErrorKind::ClientError,
+                    "Initialization pipeline failed",
+                    format!("{}", init_error),
+                )))
+            }
+        }
     }
 
     /// Reconnect and overwrite the old connection.
@@ -437,8 +927,15 @@ impl ConnectionManager {
             let new_cache_manager = manager.clone_and_increase_epoch();
             connection_config = connection_config.set_cache_manager(new_cache_manager);
         }
+        // Set readiness to not ready during reconnect
+        let _ = internals.ready_tx.send(Err(Arc::new(
+            (crate::ErrorKind::ClientError, "reconnecting").into(),
+        )));
+
         let new_connection: SharedRedisFuture<MultiplexedConnection> = async move {
-            let additional_commands = match &internals_clone.subscription_tracker {
+            // Combine configured init pipeline with resubscriptions
+            let cfg_init = internals_clone.init_pipeline.clone();
+            let subs_pipe = match &internals_clone.subscription_tracker {
                 Some(subscription_tracker) => Some(
                     subscription_tracker
                         .lock()
@@ -447,15 +944,41 @@ impl ConnectionManager {
                 ),
                 None => None,
             };
+            let combined = match (cfg_init, subs_pipe) {
+                (None, None) => None,
+                (Some(p), None) => Some(p),
+                (None, Some(s)) => Some(s),
+                (Some(mut p), Some(s)) => {
+                    for c in s.cmd_iter() {
+                        p.add_command(c.clone());
+                    }
+                    Some(p)
+                }
+            };
 
-            let con = Self::new_connection(
+            let res = Self::new_connection(
                 &internals_clone.client,
                 internals_clone.retry_strategy,
                 &connection_config,
-                additional_commands,
+                combined,
+                &internals_clone.security_config,
             )
-            .await?;
-            Ok(con)
+            .await;
+
+            // Update readiness based on result
+            match &res {
+                Ok(_) => {
+                    let _ = internals_clone.ready_tx.send(Ok(()));
+                }
+                Err(e) => {
+                    let _ = internals_clone
+                        .ready_tx
+                        .send(Err(Arc::new(e.clone_mostly("reconnect"))));
+                }
+            }
+
+            // Convert to cloneable result for Shared
+            res.map_err(Arc::new)
         }
         .boxed()
         .shared();
@@ -501,7 +1024,10 @@ impl ConnectionManager {
     pub async fn send_packed_command(&mut self, cmd: &Cmd) -> RedisResult<Value> {
         // Clone connection to avoid having to lock the ArcSwap in write mode
         let guard = self.0.connection.load();
-        let connection_result = (**guard).clone().await.map_err(|e| e.clone());
+        let connection_result = (**guard)
+            .clone()
+            .await
+            .map_err(|e| e.clone_mostly("Reconnecting failed"));
         reconnect_if_io_error!(self, connection_result, guard);
         let result = connection_result?.send_packed_command(cmd).await;
         reconnect_if_dropped!(self, &result, guard);
@@ -519,7 +1045,10 @@ impl ConnectionManager {
     ) -> RedisResult<Vec<Value>> {
         // Clone shared connection future to avoid having to lock the ArcSwap in write mode
         let guard = self.0.connection.load();
-        let connection_result = (**guard).clone().await.map_err(|e| e.clone());
+        let connection_result = (**guard)
+            .clone()
+            .await
+            .map_err(|e| e.clone_mostly("Reconnecting failed"));
         reconnect_if_io_error!(self, connection_result, guard);
         let result = connection_result?
             .send_packed_commands(cmd, offset, count)
@@ -551,7 +1080,7 @@ impl ConnectionManager {
     /// This method is only available when the connection is using RESP3 protocol, and will return an error otherwise.
     /// It should be noted that unless [ConnectionManagerConfig::set_automatic_resubscription] was called,
     /// the subscription will be removed on a disconnect and must be re-subscribed.
-    ///  
+    ///
     /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1775,11 +1775,22 @@ impl Connection {
                 }
                 return result;
             };
-            // shutdown connection on protocol error
-            if io_error.kind() == io::ErrorKind::UnexpectedEof {
-                self.close_connection();
-            } else if is_response {
-                self.messages_to_skip += 1;
+            // Treat common OS-level disconnects as a closed connection across platforms
+            match io_error.kind() {
+                io::ErrorKind::UnexpectedEof
+                | io::ErrorKind::ConnectionReset
+                | io::ErrorKind::BrokenPipe
+                | io::ErrorKind::NotConnected
+                | io::ErrorKind::ConnectionAborted => {
+                    self.close_connection();
+                }
+                _ => {
+                    // For other errors during a response read, mark that we should skip one message
+                    // on the next successful read to keep parser state consistent.
+                    if is_response {
+                        self.messages_to_skip += 1;
+                    }
+                }
             }
 
             return result;

--- a/redis/tests/test_connection_manager_init.rs
+++ b/redis/tests/test_connection_manager_init.rs
@@ -1,0 +1,247 @@
+mod support;
+
+#[cfg(all(test, feature = "connection-manager"))]
+mod connection_manager_init {
+    use super::support::*;
+    use redis::aio::ConnectionLike;
+    use redis::{
+        self as redis_crate, aio::ConnectionManagerConfig, cmd, Client, ConnectionInfo,
+        RedisConnectionInfo, Value,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_client_setname_on_connect(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                config = config.set_client_name("cm_test_client".to_string());
+                let mut cm = client
+                    .get_connection_manager_with_config(config)
+                    .await
+                    .unwrap();
+
+                cm.await_ready().await.unwrap();
+
+                // Query CLIENT LIST and verify name
+                let list: String = cmd("CLIENT")
+                    .arg("LIST")
+                    .query_async(&mut cm)
+                    .await
+                    .unwrap();
+                assert!(list.contains("name=cm_test_client"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_reinit_after_reconnect(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                config = config.set_client_name("cm_reconnect".to_string());
+                let mut cm = client
+                    .get_connection_manager_with_config(config)
+                    .await
+                    .unwrap();
+
+                cm.await_ready().await.unwrap();
+
+                // Kill the client connection to force reconnect
+                let mut admin = ctx.async_connection().await.unwrap();
+                kill_client_async(&mut admin, &client).await.unwrap();
+
+                // Wait for readiness again
+                cm.await_ready().await.unwrap();
+
+                let list: String = cmd("CLIENT")
+                    .arg("LIST")
+                    .query_async(&mut cm)
+                    .await
+                    .unwrap();
+                assert!(list.contains("name=cm_reconnect"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_security_validation_too_large_name(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                // Create a very large name > 64KB
+                let big = "x".repeat(70 * 1024);
+                // Early validation should fail manager creation
+                config = config.set_client_name(big);
+                let cm_res = client.get_connection_manager_with_config(config).await;
+                let err = cm_res
+                    .err()
+                    .expect("expected error for oversized client name");
+                assert!(format!("{}", err).contains("Client name too large"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_timeout_behavior(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+                let mut config = ConnectionManagerConfig::new();
+                // Set very short init timeout
+                let sec = redis_crate::aio::SecurityConfig::new()
+                    .set_init_timeout(std::time::Duration::from_millis(10));
+                config = config.set_security_config(sec);
+                // Use a user pipeline that will delay deterministically (DEBUG SLEEP 2)
+                let mut p = redis_crate::pipe();
+                p.cmd("DEBUG").arg("SLEEP").arg(2);
+                config = config.enable_arbitrary_init_commands().set_init_pipeline(p);
+                let res = client.get_connection_manager_with_config(config).await;
+                let err = res
+                    .err()
+                    .expect("expected manager creation to fail due to init timeout");
+                let msg = format!("{}", err);
+                assert!(
+                    msg.contains("timed out") || msg.contains("Initialization pipeline failed"),
+                    "unexpected error: {}",
+                    msg
+                );
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_safe_vs_arbitrary_modes(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                let ctx = TestContext::new();
+                let client = ctx.client.clone();
+
+                // Safe mode: user pipeline ignored
+                let mut safe_cfg = ConnectionManagerConfig::new();
+                let mut p = redis_crate::pipe();
+                p.cmd("SET").arg("cm_flag").arg("1");
+                safe_cfg = safe_cfg.set_init_pipeline(p.clone());
+                let mut cm_safe = client
+                    .get_connection_manager_with_config(safe_cfg)
+                    .await
+                    .unwrap();
+                cm_safe.await_ready().await.unwrap();
+                let v: Option<String> = cmd("GET")
+                    .arg("cm_flag")
+                    .query_async(&mut cm_safe)
+                    .await
+                    .unwrap();
+                assert!(v.is_none());
+
+                // Arbitrary enabled: user pipeline executes
+                let arb_cfg = ConnectionManagerConfig::new()
+                    .enable_arbitrary_init_commands()
+                    .set_init_pipeline(p);
+                let mut cm_arb = client
+                    .get_connection_manager_with_config(arb_cfg)
+                    .await
+                    .unwrap();
+                cm_arb.await_ready().await.unwrap();
+                let v: String = cmd("GET")
+                    .arg("cm_flag")
+                    .query_async(&mut cm_arb)
+                    .await
+                    .unwrap();
+                assert_eq!(v, "1");
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+
+    #[rstest]
+    #[cfg(feature = "connection-manager")]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    fn test_auth_ordering(#[case] runtime: RuntimeType) {
+        block_on_all(
+            async move {
+                // Create a user requiring AUTH and ensure AUTH happens before init
+                let ctx = TestContext::new();
+                let mut admin_conn = ctx.async_connection().await.unwrap();
+
+                let username = "cmuser";
+                let password = "cmpass";
+
+                // Add a user with permissions and password
+                let mut set_user_cmd = redis_crate::Cmd::new();
+                set_user_cmd
+                    .arg("ACL")
+                    .arg("SETUSER")
+                    .arg(username)
+                    .arg("on")
+                    .arg("+acl")
+                    .arg("+client")
+                    .arg(format!(">{password}"));
+                assert_eq!(
+                    admin_conn.req_packed_command(&set_user_cmd).await,
+                    Ok(Value::Okay)
+                );
+
+                let client = Client::open(ConnectionInfo {
+                    addr: ctx.server.client_addr().clone(),
+                    redis: RedisConnectionInfo {
+                        username: Some(username.to_string()),
+                        password: Some(password.to_string()),
+                        ..Default::default()
+                    },
+                })
+                .unwrap();
+
+                let mut config = ConnectionManagerConfig::new();
+                config = config.set_client_name("auth_name".to_string());
+                let mut cm = client
+                    .get_connection_manager_with_config(config)
+                    .await
+                    .unwrap();
+                cm.await_ready().await.unwrap();
+
+                // If AUTH occurred after init, SETNAME would fail. By reaching here, ordering is correct.
+                let list: String = cmd("CLIENT")
+                    .arg("LIST")
+                    .query_async(&mut cm)
+                    .await
+                    .unwrap();
+                assert!(list.contains("name=auth_name"));
+                Ok::<(), redis_crate::RedisError>(())
+            },
+            runtime,
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
This PR replaces #1787 with a clean history based on 1.0.x.\n\nWhat\'s included:\n- feat: add ConnectionManager initialization pipeline with security enhancements\n  - Post-connect init pipeline for CLIENT SETNAME and SETINFO\n  - Configurable size limits and UTF-8 validation for client names\n  - Enhanced error handling for Redis protocol errors during init\n  - Resource monitoring hooks and timeout handling\n  - Comprehensive test suite for initialization pipeline\n  - Documentation and changelog updates\n\nNotes:\n- Branched from origin/1.0.x and cherry-picked 6ea554c196e975c8939c43efd40e4d17617ef5d5.\n- Resolved conflicts in Cargo.lock, Makefile, and redis/src/aio/connection_manager.rs to align with 1.0.x.\n\nAfter this is opened, we can close #1787.
