### PR TITLE
ValueType: Add missing possible types

### DIFF
--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2578,6 +2578,8 @@ pub enum ValueType {
     TopK,
     /// A time series. [Redis Docs](https://redis.io/docs/latest/develop/data-types/timeseries/)
     TimeSeries,
+    /// A Trie. [Redis Docs](https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/autocomplete/)
+    Trie,
     /// Any other value type not explicitly defined in [Redis Docs](https://redis.io/docs/latest/commands/type/)
     Unknown(String),
 }
@@ -2601,6 +2603,8 @@ impl<T: AsRef<str>> From<T> for ValueType {
             "MBbloomCF" => ValueType::CuckooFilter,
             "TDIS-TYPE" => ValueType::TDigest,
             "TopK-TYPE" => ValueType::TopK,
+            // Search module
+            "trietype0" => ValueType::Trie,
             // Timeseries module
             "TSDB-TYPE" => ValueType::TimeSeries,
             // Fallback
@@ -2628,6 +2632,8 @@ impl From<ValueType> for String {
             ValueType::TDigest => "TDIS-TYPE".to_string(),
             ValueType::TopK => "TopK-TYPE".to_string(),
             ValueType::CountMin => "CMSk-TYPE".to_string(),
+            // Search module
+            ValueType::Trie => "trietype0".to_string(),
             // Timeseries module
             ValueType::TimeSeries => "TSDB-TYPE".to_string(),
             // Fallback

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2548,6 +2548,8 @@ pub(crate) type SyncPushSender = std::sync::mpsc::Sender<PushInfo>;
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum ValueType {
+    /// Key does not have a value
+    None,
     /// Generally returned by anything that returns a single element. [Redis Docs](https://redis.io/docs/latest/develop/data-types/strings/)
     String,
     /// A list of String values. [Redis Docs](https://redis.io/docs/latest/develop/data-types/lists/)
@@ -2569,6 +2571,7 @@ pub enum ValueType {
 impl<T: AsRef<str>> From<T> for ValueType {
     fn from(s: T) -> Self {
         match s.as_ref() {
+            "none" => ValueType::None,
             "string" => ValueType::String,
             "list" => ValueType::List,
             "set" => ValueType::Set,
@@ -2584,6 +2587,7 @@ impl<T: AsRef<str>> From<T> for ValueType {
 impl From<ValueType> for String {
     fn from(v: ValueType) -> Self {
         match v {
+            ValueType::None => "none".to_string(),
             ValueType::String => "string".to_string(),
             ValueType::List => "list".to_string(),
             ValueType::Set => "set".to_string(),

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2566,6 +2566,16 @@ pub enum ValueType {
     VectorSet,
     /// A RedisJSON value. [Redis Docs](https://redis.io/docs/latest/develop/data-types/json/)
     JSON,
+    /// A Bloom filter. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/bloom-filter/)
+    BloomFilter,
+    /// A Cuckoo filter. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/cuckoo-filter/)
+    CuckooFilter,
+    /// A Count-min. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/count-min-sketch/)
+    CountMin,
+    /// A t-Digest. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/t-digest/)
+    TDigest,
+    /// A Top-K. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/top-k/)
+    TopK,
     /// Any other value type not explicitly defined in [Redis Docs](https://redis.io/docs/latest/commands/type/)
     Unknown(String),
 }
@@ -2581,7 +2591,15 @@ impl<T: AsRef<str>> From<T> for ValueType {
             "hash" => ValueType::Hash,
             "stream" => ValueType::Stream,
             "vectorset" => ValueType::VectorSet,
+            // JSON module
             "ReJSON-RL" => ValueType::JSON,
+            // Bloom module
+            "CMSk-TYPE" => ValueType::CountMin,
+            "MBbloom--" => ValueType::BloomFilter,
+            "MBbloomCF" => ValueType::CuckooFilter,
+            "TDIS-TYPE" => ValueType::TDigest,
+            "TopK-TYPE" => ValueType::TopK,
+            // Fallback
             s => ValueType::Unknown(s.to_string()),
         }
     }
@@ -2598,7 +2616,15 @@ impl From<ValueType> for String {
             ValueType::Hash => "hash".to_string(),
             ValueType::Stream => "stream".to_string(),
             ValueType::VectorSet => "vectorset".to_string(),
+            // JSON module
             ValueType::JSON => "ReJSON-RL".to_string(),
+            // Bloom module
+            ValueType::BloomFilter => "MBbloom--".to_string(),
+            ValueType::CuckooFilter => "MBbloomCF".to_string(),
+            ValueType::TDigest => "TDIS-TYPE".to_string(),
+            ValueType::TopK => "TopK-TYPE".to_string(),
+            ValueType::CountMin => "CMSk-TYPE".to_string(),
+            // Fallback
             ValueType::Unknown(s) => s,
         }
     }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2566,8 +2566,8 @@ pub enum ValueType {
     VectorSet,
     /// A RedisJSON value. [Redis Docs](https://redis.io/docs/latest/develop/data-types/json/)
     JSON,
-    /// A Bloom filter. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/bloom-filter/)
-    BloomFilter,
+    /// A Bloom filter from Redis' module. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/bloom-filter/)
+    BloomFilterRedis,
     /// A Cuckoo filter. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/cuckoo-filter/)
     CuckooFilter,
     /// A Count-min. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/count-min-sketch/)
@@ -2580,6 +2580,8 @@ pub enum ValueType {
     TimeSeries,
     /// A Trie. [Redis Docs](https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/autocomplete/)
     Trie,
+    /// A Bloom filter from Valkey's module. [ValKey Docs](https://valkey.io/topics/bloomfilters/)
+    BloomFilterValKey,
     /// Any other value type not explicitly defined in [Redis Docs](https://redis.io/docs/latest/commands/type/)
     Unknown(String),
 }
@@ -2597,9 +2599,9 @@ impl<T: AsRef<str>> From<T> for ValueType {
             "vectorset" => ValueType::VectorSet,
             // JSON module
             "ReJSON-RL" => ValueType::JSON,
-            // Bloom module
+            // Bloom module (Redis)
             "CMSk-TYPE" => ValueType::CountMin,
-            "MBbloom--" => ValueType::BloomFilter,
+            "MBbloom--" => ValueType::BloomFilterRedis,
             "MBbloomCF" => ValueType::CuckooFilter,
             "TDIS-TYPE" => ValueType::TDigest,
             "TopK-TYPE" => ValueType::TopK,
@@ -2607,6 +2609,8 @@ impl<T: AsRef<str>> From<T> for ValueType {
             "trietype0" => ValueType::Trie,
             // Timeseries module
             "TSDB-TYPE" => ValueType::TimeSeries,
+            // Bloom module (ValKey)
+            "bloomfltr" => ValueType::BloomFilterValKey,
             // Fallback
             s => ValueType::Unknown(s.to_string()),
         }
@@ -2626,8 +2630,8 @@ impl From<ValueType> for String {
             ValueType::VectorSet => "vectorset".to_string(),
             // JSON module
             ValueType::JSON => "ReJSON-RL".to_string(),
-            // Bloom module
-            ValueType::BloomFilter => "MBbloom--".to_string(),
+            // Bloom module (Redis)
+            ValueType::BloomFilterRedis => "MBbloom--".to_string(),
             ValueType::CuckooFilter => "MBbloomCF".to_string(),
             ValueType::TDigest => "TDIS-TYPE".to_string(),
             ValueType::TopK => "TopK-TYPE".to_string(),
@@ -2636,6 +2640,8 @@ impl From<ValueType> for String {
             ValueType::Trie => "trietype0".to_string(),
             // Timeseries module
             ValueType::TimeSeries => "TSDB-TYPE".to_string(),
+            // Bloom module (ValKey)
+            ValueType::BloomFilterValKey => "bloomfltr".to_string(),
             // Fallback
             ValueType::Unknown(s) => s,
         }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2576,6 +2576,8 @@ pub enum ValueType {
     TDigest,
     /// A Top-K. [Redis Docs](https://redis.io/docs/latest/develop/data-types/probabilistic/top-k/)
     TopK,
+    /// A time series. [Redis Docs](https://redis.io/docs/latest/develop/data-types/timeseries/)
+    TimeSeries,
     /// Any other value type not explicitly defined in [Redis Docs](https://redis.io/docs/latest/commands/type/)
     Unknown(String),
 }
@@ -2599,6 +2601,8 @@ impl<T: AsRef<str>> From<T> for ValueType {
             "MBbloomCF" => ValueType::CuckooFilter,
             "TDIS-TYPE" => ValueType::TDigest,
             "TopK-TYPE" => ValueType::TopK,
+            // Timeseries module
+            "TSDB-TYPE" => ValueType::TimeSeries,
             // Fallback
             s => ValueType::Unknown(s.to_string()),
         }
@@ -2624,6 +2628,8 @@ impl From<ValueType> for String {
             ValueType::TDigest => "TDIS-TYPE".to_string(),
             ValueType::TopK => "TopK-TYPE".to_string(),
             ValueType::CountMin => "CMSk-TYPE".to_string(),
+            // Timeseries module
+            ValueType::TimeSeries => "TSDB-TYPE".to_string(),
             // Fallback
             ValueType::Unknown(s) => s,
         }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -2562,6 +2562,8 @@ pub enum ValueType {
     Hash,
     /// A Redis Stream. [Redis Docs](https://redis.io/docs/latest/develop/data-types/stream)
     Stream,
+    /// A vector set. [Redis Docs](https://redis.io/docs/latest/develop/data-types/vector-sets/)
+    VectorSet,
     /// A RedisJSON value. [Redis Docs](https://redis.io/docs/latest/develop/data-types/json/)
     JSON,
     /// Any other value type not explicitly defined in [Redis Docs](https://redis.io/docs/latest/commands/type/)
@@ -2578,6 +2580,7 @@ impl<T: AsRef<str>> From<T> for ValueType {
             "zset" => ValueType::ZSet,
             "hash" => ValueType::Hash,
             "stream" => ValueType::Stream,
+            "vectorset" => ValueType::VectorSet,
             "ReJSON-RL" => ValueType::JSON,
             s => ValueType::Unknown(s.to_string()),
         }
@@ -2594,6 +2597,7 @@ impl From<ValueType> for String {
             ValueType::ZSet => "zset".to_string(),
             ValueType::Hash => "hash".to_string(),
             ValueType::Stream => "stream".to_string(),
+            ValueType::VectorSet => "vectorset".to_string(),
             ValueType::JSON => "ReJSON-RL".to_string(),
             ValueType::Unknown(s) => s,
         }

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -160,6 +160,12 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
+        // The key does not have a value
+        let none_key_type = con
+            .key_type("foo")
+            .expect("getting the type should succeed");
+        assert_eq!(none_key_type, ValueType::None);
+
         //The key is a simple value
         redis::cmd("SET").arg("foo").arg(42).exec(&mut con).unwrap();
         let string_key_type = con.key_type("foo").unwrap();


### PR DESCRIPTION
Adding missing types is backwards incompatible. In order to keep the
number of such backward incompatible changes low, as many types as
possible get added in one go:

* `None` - for keys without value (was `Unknown("none")` before).
* `VectorSet` - for bundled vectorset module.
* `BloomFilter`, `CuckooFilter`, `CountMin`, `TDigest`, `TopK` from
  Redis' `bloom` module.
* `TimeSeries` from Redis' `timeseries` module.
* `Trie` from Redis' `search` module

Redis' `search` also defines `scdtype00`, and `ft_invidx0` which are
ignored as they do not occur in the keyspace and `ft_invidx`,
`numericdx`, and `ft_tagidx` which are omitted as they are legacy
types.

ValKey's `json` module uses the same type as Redis', so it is covered
as well.

ValKey's `search` module's indices live outside the keyspace. So they
do not need coverage.

None of the added types are currently covered by tests, as they rely
on modules to create suitable values.
