### PR TITLE
[token-based authentication] Require explicit credentials provider per connection

### DIFF
--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -602,7 +602,7 @@ impl MultiplexedConnection {
         let connection_info = connection_info.clone();
 
         #[cfg(feature = "token-based-authentication")]
-        if let Some(ref credentials_provider) = connection_info.credentials_provider {
+        if let Some(ref credentials_provider) = config.credentials_provider {
             // Retrieve the initial credentials from the provider and apply them to the connection info
             match credentials_provider.subscribe().next().await {
                 Some(Ok(credentials)) => {
@@ -662,7 +662,7 @@ impl MultiplexedConnection {
 
         // Set up streaming credentials subscription if provider is available
         #[cfg(feature = "token-based-authentication")]
-        if let Some(streaming_provider) = connection_info.credentials_provider {
+        if let Some(streaming_provider) = config.credentials_provider {
             let mut inner_connection = con.clone();
             let re_authentication_failed_arc = Arc::clone(&con.re_authentication_failed);
             let mut stream = streaming_provider.subscribe();

--- a/redis/src/errors/redis_error.rs
+++ b/redis/src/errors/redis_error.rs
@@ -218,7 +218,7 @@ impl fmt::Display for RedisError {
 }
 
 /// What method should be used if retrying this request.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum RetryMethod {
     /// Create a fresh connection, since the current connection is no longer usable.

--- a/redis/tests/test_auth.rs
+++ b/redis/tests/test_auth.rs
@@ -62,9 +62,13 @@ mod entra_id_tests {
         init_logger();
         provider.start(RetryConfig::default());
 
-        let client = Client::open_with_credentials_provider(get_redis_url(), provider).unwrap();
+        let client = Client::open(get_redis_url()).unwrap();
+        let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
 
-        let mut con = client.get_multiplexed_async_connection().await.unwrap();
+        let mut con = client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await
+            .unwrap();
 
         redis::cmd("SET")
             .arg(test_key)

--- a/redis/tests/test_credentials_provider_failures.rs
+++ b/redis/tests/test_credentials_provider_failures.rs
@@ -109,9 +109,12 @@ mod credentials_provider_failures_tests {
         let ctx = TestContext::new();
 
         let provider = ImmediatelyFailingCredentialsProvider;
-        let client = ctx.client.with_credentials_provider(provider);
+        let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
 
-        let result = client.get_multiplexed_async_connection().await;
+        let result = ctx
+            .client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await;
 
         assert!(
             result.is_err(),
@@ -128,9 +131,12 @@ mod credentials_provider_failures_tests {
         let ctx = TestContext::new();
 
         let provider = EmptyStreamCredentialsProvider;
-        let client = ctx.client.with_credentials_provider(provider);
+        let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
 
-        let result = client.get_multiplexed_async_connection().await;
+        let result = ctx
+            .client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await;
 
         assert!(
             result.is_err(),
@@ -147,10 +153,11 @@ mod credentials_provider_failures_tests {
         let ctx = TestContext::new();
 
         let provider = OneTimeCredentialsProvider;
-        let client = ctx.client.with_credentials_provider(provider);
+        let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
 
-        let mut con = client
-            .get_multiplexed_async_connection()
+        let mut con = ctx
+            .client
+            .get_multiplexed_async_connection_with_config(&config)
             .await
             .expect("Initial connection should succeed.");
 
@@ -181,10 +188,11 @@ mod credentials_provider_failures_tests {
         let ctx = TestContext::new();
 
         let provider = DelayedFailureCredentialsProvider;
-        let client = ctx.client.with_credentials_provider(provider);
+        let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
 
-        let mut con = client
-            .get_multiplexed_async_connection()
+        let mut con = ctx
+            .client
+            .get_multiplexed_async_connection_with_config(&config)
             .await
             .expect("Initial connection should succeed.");
 


### PR DESCRIPTION
# Require explicit credentials provider per connection

This is an API refactoring required to support the overall `token-based-authentication` changes without introducing breaking changes to the library.

## What changes?

The way of obtaining a connection that would automatically re-authenticate itself when new credentials are provided from the credentials provider.

### Before:
Previously, connections were created from a client that already had a credentials provider attached, so each connection implicitly leveraged that provider.

``` rust
let client = Client::open_with_credentials_provider(get_redis_url(), provider).unwrap();
let mut con = client.get_multiplexed_async_connection().await.unwrap();
```

---

### After:
With the new approach, each connection must be explicitly configured with its own credentials provider instead of implicitly inheriting it from the client.

``` rust
let client = Client::open(get_redis_url()).unwrap();
let config = redis::AsyncConnectionConfig::new().set_credentials_provider(provider);
let mut con = client.get_multiplexed_async_connection_with_config(&config).await.unwrap();
```

## Why were the initial changes breaking?

The `TokenCredential` trait from the `azure_core` crate, which is used by `EntraIdCredentialsProvider`, does not implement `UnwindSafe`. As a result, any type containing it also becomes `!UnwindSafe`.

Modifying `RedisConnectionInfo` to include an `Arc<dyn StreamingCredentialsProvider>` caused it to become `!UnwindSafe`, which in turn made `Client` `!UnwindSafe` as well. Because these structs are public and this changes their auto trait implementations, the modification constitutes a breaking change.

## Why aren't the new changes breaking?

`AsyncConnectionConfig` was already `!UnwindSafe`. Adding a new field that is also `!UnwindSafe` does not change its auto trait behavior.

Because the struct’s `UnwindSafe` status remains unchanged, this modification does not introduce a breaking change.