### PR TITLE
Remove the usage of tokio channels.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { version = "1", features = [
 
 # Only needed for the connection manager
 arc-swap = { version = "1.8.2", optional = true }
-futures-channel = { version = "0.3.31", optional = true }
+futures-channel = { version = "0.3.31", optional = true, features = ["sink"] }
 backon = { version = "1.6.0", optional = true, default-features = false }
 
 # Only needed for the r2d2 feature
@@ -138,7 +138,6 @@ tokio-native-tls-comp = ["tokio-comp", "tls-native-tls", "dep:tokio-native-tls"]
 tokio-rustls-comp = ["tokio-comp", "tls-rustls", "dep:tokio-rustls"]
 connection-manager = [
   "dep:arc-swap",
-  "dep:futures-channel",
   "aio",
   "dep:backon",
 ]
@@ -169,6 +168,7 @@ aio = [
   "tokio-util/codec",
   "combine/tokio",
   "dep:cfg-if",
+  "dep:futures-channel",
 ]
 
 [dev-dependencies]

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -12,13 +12,14 @@ use crate::{
     types::{RedisResult, Value},
 };
 use arc_swap::ArcSwap;
+use async_lock::Mutex;
 use backon::{ExponentialBuilder, Retryable};
+use futures_channel::mpsc::{UnboundedReceiver, unbounded};
 use futures_channel::oneshot;
 use futures_util::future::{BoxFuture, FutureExt, Shared};
+use futures_util::stream::StreamExt;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
-use tokio::sync::Mutex;
-use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
 type OptionalPushSender = Option<Arc<dyn AsyncPushSender>>;
 
@@ -491,13 +492,13 @@ impl ConnectionManager {
                 "Can only pass push sender to a connection using RESP3"
             );
 
-            let (internal_sender, internal_receiver) = unbounded_channel();
+            let (internal_sender, internal_receiver) = unbounded();
             components_for_reconnection_on_push = Some((internal_receiver, Some(push_sender)));
 
             connection_config =
                 connection_config.set_push_sender_internal(Arc::new(internal_sender));
         } else if client.connection_info.redis.protocol.supports_resp3() {
-            let (internal_sender, internal_receiver) = unbounded_channel();
+            let (internal_sender, internal_receiver) = unbounded();
             components_for_reconnection_on_push = Some((internal_receiver, None));
 
             connection_config =
@@ -647,7 +648,7 @@ impl ConnectionManager {
         let Ok((this, mut internal_receiver, external_sender)) = receiver.await else {
             return;
         };
-        while let Some(push_info) = internal_receiver.recv().await {
+        while let Some(push_info) = internal_receiver.next().await {
             if push_info.kind == PushKind::Disconnection {
                 let Some(internals) = this.upgrade() else {
                     return;

--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -185,6 +185,16 @@ pub trait AsyncPushSender: Send + Sync + 'static {
     fn send(&self, info: PushInfo) -> Result<(), SendError>;
 }
 
+impl AsyncPushSender for futures_channel::mpsc::UnboundedSender<PushInfo> {
+    fn send(&self, info: PushInfo) -> Result<(), SendError> {
+        match self.unbounded_send(info) {
+            Ok(_) => Ok(()),
+            Err(_) => Err(SendError),
+        }
+    }
+}
+
+// TODO - move to behind a feature, to allow removing the tokio dependency.
 impl AsyncPushSender for ::tokio::sync::mpsc::UnboundedSender<PushInfo> {
     fn send(&self, info: PushInfo) -> Result<(), SendError> {
         match self.send(info) {
@@ -194,6 +204,7 @@ impl AsyncPushSender for ::tokio::sync::mpsc::UnboundedSender<PushInfo> {
     }
 }
 
+// TODO - move to behind a feature, to allow removing the tokio dependency.
 impl AsyncPushSender for ::tokio::sync::broadcast::Sender<PushInfo> {
     fn send(&self, info: PushInfo) -> Result<(), SendError> {
         match self.send(info) {

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -11,10 +11,8 @@ use crate::{
     parser::ValueCodec,
     types::{RedisFuture, RedisResult, Value},
 };
-use ::tokio::{
-    io::{AsyncRead, AsyncWrite},
-    sync::{mpsc, oneshot},
-};
+use ::tokio::io::{AsyncRead, AsyncWrite};
+use futures_channel::{mpsc, oneshot};
 #[cfg(feature = "token-based-authentication")]
 use {
     crate::errors::ErrorKind,
@@ -26,8 +24,8 @@ use {
 use futures_util::{
     future::{Future, FutureExt},
     ready,
-    sink::Sink,
-    stream::{self, Stream, StreamExt},
+    sink::{Sink, SinkExt},
+    stream::{Stream, StreamExt},
 };
 use pin_project_lite::pin_project;
 use std::collections::VecDeque;
@@ -328,7 +326,7 @@ where
         // If initially a receiver was created, but then dropped, there is nothing to receive our output we do not need to send the message as it is
         // ambiguous whether the message will be sent anyway. Helps shed some load on the
         // connection.
-        if output.as_ref().is_some_and(|output| output.is_closed()) {
+        if output.as_ref().is_some_and(|output| output.is_canceled()) {
             return Ok(());
         }
 
@@ -411,7 +409,7 @@ impl Pipeline {
         T: Stream<Item = RedisResult<Value>>,
         T: Unpin + Send + 'static,
     {
-        let (sender, mut receiver) = mpsc::channel(buffer_size);
+        let (sender, receiver) = mpsc::channel(buffer_size);
 
         let sink = PipelineSink::new(
             sink_stream,
@@ -419,10 +417,7 @@ impl Pipeline {
             #[cfg(feature = "cache-aio")]
             cache_manager,
         );
-        let f = stream::poll_fn(move |cx| receiver.poll_recv(cx))
-            .map(Ok)
-            .forward(sink)
-            .map(|_| ());
+        let f = receiver.map(Ok).forward(sink).map(|_| ());
         (Pipeline { sender }, f)
     }
 
@@ -441,28 +436,32 @@ impl Pipeline {
 
         let request = async {
             if skip_response {
-                self.sender
-                    .send(PipelineMessage {
+                SinkExt::send(
+                    &mut self.sender,
+                    PipelineMessage {
                         input,
                         expectation,
                         output: None,
-                    })
-                    .await
-                    .map_err(|_| None)?;
+                    },
+                )
+                .await
+                .map_err(|_| None)?;
 
                 return Ok(Value::Nil);
             }
 
             let (sender, receiver) = oneshot::channel();
 
-            self.sender
-                .send(PipelineMessage {
+            SinkExt::send(
+                &mut self.sender,
+                PipelineMessage {
                     input,
                     expectation,
                     output: Some(sender),
-                })
-                .await
-                .map_err(|_| None)?;
+                },
+            )
+            .await
+            .map_err(|_| None)?;
 
             receiver.await
             // The `sender` was dropped which likely means that the stream part
@@ -899,7 +898,7 @@ impl MultiplexedConnection {
     /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();
-    /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    /// let (tx, mut rx) = futures_channel::mpsc::unbounded();
     /// let config = redis::AsyncConnectionConfig::new().set_push_sender(tx);
     /// let mut con = client.get_multiplexed_async_connection_with_config(&config).await?;
     /// con.subscribe(&["channel_1", "channel_2"]).await?;
@@ -920,7 +919,7 @@ impl MultiplexedConnection {
     /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();
-    /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    /// let (tx, mut rx) = futures_channel::mpsc::unbounded();
     /// let config = redis::AsyncConnectionConfig::new().set_push_sender(tx);
     /// let mut con = client.get_multiplexed_async_connection_with_config(&config).await?;
     /// con.subscribe(&["channel_1", "channel_2"]).await?;
@@ -945,7 +944,7 @@ impl MultiplexedConnection {
     /// ```rust,no_run
     /// # async fn func() -> redis::RedisResult<()> {
     /// let client = redis::Client::open("redis://127.0.0.1/?protocol=resp3").unwrap();
-    /// let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    /// let (tx, mut rx) = futures_channel::mpsc::unbounded();
     /// let config = redis::AsyncConnectionConfig::new().set_push_sender(tx);
     /// let mut con = client.get_multiplexed_async_connection_with_config(&config).await?;
     /// con.psubscribe("channel*_1").await?;

--- a/redis/src/aio/pubsub.rs
+++ b/redis/src/aio/pubsub.rs
@@ -3,10 +3,9 @@ use crate::{
     FromRedisValue, Msg, RedisConnectionInfo, ToRedisArgs, aio::Runtime, cmd, errors::RedisError,
     errors::closed_connection_error, from_redis_value, parser::ValueCodec,
 };
-use ::tokio::{
-    io::{AsyncRead, AsyncWrite},
-    sync::oneshot,
-};
+use ::tokio::io::{AsyncRead, AsyncWrite};
+use futures_channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded};
+use futures_channel::oneshot;
 use futures_util::{
     future::{Future, FutureExt},
     ready,
@@ -17,8 +16,6 @@ use pin_project_lite::pin_project;
 use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::{self, Poll};
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::mpsc::unbounded_channel;
 use tokio_util::codec::Decoder;
 
 use super::{SharedHandleContainer, setup_connection};
@@ -58,7 +55,7 @@ pin_project! {
     /// the stream will cause the sink to return errors on requests.
     pub struct PubSubStream {
         #[pin]
-        receiver: tokio::sync::mpsc::UnboundedReceiver<Msg>,
+        receiver: UnboundedReceiver<Msg>,
         // This handle ensures that once the stream will be dropped, the underlying task will stop.
         _task_handle: Option<SharedHandleContainer>,
     }
@@ -127,7 +124,7 @@ where
                 }
 
                 if let Some(msg) = Msg::from_owned_value(Value::Array(value)) {
-                    let _ = self_.sender.send(msg);
+                    let _ = self_.sender.unbounded_send(msg);
                     Ok(())
                 } else {
                     Err(())
@@ -143,7 +140,7 @@ where
                 }
 
                 if let Some(msg) = Msg::from_push_info(crate::PushInfo { kind, data }) {
-                    let _ = self_.sender.send(msg);
+                    let _ = self_.sender.unbounded_send(msg);
                     Ok(())
                 } else {
                     Err(())
@@ -251,10 +248,10 @@ impl PubSubSink {
         T: Stream<Item = RedisResult<Value>>,
         T: Unpin + Send + 'static,
     {
-        let (sender, mut receiver) = unbounded_channel();
+        let (sender, mut receiver) = unbounded();
         let sink = PipelineSink::new(sink_stream, messages_sender);
         let f = stream::poll_fn(move |cx| {
-            let res = receiver.poll_recv(cx);
+            let res = receiver.poll_next_unpin(cx);
             match res {
                 // We don't want to stop the backing task for the stream, even if the sink was closed.
                 Poll::Ready(None) => Poll::Pending,
@@ -271,7 +268,7 @@ impl PubSubSink {
         let (sender, receiver) = oneshot::channel();
 
         self.sender
-            .send(PipelineMessage {
+            .unbounded_send(PipelineMessage {
                 input,
                 output: sender,
             })
@@ -393,7 +390,7 @@ impl PubSub {
             None,
         )
         .await?;
-        let (sender, receiver) = unbounded_channel();
+        let (sender, receiver) = unbounded();
         let (sink, driver) = PubSubSink::new(codec, sender);
         let handle = Runtime::locate().spawn(driver);
         let _task_handle = Some(SharedHandleContainer::new(handle));
@@ -513,6 +510,6 @@ impl Stream for PubSubStream {
     type Item = Msg;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
-        self.project().receiver.poll_recv(cx)
+        self.project().receiver.poll_next(cx)
     }
 }


### PR DESCRIPTION
This will allow us, on a major change, to remove the `tokio::sync` dependency. ATM we can't remove that dependency due to the tokio's channels implementing `AsyncPushSender` - we'll probably move that to behind a feature gate after a major version bump.