### PR TITLE
Fix `unreachable!` panics

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2098,10 +2098,10 @@ macro_rules! from_redis_value_for_tuple {
                     rv.push(($(from_redis_value_ref($name)?,)*));
                     return Ok(rv);
                 }
-                for chunk in items.chunks_exact(n) {
+                for chunk in items.chunks(n) {
                     match chunk {
                         [$($name),*] => rv.push(($(from_redis_value_ref($name)?,)*)),
-                         _ => {},
+                         _ => return Err(format!("Vector of length {} doesn't have arity of {n}", items.len()).into()),
                     }
                 }
                 Ok(rv)
@@ -2136,7 +2136,7 @@ macro_rules! from_redis_value_for_tuple {
                         // Since `items` is consumed by this function and not used later, this replacement
                         // is not observable to the rest of the code.
                         [$($name),*] => rv.push(extract(($(from_redis_value(std::mem::replace($name, Value::Nil)).into(),)*))),
-                         _ => unreachable!(),
+                         _ => return vec![Err(format!("Vector of length {} doesn't have arity of {n}", items.len()).into())],
                     }
                 }
                 rv
@@ -2164,7 +2164,7 @@ macro_rules! from_redis_value_for_tuple {
                         // Since `items` is consume by this function and not used later, this replacement
                         // is not observable to the rest of the code.
                         [$($name),*] => rv.push(($(from_redis_value(std::mem::replace($name, Value::Nil))?,)*)),
-                         _ => unreachable!(),
+                         _ => return Err(format!("Vector of length {} doesn't have arity of {n}", items.len()).into()),
                     }
                 }
                 Ok(rv)

--- a/redis/tests/test_types.rs
+++ b/redis/tests/test_types.rs
@@ -418,6 +418,20 @@ mod types {
     }
 
     #[test]
+    fn test_tuple_does_not_panic_if_vec_is_wrong_size() {
+        let val = Value::Array(vec![Value::Array(vec![
+            Value::BulkString("1".into()),
+            Value::BulkString("2".into()),
+            Value::BulkString("3".into()),
+        ])]);
+        for parse_mode in [RedisParseMode::Owned, RedisParseMode::Ref] {
+            parse_mode
+                .parse_redis_value::<Vec<(u8, u8)>>(val.clone())
+                .unwrap_err();
+        }
+    }
+
+    #[test]
     fn test_hashmap() {
         use fnv::FnvHasher;
         use std::collections::HashMap;


### PR DESCRIPTION
The code would've panicked when converting vectors with the wrong length into tuples.

https://github.com/redis-rs/redis-rs/issues/1837