### PR TITLE
Return an error when receiving an empty command/pipeline.

### DIFF
--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -420,6 +420,10 @@ impl Pipeline {
         timeout: Option<Duration>,
         skip_response: bool,
     ) -> Result<Value, RedisError> {
+        if input.is_empty() {
+            return Err(RedisError::make_empty_command());
+        }
+
         let request = async {
             if skip_response {
                 self.sender
@@ -651,6 +655,9 @@ impl MultiplexedConnection {
         if let Some(cache_manager) = &self.cache_manager {
             let (cacheable_pipeline, pipeline, (skipped_response_count, expected_response_count)) =
                 cache_manager.get_cached_pipeline(cmd);
+            if pipeline.is_empty() {
+                return cacheable_pipeline.resolve(cache_manager, Value::Array(Vec::new()));
+            }
             let result = self
                 .pipeline
                 .send_recv(

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -1010,11 +1010,17 @@ impl<C: Connect + ConnectionLike> ConnectionLike for ClusterConnection<C> {
     }
 
     fn req_command(&mut self, cmd: &Cmd) -> RedisResult<Value> {
+        if cmd.is_empty() {
+            return Err(RedisError::make_empty_command());
+        }
         let routing = RoutingInfo::for_routable(cmd);
         self.request(Input::Cmd(cmd), routing).map(|res| res.into())
     }
 
     fn req_packed_command(&mut self, cmd: &[u8]) -> RedisResult<Value> {
+        if cmd.is_empty() {
+            return Err(RedisError::make_empty_command());
+        }
         let actual_cmd = if cmd.starts_with(MULTI) {
             &cmd[MULTI.len()..]
         } else {
@@ -1038,6 +1044,9 @@ impl<C: Connect + ConnectionLike> ConnectionLike for ClusterConnection<C> {
         offset: usize,
         count: usize,
     ) -> RedisResult<Vec<Value>> {
+        if cmd.is_empty() {
+            return Err(RedisError::make_empty_command());
+        }
         let actual_cmd = if cmd.starts_with(MULTI) {
             &cmd[MULTI.len()..]
         } else {

--- a/redis/src/cluster_handling/sync_connection/pipeline.rs
+++ b/redis/src/cluster_handling/sync_connection/pipeline.rs
@@ -2,6 +2,7 @@ use super::ClusterConnection;
 use crate::cmd::{cmd, Cmd};
 use crate::errors::ErrorKind;
 use crate::types::{from_redis_value, FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value};
+use crate::RedisError;
 
 pub(crate) const UNROUTABLE_ERROR: (ErrorKind, &str) = (
     ErrorKind::Client,
@@ -120,7 +121,7 @@ impl ClusterPipeline {
         }
 
         if self.commands.is_empty() {
-            Ok(from_redis_value(Value::Array(vec![]))?)
+            Err(RedisError::make_empty_command())
         } else {
             self.compose_response(con.execute_pipeline(self)?)
         }

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -583,6 +583,9 @@ impl Cmd {
     #[inline]
     pub fn get_packed_command(&self) -> Vec<u8> {
         let mut cmd = Vec::new();
+        if self.is_empty() {
+            return cmd;
+        }
         self.write_packed_command(&mut cmd);
         cmd
     }
@@ -801,6 +804,10 @@ impl Cmd {
     pub(crate) fn get_cache_config(&self) -> &Option<CommandCacheConfig> {
         &self.cache
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.args.is_empty()
+    }
 }
 
 /// Shortcut function to creating a command with a single argument.
@@ -931,7 +938,7 @@ mod tests {
         // Everything should be reset, but the capacity should still be there
         assert!(cmd.data.is_empty());
         assert!(cmd.data.capacity() > 0);
-        assert!(cmd.args.is_empty());
+        assert!(cmd.is_empty());
         assert!(cmd.args.capacity() > 0);
         assert_eq!(cmd.cursor, None);
         assert!(!cmd.no_response);
@@ -951,7 +958,7 @@ mod tests {
         // Everything should be reset, but the capacity should still be there
         assert!(cmd.data.is_empty());
         assert!(cmd.data.capacity() > 0);
-        assert!(cmd.args.is_empty());
+        assert!(cmd.is_empty());
         assert!(cmd.args.capacity() > 0);
         assert_eq!(cmd.cursor, None);
         assert!(!cmd.no_response);

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -1833,6 +1833,9 @@ impl Connection {
     }
 
     fn send_bytes(&mut self, bytes: &[u8]) -> RedisResult<Value> {
+        if bytes.is_empty() {
+            return Err(RedisError::make_empty_command());
+        }
         let result = self.con.send_bytes(bytes);
         if self.protocol.supports_resp3() {
             if let Err(e) = &result {

--- a/redis/src/errors/redis_error.rs
+++ b/redis/src/errors/redis_error.rs
@@ -477,6 +477,12 @@ impl RedisError {
             repr: ErrorRepr::TransactionAborted(Arc::from(errs)),
         }
     }
+
+    pub(crate) fn make_empty_command() -> Self {
+        Self {
+            repr: ErrorRepr::General(ErrorKind::Client, "empty command", None),
+        }
+    }
 }
 
 /// Creates a new Redis error with the `Extension` kind.

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -182,9 +182,7 @@ impl Pipeline {
             ));
         }
 
-        let response = if self.commands.is_empty() {
-            vec![]
-        } else if self.transaction_mode {
+        let response = if self.transaction_mode {
             con.req_packed_commands(
                 &encode_pipeline(&self.commands, true),
                 self.commands.len() + 1,
@@ -208,9 +206,7 @@ impl Pipeline {
         &self,
         con: &mut impl crate::aio::ConnectionLike,
     ) -> RedisResult<T> {
-        let response = if self.commands.is_empty() {
-            vec![]
-        } else if self.transaction_mode {
+        let response = if self.transaction_mode {
             con.req_packed_commands(self, self.commands.len() + 1, 1)
                 .await?
         } else {

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -1871,4 +1871,26 @@ mod basic_async {
 
         Ok(())
     }
+
+    #[async_test]
+    async fn fail_on_empty_command() -> RedisResult<()> {
+        let ctx = TestContext::new();
+        let mut connection = ctx.async_connection().await.unwrap();
+
+        let error: RedisError = redis::Pipeline::new()
+            .query_async::<String>(&mut connection)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Client);
+        assert_eq!(error.to_string(), "empty command - Client");
+
+        let error: RedisError = redis::Cmd::new()
+            .query_async::<String>(&mut connection)
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Client);
+        assert_eq!(error.to_string(), "empty command - Client");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
The server won't respond when receiving an empty command, and the expectation of the sender is also unclear in such a situation. It's simpler to forbid it than try to guess the right expected behavior.