### PR TITLE
Fix tabs to spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ implements the `FromRedisValue` trait.
 use redis::TypedCommands;
 
 fn fetch_an_integer() -> Option<isize> {
-	// connect to redis
-	let client = redis::Client::open("redis://127.0.0.1/")?;
-	let mut con = client.get_connection()?;
-	// `set` returns a `()`, so we don't need to specify the return type manually unlike in the previous example.
-	con.set("my_key", 42)?;
-	// `get_int` returns Option<isize>, as the key may not be found.
-	con.get_int("my_key").unwrap()
+    // connect to redis
+    let client = redis::Client::open("redis://127.0.0.1/")?;
+    let mut con = client.get_connection()?;
+    // `set` returns a `()`, so we don't need to specify the return type manually unlike in the previous example.
+    con.set("my_key", 42)?;
+    // `get_int` returns Option<isize>, as the key may not be found.
+    con.get_int("my_key").unwrap()
 }
 ```
 

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -71,12 +71,12 @@ macro_rules! implement_json_commands {
                 $(#[$attr])*
                 #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
                 pub fn $name<$lifetime, $($tyargs: $ty),*>($($argname: $argty),*) -> RedisResult<Self> {
-					$body
+                    $body
                 }
             )*
         }
 
-		/// Implements RedisJSON commands over asynchronous connections. This
+        /// Implements RedisJSON commands over asynchronous connections. This
         /// allows you to send commands straight to a connection or client.
         ///
         /// This allows you to use nicer syntax for some common operations.
@@ -112,7 +112,7 @@ macro_rules! implement_json_commands {
         /// in square brackets (or empty brackets if not found). If you want to deserialize it
         /// with e.g. `serde_json` you have to use `Vec<T>` for your output type instead of `T`.
         ///
-		#[cfg(feature = "aio")]
+        #[cfg(feature = "aio")]
         pub trait JsonAsyncCommands : crate::aio::ConnectionLike + Send + Sized {
             $(
                 $(#[$attr])*
@@ -130,9 +130,9 @@ macro_rules! implement_json_commands {
                     })
                 }
             )*
-		}
+        }
 
-		/// Implements RedisJSON commands for pipelines.  Unlike the regular
+        /// Implements RedisJSON commands for pipelines.  Unlike the regular
         /// commands trait, this returns the pipeline rather than a result
         /// directly.  Other than that it works the same however.
         impl Pipeline {
@@ -144,12 +144,12 @@ macro_rules! implement_json_commands {
                     &mut self $(, $argname: $argty)*
                 ) -> RedisResult<&mut Self> {
                     self.add_command($body?);
-					Ok(self)
+                    Ok(self)
                 }
             )*
         }
 
-		/// Implements RedisJSON commands for cluster pipelines.  Unlike the regular
+        /// Implements RedisJSON commands for cluster pipelines.  Unlike the regular
         /// commands trait, this returns the cluster pipeline rather than a result
         /// directly.  Other than that it works the same however.
         #[cfg(feature = "cluster")]
@@ -162,7 +162,7 @@ macro_rules! implement_json_commands {
                     &mut self $(, $argname: $argty)*
                 ) -> RedisResult<&mut Self> {
                     self.add_command($body?);
-					Ok(self)
+                    Ok(self)
                 }
             )*
         }

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -1,85 +1,85 @@
 // Generate implementation for function skeleton, we use this for `AsyncTypedCommands` because we want to be able to handle having a return type specified or unspecified with a fallback
 #[cfg(feature = "aio")]
 macro_rules! implement_command_async {
-	// If the return type is `Generic`, then we require the user to specify the return type
-	(
+    // If the return type is `Generic`, then we require the user to specify the return type
+    (
         $lifetime: lifetime
-		$(#[$attr:meta])+
-		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-			$($argname:ident: $argty:ty),*) $body:block Generic
+        $(#[$attr:meta])+
+        fn $name:ident<$($tyargs:ident : $ty:ident),*>(
+            $($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
-		$(#[$attr])*
-		#[inline]
-		#[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-		fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-			& $lifetime mut self
-			$(, $argname: $argty)*
-		) -> crate::types::RedisFuture<$lifetime, RV>
-		{
-			Box::pin(async move { $body.query_async(self).await })
-		}
-	};
+        $(#[$attr])*
+        #[inline]
+        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+        fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
+            & $lifetime mut self
+            $(, $argname: $argty)*
+        ) -> crate::types::RedisFuture<$lifetime, RV>
+        {
+            Box::pin(async move { $body.query_async(self).await })
+        }
+    };
 
-	// If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
-	(
+    // If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
+    (
         $lifetime: lifetime
-		$(#[$attr:meta])+
-		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-			$($argname:ident: $argty:ty),*) $body:block $rettype:ty
+        $(#[$attr:meta])+
+        fn $name:ident<$($tyargs:ident : $ty:ident),*>(
+            $($argname:ident: $argty:ty),*) $body:block $rettype:ty
     ) => {
-		$(#[$attr])*
-		#[inline]
-		#[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-		fn $name<$lifetime, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-			& $lifetime mut self
-			$(, $argname: $argty)*
-		) -> crate::types::RedisFuture<$lifetime, $rettype>
+        $(#[$attr])*
+        #[inline]
+        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+        fn $name<$lifetime, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
+            & $lifetime mut self
+            $(, $argname: $argty)*
+        ) -> crate::types::RedisFuture<$lifetime, $rettype>
 
-		{
-			Box::pin(async move { $body.query_async(self).await })
-		}
-	};
+        {
+            Box::pin(async move { $body.query_async(self).await })
+        }
+    };
 }
 
 macro_rules! implement_command_sync {
-	// If the return type is `Generic`, then we require the user to specify the return type
-	(
+    // If the return type is `Generic`, then we require the user to specify the return type
+    (
         $lifetime: lifetime
-		$(#[$attr:meta])+
-		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-			$($argname:ident: $argty:ty),*) $body:block Generic
+        $(#[$attr:meta])+
+        fn $name:ident<$($tyargs:ident : $ty:ident),*>(
+            $($argname:ident: $argty:ty),*) $body:block Generic
     ) => {
-		$(#[$attr])*
-		#[inline]
-		#[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-		fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-			& $lifetime mut self
-			$(, $argname: $argty)*
-		) -> RedisResult<RV>
-		{
-			Cmd::$name($($argname),*).query(self)
-		}
-	};
+        $(#[$attr])*
+        #[inline]
+        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+        fn $name<$lifetime, RV: FromRedisValue, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
+            & $lifetime mut self
+            $(, $argname: $argty)*
+        ) -> RedisResult<RV>
+        {
+            Cmd::$name($($argname),*).query(self)
+        }
+    };
 
-	// If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
-	(
+    // If return type is specified in the input skeleton, then we will return it in the generated function (note match rule `$rettype:ty`)
+    (
         $lifetime: lifetime
-		$(#[$attr:meta])+
-		fn $name:ident<$($tyargs:ident : $ty:ident),*>(
-			$($argname:ident: $argty:ty),*) $body:block $rettype:ty
+        $(#[$attr:meta])+
+        fn $name:ident<$($tyargs:ident : $ty:ident),*>(
+            $($argname:ident: $argty:ty),*) $body:block $rettype:ty
     ) => {
-		$(#[$attr])*
-		#[inline]
-		#[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
-		fn $name<$lifetime, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
-			& $lifetime mut self
-			$(, $argname: $argty)*
-		) -> RedisResult<$rettype>
+        $(#[$attr])*
+        #[inline]
+        #[allow(clippy::extra_unused_lifetimes, clippy::needless_lifetimes)]
+        fn $name<$lifetime, $($tyargs: $ty + Send + Sync + $lifetime,)*>(
+            & $lifetime mut self
+            $(, $argname: $argty)*
+        ) -> RedisResult<$rettype>
 
-		{
-			Cmd::$name($($argname),*).query(self)
-		}
-	};
+        {
+            Cmd::$name($($argname),*).query(self)
+        }
+    };
 }
 
 macro_rules! implement_iterators {
@@ -221,9 +221,9 @@ macro_rules! implement_commands {
             )*
 
             implement_iterators! {
-				|c: Cmd, this| c.iter(this),
-				RedisResult<Iter<'_, RV>>
-			}
+                |c: Cmd, this| c.iter(this),
+                RedisResult<Iter<'_, RV>>
+            }
         }
 
         impl Cmd {
@@ -282,9 +282,9 @@ macro_rules! implement_commands {
                 }
             )*
 
-			implement_iterators! {
+            implement_iterators! {
                 |c: Cmd, this| Box::pin(async move { c.iter_async(this).await }),
-				crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>>
+                crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>>
             }
         }
 
@@ -292,67 +292,67 @@ macro_rules! implement_commands {
         /// The return types are concrete and opinionated. If you want to choose the return type you should use the `Commands` trait.
         pub trait TypedCommands : ConnectionLike+Sized {
             $(
-				implement_command_sync! {
-					$lifetime
-					$(#[$attr])*
-					fn $name<$($tyargs: $ty),*>(
-						$($argname: $argty),*
-					)
+                implement_command_sync! {
+                    $lifetime
+                    $(#[$attr])*
+                    fn $name<$($tyargs: $ty),*>(
+                        $($argname: $argty),*
+                    )
 
-					{
-						$body
-					} $rettype
-				}
+                    {
+                        $body
+                    } $rettype
+                }
             )*
 
             implement_iterators! {
                 |c: Cmd, this| c.iter(this),
-				RedisResult<Iter<'_, RV>>
+                RedisResult<Iter<'_, RV>>
             }
 
-			/// Get a value from Redis and convert it to an `Option<isize>`.
-			fn get_int<K: ToSingleRedisArg>(&mut self, key: K) -> RedisResult<Option<isize>> {
-        		cmd("GET").arg(key).query(self)
-    		}
+            /// Get a value from Redis and convert it to an `Option<isize>`.
+            fn get_int<K: ToSingleRedisArg>(&mut self, key: K) -> RedisResult<Option<isize>> {
+                cmd("GET").arg(key).query(self)
+            }
 
-			/// Get values from Redis and convert them to `Option<isize>`s.
-			fn mget_ints<K: ToRedisArgs>(&mut self, key: K) -> RedisResult<Vec<Option<isize>>> {
-        		cmd("MGET").arg(key).query(self)
-    		}
+            /// Get values from Redis and convert them to `Option<isize>`s.
+            fn mget_ints<K: ToRedisArgs>(&mut self, key: K) -> RedisResult<Vec<Option<isize>>> {
+                cmd("MGET").arg(key).query(self)
+            }
         }
 
-		/// Implements common redis commands over asynchronous connections.
+        /// Implements common redis commands over asynchronous connections.
         /// The return types are concrete and opinionated. If you want to choose the return type you should use the `AsyncCommands` trait.
-		#[cfg(feature = "aio")]
+        #[cfg(feature = "aio")]
         pub trait AsyncTypedCommands : crate::aio::ConnectionLike + Send + Sized {
             $(
-				implement_command_async! {
-					$lifetime
-					$(#[$attr])*
-					fn $name<$($tyargs: $ty),*>(
-						$($argname: $argty),*
-					)
+                implement_command_async! {
+                    $lifetime
+                    $(#[$attr])*
+                    fn $name<$($tyargs: $ty),*>(
+                        $($argname: $argty),*
+                    )
 
-					{
-						$body
-					} $rettype
-				}
+                    {
+                        $body
+                    } $rettype
+                }
             )*
 
             implement_iterators! {
-				|c: Cmd, this| Box::pin(async move { c.iter_async(this).await }),
-				crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>>
-			}
+                |c: Cmd, this| Box::pin(async move { c.iter_async(this).await }),
+                crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>>
+            }
 
-			/// Get a value from Redis and convert it to an `Option<isize>`.
-			fn get_int<$lifetime, K: ToSingleRedisArg + Send + Sync + $lifetime>(&$lifetime mut self, key: K) -> crate::types::RedisFuture<$lifetime, Option<isize>> {
-				Box::pin(async move { cmd("GET").arg(key).query_async(self).await })
-    		}
+            /// Get a value from Redis and convert it to an `Option<isize>`.
+            fn get_int<$lifetime, K: ToSingleRedisArg + Send + Sync + $lifetime>(&$lifetime mut self, key: K) -> crate::types::RedisFuture<$lifetime, Option<isize>> {
+                Box::pin(async move { cmd("GET").arg(key).query_async(self).await })
+            }
 
-			/// Get values from Redis and convert them to `Option<isize>`s.
-			fn mget_ints<$lifetime, K: ToRedisArgs + Send + Sync + $lifetime>(&$lifetime mut self, key: K) -> crate::types::RedisFuture<$lifetime, Vec<Option<isize>>> {
-				Box::pin(async move { cmd("MGET").arg(key).query_async(self).await })
-    		}
+            /// Get values from Redis and convert them to `Option<isize>`s.
+            fn mget_ints<$lifetime, K: ToRedisArgs + Send + Sync + $lifetime>(&$lifetime mut self, key: K) -> crate::types::RedisFuture<$lifetime, Vec<Option<isize>>> {
+                Box::pin(async move { cmd("MGET").arg(key).query_async(self).await })
+            }
         }
 
         /// Implements common redis commands for pipelines.  Unlike the regular

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -687,7 +687,7 @@ pub use crate::types::{
     Role,
     ReplicaInfo,
     IntegerReplyOrNoOp,
-	ValueType,
+    ValueType,
     RedisResult,
     RedisWrite,
     ToRedisArgs,


### PR DESCRIPTION
While most files used 4 spaces for indentation, some files mixed in a few tabs, which was hard to read. So we convert tabs to 4 spaces.