### PR TITLE
Streams - Simplify the process of claiming pending entries by adding the CLAIM argument to the XREADGROUP command

### DIFF
--- a/redis/examples/streams.rs
+++ b/redis/examples/streams.rs
@@ -86,7 +86,7 @@ fn demo_group_reads(client: &redis::Client) {
 
                 // fake some expensive work
                 for StreamKey { key, ids } in read_reply.keys {
-                    for StreamId { id, map: _ } in &ids {
+                    for StreamId { id, map: _, .. } in &ids {
                         thread::sleep(Duration::from_millis(random_wait_millis(*slowness)));
                         println!(
                             "Stream {} ID {} Consumer slowness {} SysTime {}",
@@ -103,7 +103,7 @@ fn demo_group_reads(client: &redis::Client) {
                     // acknowledge each stream and message ID once all messages are
                     // correctly processed
                     let id_strs: Vec<&String> =
-                        ids.iter().map(|StreamId { id, map: _ }| id).collect();
+                        ids.iter().map(|StreamId { id, map: _, .. }| id).collect();
                     con.xack(key, GROUP_NAME, &id_strs).expect("ack")
                 }
             }
@@ -217,7 +217,7 @@ fn read_records(client: &redis::Client) -> RedisResult<()> {
 
     for StreamKey { key, ids } in srr.keys {
         println!("Stream {key}");
-        for StreamId { id, map } in ids {
+        for StreamId { id, map, .. } in ids {
             println!("\tID {id}");
             for (n, s) in map {
                 if let Value::BulkString(bytes) = s {

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -411,6 +411,7 @@ pub fn is_version(expected_major_minor: (u16, u16), version: Version) -> bool {
 // Redis version constants for version-gated tests
 pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
 pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
+pub const REDIS_VERSION_CE_8_4: Version = (8, 3, 224);
 
 /// Macro to run tests only if the Redis version meets the minimum requirement.
 /// If the version is insufficient, the test is skipped with a message.


### PR DESCRIPTION
# Streams: Simplify Pending Entries Claiming
## Summary

Redis 8.4 enhances stream processing with the **CLAIM** _min-idle-time_ option for [XREADGROUP](https://redis.io/docs/latest/commands/xreadgroup/). This feature enables consumer groups to automatically claim and process both idle pending entries and new entries in one operation, simplifying consumer group management and improving processing efficiency.

---
# Changes introduced with this Pull Request:

## Extend the `XREADGROUP` Command with a new parameter - **CLAIM** _min-idle-time_

**Description:**
The new API of the `XREADGROUP` considers a new optional **CLAIM** _min-idle-time_ argument that accepts an integer type that represents a time interval in milliseconds. Setting this argument will extend the response of `XREAGROUP` with _PEL_ entries that are in the list for at least _min-idle-time_ milliseconds.

**Syntax:**
```
XREADGROUP GROUP group consumer [COUNT count][BLOCK milliseconds][NOACK][🆕CLAIM min-idle-time] STREAMS key [key ...] id [id ...]
```

**Reply extension:**
When **CLAIM** _min-idle-time_ is specified, each retrieved pending entry will also include additional information.

Reference: https://redis.io/docs/latest/commands/xreadgroup/#the-claim-option

## Tests
Unit tests have been added to ensure that the newly added option behaves as expected.