### PR TITLE
Fix handling transactions in async cluster.

### DIFF
--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -366,6 +366,25 @@ mod cluster_async {
         assert_eq!(res, "OK");
         let res: Vec<String> = connection.mget(&["baz", "foo", "bar"]).await?;
         assert_eq!(res, vec!["bazz", "bar", "foo"]);
+
+        Ok::<_, RedisError>(())
+    }
+
+    #[async_test]
+    async fn async_cluster_can_run_a_transaction() -> RedisResult<()> {
+        let cluster = TestClusterContext::new();
+
+        let mut connection = cluster.async_connection().await;
+
+        let result: Vec<Value> = redis::pipe()
+            .atomic()
+            .set("foo", b"bar")
+            .expire("foo", 10)
+            .query_async(&mut connection)
+            .await?;
+
+        assert_eq!(result, vec![Value::Okay, Value::Int(1)]);
+
         Ok::<_, RedisError>(())
     }
 


### PR DESCRIPTION
The logic assumed that the number of commands in the transaction matched the number of returned values, but in a transaction the raw returned values is an array with a single value, which is another array.

fixes https://github.com/redis-rs/redis-rs/issues/1899