### PR TITLE
only assert unconsumed commands on drop of last reference counted ins…

### DIFF
--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -191,7 +191,10 @@ impl MockRedisConnection {
 impl Drop for MockRedisConnection {
     fn drop(&mut self) {
         if self.assert_is_empty_on_drop {
-            assert!(self.commands.lock().unwrap().back().is_none());
+            let commands = self.commands.lock().unwrap();
+            if Arc::strong_count(&self.commands) == 1 {
+                assert!(commands.back().is_none());
+            }
         }
     }
 }


### PR DESCRIPTION
Bugfix for #1898: There I added the possibility let the MockRedisConnection assert that all the commands have been consumed on drop(). But I forgot, that a MockRedisConnection may be cloned, whereas the commands will be shared via the Arc. Therefore the assert must only be applied at the drop() of the last reference holder of the commands Arc.