### PR TITLE
test-macros needs syn full

### DIFF
--- a/test-macros/Cargo.toml
+++ b/test-macros/Cargo.toml
@@ -8,4 +8,4 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.44"
-syn = "2.0.114"
+syn = { version="2.0.114", features=["full"] }


### PR DESCRIPTION
Without this, `cargo build` gets the following
```
error[E0433]: failed to resolve: could not find `FnArg` in `syn`
   --> test-macros/src/lib.rs:13:23
    |
 13 |         let Some(syn::FnArg::Typed(pat_type)) = item.sig.inputs.last() else {
    |                       ^^^^^ could not find `FnArg` in `syn`
    |
note: found an item that was configured out
   --> /home/palfrey/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.114/src/lib.rs:429:5
    |
426 | #[cfg(feature = "full")]
    |       ---------------- the item is gated behind the `full` feature
...
429 |     FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
    |     ^^^^^

error[E0425]: cannot find type `ItemFn` in crate `syn`
   --> test-macros/src/lib.rs:6:54
    |
  6 |     let item = syn::parse_macro_input!(input as syn::ItemFn);
    |                                                      ^^^^^^ not found in `syn`
    |
note: found an item that was configured out
   --> /home/palfrey/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/syn-2.0.114/src/lib.rs:431:43
    |
426 | #[cfg(feature = "full")]
    |       ---------------- the item is gated behind the `full` feature
...
431 |     ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
    |                                           ^^^^^^

Some errors have detailed explanations: E0425, E0433.
For more information about an error, try `rustc --explain E0425`.
```

Although `cargo build --tests` was fine, which implies something was pulling in the required feature elsewhere.