### PR TITLE
Add support for the MSETEX command

### DIFF
--- a/redis/src/cluster_handling/sync_connection/pipeline.rs
+++ b/redis/src/cluster_handling/sync_connection/pipeline.rs
@@ -22,7 +22,7 @@ fn is_illegal_cmd(cmd: &str) -> bool {
         "INFO" |
         "KEYS" |
         "LASTSAVE" |
-        "MGET" | "MOVE" | "MSET" | "MSETNX" |
+        "MGET" | "MOVE" | "MSET" | "MSETNX" | "MSETEX" |
         "PING" | "PUBLISH" |
         "RANDOMKEY" | "RENAME" | "RENAMENX" | "RPOPLPUSH" |
         "SAVE" | "SCAN" |
@@ -61,7 +61,7 @@ pub struct ClusterPipeline {
 /// INFO
 /// KEYS
 /// LASTSAVE
-/// MGET, MOVE, MSET, MSETNX
+/// MGET, MOVE, MSET, MSETNX, MSETEX
 /// PING, PUBLISH
 /// RANDOMKEY, RENAME, RENAMENX, RPOPLPUSH
 /// SAVE, SCAN, SCRIPT EXISTS, SCRIPT FLUSH, SCRIPT KILL, SCRIPT LOAD, SDIFF, SDIFFSTORE,

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -640,7 +640,7 @@ pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{cmd, pack_command, pipe, Arg, Cmd, Iter};
 pub use crate::commands::{
     Commands, ControlFlow, CopyOptions, Direction, FlushAllOptions, FlushDbOptions,
-    HashFieldExpirationOptions, LposOptions, PubSubCommands, ScanOptions, SetOptions,
+    HashFieldExpirationOptions, LposOptions, MSetOptions, PubSubCommands, ScanOptions, SetOptions,
     SortedSetAddOptions, TypedCommands, UpdateCheck,
 };
 pub use crate::connection::{

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -47,6 +47,35 @@ pub enum SetExpiry {
     KEEPTTL,
 }
 
+impl ToRedisArgs for SetExpiry {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            SetExpiry::EX(secs) => {
+                out.write_arg(b"EX");
+                out.write_arg(format!("{secs}").as_bytes());
+            }
+            SetExpiry::PX(millis) => {
+                out.write_arg(b"PX");
+                out.write_arg(format!("{millis}").as_bytes());
+            }
+            SetExpiry::EXAT(unix_time) => {
+                out.write_arg(b"EXAT");
+                out.write_arg(format!("{unix_time}").as_bytes());
+            }
+            SetExpiry::PXAT(unix_time) => {
+                out.write_arg(b"PXAT");
+                out.write_arg(format!("{unix_time}").as_bytes());
+            }
+            SetExpiry::KEEPTTL => {
+                out.write_arg(b"KEEPTTL");
+            }
+        }
+    }
+}
+
 /// Helper enum that is used to define existence checks
 #[derive(Clone, Copy)]
 #[non_exhaustive]
@@ -57,6 +86,22 @@ pub enum ExistenceCheck {
     XX,
 }
 
+impl ToRedisArgs for ExistenceCheck {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            ExistenceCheck::NX => {
+                out.write_arg(b"NX");
+            }
+            ExistenceCheck::XX => {
+                out.write_arg(b"XX");
+            }
+        }
+    }
+}
+
 /// Helper enum that is used to define field existence checks
 #[derive(Clone, Copy)]
 #[non_exhaustive]
@@ -65,6 +110,18 @@ pub enum FieldExistenceCheck {
     FNX,
     /// FXX -- Only set the fields if all already exist.
     FXX,
+}
+
+impl ToRedisArgs for FieldExistenceCheck {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            FieldExistenceCheck::FNX => out.write_arg(b"FNX"),
+            FieldExistenceCheck::FXX => out.write_arg(b"FXX"),
+        }
+    }
 }
 
 /// Helper enum that is used in some situations to describe


### PR DESCRIPTION
# Add support for the MSETEX command
## Summary
Redis 8.4 introduces the [MSETEX](https://redis.io/docs/latest/commands/msetex/) command. It is an extension to the [MSETNX](https://redis.io/docs/latest/commands/msetnx/) command, which allows multiple string keys to be set with an optional shared expiration in a single atomic operation.

## Command Specifications
**Description**:
Set multiple string keys with an optional shared expiration in a single atomic operation.

**Syntax**:
```
MSETEX numkeys key value [key value ...] 
[NX | XX] [EX seconds |  PX milliseconds | EXAT unix-time-seconds |  PXAT unix-time-milliseconds | KEEPTTL]
```
**Options**:

- Existence options:
**NX** -- Only set the keys and their expiration time if **none** of them already exist.
**XX** -- Only set the keys and their expiration time if **all** of them already exist.

- Expiration options:
**EX** _seconds_ -- Set expiration time in seconds.
**PX** _milliseconds_ -- Set expiration time in milliseconds.
**EXAT** _timestamp-seconds_ -- Set absolute Unix expiration time (seconds).
**PXAT** _timestamp-milliseconds_ -- Set absolute Unix expiration time (milliseconds).
**KEEPTTL** -- Retain the time to live associated with the key(s).

**Reply**:
Integer reply:
`0` – No keys were set.
`1` – All keys were successfully set.

## Testing
Unit tests have been added to verify the correct behavior of the command.

## Additional Changes:
Implemented the `ToRedisArgs` trait for some of the existing `enums` to reduce code duplication.

## References:
Official documentation of the command - [MSETEX](https://redis.io/docs/latest/commands/msetex/)

Relevant Pull Requests from the Redis server:
[Use fixed position keys parameter for MSETEX command](https://github.com/redis/redis/pull/14470)
[Add MSETEX command](https://github.com/redis/redis/pull/14434)