### PR TITLE
Add TLS certificate-based authentication support

### DIFF
--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -149,6 +149,7 @@ impl RedisCluster {
                 None,
                 tls_paths.clone(),
                 mtls_enabled,
+                None, // cert_auth_field - not used in cluster tests
                 &modules,
                 |cmd| {
                     let tempdir = tempfile::Builder::new()

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -125,6 +125,7 @@ fn spawn_master_server(
         None,
         Some(tlspaths.clone()),
         MTLS_NOT_ENABLED,
+        None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
             // Minimize startup delay
@@ -153,6 +154,7 @@ fn spawn_replica_server(
         Some(&config_file_path),
         Some(tlspaths.clone()),
         MTLS_NOT_ENABLED,
+        None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
             cmd.arg("--replicaof")
@@ -189,6 +191,7 @@ fn spawn_sentinel_server(
         Some(&config_file_path),
         Some(tlspaths.clone()),
         MTLS_NOT_ENABLED,
+        None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
             cmd.arg("--sentinel");

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -36,6 +36,7 @@ fn spawn_master_server(
         None,
         Some(tlspaths.clone()),
         MTLS_NOT_ENABLED,
+        None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
             // Minimize startup delay
@@ -64,6 +65,7 @@ fn spawn_replica_server(
         Some(&config_file_path),
         Some(tlspaths.clone()),
         MTLS_NOT_ENABLED,
+        None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
             cmd.arg("--replicaof")
@@ -100,6 +102,7 @@ fn spawn_sentinel_server(
         Some(&config_file_path),
         Some(tlspaths.clone()),
         MTLS_NOT_ENABLED,
+        None, // cert_auth_field - not used in sentinel tests
         modules,
         |cmd| {
             cmd.arg("--sentinel");

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -80,19 +80,24 @@ impl RedisServer {
         std::fs::read_to_string(self.log_file.clone()).ok()
     }
 
+    /// Get the default host to use for TCP connections.
+    pub fn get_default_host() -> String {
+        "127.0.0.1".to_string()
+    }
+
     pub fn get_addr(port: u16) -> ConnectionAddr {
         let server_type = ServerType::get_intended();
         match server_type {
             ServerType::Tcp { tls } => {
                 if tls {
                     redis::ConnectionAddr::TcpTls {
-                        host: "127.0.0.1".to_string(),
+                        host: Self::get_default_host(),
                         port,
                         insecure: true,
                         tls_params: None,
                     }
                 } else {
-                    redis::ConnectionAddr::Tcp("127.0.0.1".to_string(), port)
+                    redis::ConnectionAddr::Tcp(Self::get_default_host(), port)
                 }
             }
             ServerType::Unix => {
@@ -114,6 +119,7 @@ impl RedisServer {
             None,
             None,
             mtls_enabled,
+            None,
             modules,
             |cmd| {
                 cmd.spawn()
@@ -132,6 +138,7 @@ impl RedisServer {
             None,
             None,
             mtls_enabled,
+            None,
             modules,
             |cmd| {
                 cmd.spawn()
@@ -147,6 +154,7 @@ impl RedisServer {
         config_file: Option<&Path>,
         tls_paths: Option<TlsFilePaths>,
         mtls_enabled: bool,
+        cert_auth_field: Option<&str>,
         modules: &[Module],
         spawner: F,
     ) -> RedisServer {
@@ -238,6 +246,13 @@ impl RedisServer {
                     .arg(auth_client)
                     .arg("--bind")
                     .arg(host);
+
+                // Enable certificate-based authentication (Redis 8.6+)
+                // The cert_auth_field specifies which certificate field to use for username mapping
+                // (e.g., "CN" for Common Name)
+                if let Some(field) = cert_auth_field {
+                    redis_cmd.arg("--tls-auth-clients-user").arg(field);
+                }
 
                 // Insecure only disabled if `mtls` is enabled
                 let insecure = !mtls_enabled;

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -18,6 +18,11 @@ pub fn redis_settings() -> RedisConnectionInfo {
     RedisConnectionInfo::default().set_protocol(use_protocol())
 }
 
+/// Get the default host to use for TCP connections.
+pub fn get_default_host() -> String {
+    "127.0.0.1".to_string()
+}
+
 #[derive(PartialEq)]
 enum ServerType {
     Tcp { tls: bool },
@@ -80,24 +85,19 @@ impl RedisServer {
         std::fs::read_to_string(self.log_file.clone()).ok()
     }
 
-    /// Get the default host to use for TCP connections.
-    pub fn get_default_host() -> String {
-        "127.0.0.1".to_string()
-    }
-
     pub fn get_addr(port: u16) -> ConnectionAddr {
         let server_type = ServerType::get_intended();
         match server_type {
             ServerType::Tcp { tls } => {
                 if tls {
                     redis::ConnectionAddr::TcpTls {
-                        host: Self::get_default_host(),
+                        host: get_default_host(),
                         port,
                         insecure: true,
                         tls_params: None,
                     }
                 } else {
-                    redis::ConnectionAddr::Tcp(Self::get_default_host(), port)
+                    redis::ConnectionAddr::Tcp(get_default_host(), port)
                 }
             }
             ServerType::Unix => {

--- a/redis-test/src/utils.rs
+++ b/redis-test/src/utils.rs
@@ -12,6 +12,13 @@ pub struct TlsFilePaths {
     pub ca_crt: PathBuf,
 }
 
+/// Client certificate and key paths for mTLS authentication
+#[derive(Clone, Debug)]
+pub struct ClientCertPaths {
+    pub client_crt: PathBuf,
+    pub client_key: PathBuf,
+}
+
 pub fn build_keys_and_certs_for_tls(tempdir: &TempDir) -> TlsFilePaths {
     build_keys_and_certs_for_tls_ext(tempdir, true)
 }
@@ -158,6 +165,99 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
         redis_crt,
         redis_key,
         ca_crt,
+    }
+}
+
+/// Build a client certificate with a custom common name (CN) field
+/// Redis 8.6+ allows certificate-based authentication where the common name (CN)
+/// is mapped to an ACL username
+pub fn build_client_cert_with_custom_cn(
+    tempdir: &TempDir,
+    common_name: &str,
+    ca_crt: &PathBuf,
+    ca_key: &PathBuf,
+) -> ClientCertPaths {
+    let client_crt = tempdir.path().join(format!("{}.crt", common_name));
+    let client_key = tempdir.path().join(format!("{}.key", common_name));
+    let ca_serial = tempdir.path().join("ca.txt");
+
+    // Generate client private key
+    let status = process::Command::new("openssl")
+        .arg("genrsa")
+        .arg("-out")
+        .arg(&client_key)
+        .arg("2048")
+        .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn openssl")
+        .wait()
+        .expect("failed to create client key");
+    assert!(
+        status.success(),
+        "`openssl genrsa` failed to create client key: {status}"
+    );
+
+    // Create a basic extensions file for X.509 v3 client certificate
+    let client_ext_file = tempdir.path().join("client_ext.cnf");
+    let client_ext_content = "\
+        basicConstraints = CA:FALSE\n\
+        keyUsage = digitalSignature, keyEncipherment\n\
+    ";
+    fs::write(&client_ext_file, client_ext_content)
+        .expect("failed to create client extensions file");
+
+    // Create certificate signing request with custom CN
+    let mut csr_cmd = process::Command::new("openssl")
+        .arg("req")
+        .arg("-new")
+        .arg("-sha256")
+        .arg("-subj")
+        .arg(format!("/O=Redis Test/CN={}", common_name))
+        .arg("-key")
+        .arg(&client_key)
+        .stdout(process::Stdio::piped())
+        .stderr(process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn openssl for CSR");
+
+    // Sign the certificate with CA (X.509 v3)
+    let cert_status = process::Command::new("openssl")
+        .arg("x509")
+        .arg("-req")
+        .arg("-sha256")
+        .arg("-CA")
+        .arg(ca_crt)
+        .arg("-CAkey")
+        .arg(ca_key)
+        .arg("-CAserial")
+        .arg(&ca_serial)
+        .arg("-CAcreateserial")
+        .arg("-days")
+        .arg("365")
+        .arg("-extfile")
+        .arg(&client_ext_file)
+        .arg("-out")
+        .arg(&client_crt)
+        .stdin(csr_cmd.stdout.take().expect("should have stdout"))
+        .spawn()
+        .expect("failed to spawn openssl for certificate signing")
+        .wait()
+        .expect("failed to sign client certificate");
+
+    let csr_status = csr_cmd.wait().expect("failed to create CSR");
+    assert!(
+        csr_status.success(),
+        "`openssl req` failed to create CSR: {csr_status}"
+    );
+    assert!(
+        cert_status.success(),
+        "`openssl x509` failed to sign client certificate"
+    );
+
+    ClientCertPaths {
+        client_crt,
+        client_key,
     }
 }
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -220,6 +220,10 @@ required-features = ["script"]
 [[test]]
 name = "test_digest_utils"
 
+[[test]]
+name = "test_tls_cert_auth"
+required-features = ["acl", "tls-rustls", "tokio-rustls-comp", "cluster"]
+
 [[bench]]
 name = "bench_basic"
 harness = false

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -2,7 +2,10 @@
 
 #[cfg(feature = "aio")]
 use futures::Future;
-use redis::{Commands, ConnectionAddr, InfoDict, Pipeline, ProtocolVersion, RedisResult, Value};
+use redis::{
+    Commands, ConnectionAddr, ErrorKind, InfoDict, Pipeline, ProtocolVersion, RedisResult,
+    ServerErrorKind, Value,
+};
 #[cfg(feature = "aio")]
 use redis::{aio, cmd};
 use redis_test::server::{Module, RedisServer, use_protocol};
@@ -156,6 +159,53 @@ impl TestContext {
         Self::with_modules_and_tls(&[], true, None)
     }
 
+    #[cfg(feature = "tls-rustls")]
+    pub fn new_with_cert_auth(tls_files: TlsFilePaths) -> TestContext {
+        Self::new_with_cert_auth_field(tls_files, "CN")
+    }
+
+    #[cfg(feature = "tls-rustls")]
+    pub fn new_with_cert_auth_field(tls_files: TlsFilePaths, cert_field: &str) -> TestContext {
+        start_tls_crypto_provider();
+        let redis_port = get_random_available_port();
+        let addr = RedisServer::get_addr(redis_port);
+
+        // TLS certificate-based authentication requires TLS connection.
+        let addr = match addr {
+            ConnectionAddr::Tcp(host, port) => ConnectionAddr::TcpTls {
+                host,
+                port,
+                insecure: true,
+                tls_params: None,
+            },
+            ConnectionAddr::TcpTls { .. } => addr, // Already TLS
+            ConnectionAddr::Unix(_) => {
+                // Unix sockets don't support TLS - fall back to TCP+TLS
+                // Use the same default host that RedisServer::get_addr() would use for TCP
+                ConnectionAddr::TcpTls {
+                    host: RedisServer::get_default_host(),
+                    port: redis_port,
+                    insecure: true,
+                    tls_params: None,
+                }
+            }
+            _ => {
+                panic!(
+                    "Unsupported ConnectionAddr variant for cert-based authentication: {:?}",
+                    addr
+                )
+            }
+        };
+
+        Self::with_modules_addr_tls_and_cert_auth(
+            &[],
+            true,
+            addr,
+            Some(tls_files),
+            Some(cert_field),
+        )
+    }
+
     pub fn with_tls(tls_files: TlsFilePaths, mtls_enabled: bool) -> TestContext {
         Self::with_modules_and_tls(&[], mtls_enabled, Some(tls_files))
     }
@@ -185,11 +235,22 @@ impl TestContext {
         addr: ConnectionAddr,
         tls_files: Option<TlsFilePaths>,
     ) -> Self {
+        Self::with_modules_addr_tls_and_cert_auth(modules, mtls_enabled, addr, tls_files, None)
+    }
+
+    fn with_modules_addr_tls_and_cert_auth(
+        modules: &[Module],
+        mtls_enabled: bool,
+        addr: ConnectionAddr,
+        tls_files: Option<TlsFilePaths>,
+        cert_auth_field: Option<&str>,
+    ) -> Self {
         let server = RedisServer::new_with_addr_tls_modules_and_spawner(
             addr,
             None,
             tls_files,
             mtls_enabled,
+            cert_auth_field,
             modules,
             |cmd| {
                 cmd.spawn()
@@ -229,7 +290,34 @@ impl TestContext {
                 }
             }
         }
-        con.flushdb::<()>().unwrap();
+
+        // Redis may still be loading its dataset after accepting connections,
+        // especially with TLS where the handshake completes before Redis is fully ready.
+        // Retry flushdb if the BusyLoading error is returned to allow time for initialization.
+        let mut flush_retries = 0;
+        loop {
+            match con.flushdb::<()>() {
+                Ok(_) => break,
+                Err(err)
+                    if matches!(err.kind(), ErrorKind::Server(ServerErrorKind::BusyLoading)) =>
+                {
+                    sleep(millisecond);
+                    flush_retries += 1;
+                    if flush_retries > 10000 {
+                        panic!(
+                            "Redis is still loading after too many retries, last error: {err}, logfile: {:?}",
+                            server.log_file_contents()
+                        );
+                    }
+                }
+                Err(err) => {
+                    panic!(
+                        "Failed to flush database: {err}, logfile: {:?}",
+                        server.log_file_contents()
+                    );
+                }
+            }
+        }
 
         TestContext {
             server,
@@ -399,6 +487,36 @@ fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
     parse_version(info)
 }
 
+/// Get the Redis server version by running `redis-server --version`.
+pub fn get_redis_binary_version() -> Version {
+    use std::process::Command;
+
+    let output = Command::new(
+        std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string()),
+    )
+    .arg("--version")
+    .output()
+    .expect("Failed to execute redis-server --version");
+
+    let full_string =
+        String::from_utf8(output.stdout).expect("Invalid UTF-8 in redis-server version output");
+
+    let version_str = full_string
+        .split_whitespace()
+        .find(|s| s.starts_with("v="))
+        .and_then(|s| s.strip_prefix("v="))
+        .expect("Could not find version in redis-server output");
+
+    let versions: Vec<u16> = version_str
+        .split('.')
+        .take(3)
+        .map(|v| v.parse::<u16>().expect("Failed to parse version number"))
+        .collect();
+
+    assert_eq!(versions.len(), 3, "Expected version format x.y.z");
+    (versions[0], versions[1], versions[2])
+}
+
 pub fn is_major_version(expected_version: u16, version: Version) -> bool {
     expected_version <= version.0
 }
@@ -434,6 +552,34 @@ macro_rules! run_test_if_version_supported {
     }};
 }
 
+/// Macro to run tests only if the version of the Redis binary meets the minimum requirement.
+/// If the version is insufficient, the test is skipped with a message.
+///
+/// # Example
+/// ```rust,no_run
+/// #[test]
+/// fn test_redis_8_6_feature() {
+///     run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+///     // Only now create the expensive test context
+///     let ctx = TestContext::new_with_cert_auth(tls_files);
+///     // ...
+/// }
+/// ```
+#[macro_export]
+macro_rules! run_test_if_redis_binary_version_supported {
+    ($minimum_required_version:expr) => {{
+        let redis_version = $crate::get_redis_binary_version();
+
+        if redis_version < *$minimum_required_version {
+            eprintln!(
+                "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
+                redis_version, $minimum_required_version
+            );
+            return;
+        }
+    }};
+}
+
 #[cfg(feature = "tls-rustls")]
 fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
     let ca_file = File::open(&tls_file_paths.ca_crt).expect("Cannot open CA cert file");
@@ -442,17 +588,17 @@ fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
         .read_to_end(&mut root_cert_vec)
         .expect("Unable to read CA cert file");
 
-    let cert_file = File::open(&tls_file_paths.redis_crt).expect("cannot open private cert file");
+    let cert_file = File::open(&tls_file_paths.redis_crt).expect("Cannot open cert file");
     let mut client_cert_vec = Vec::new();
     BufReader::new(cert_file)
         .read_to_end(&mut client_cert_vec)
-        .expect("Unable to read client cert file");
+        .expect("Unable to read cert file");
 
-    let key_file = File::open(&tls_file_paths.redis_key).expect("Cannot open private key file");
+    let key_file = File::open(&tls_file_paths.redis_key).expect("Cannot open key file");
     let mut client_key_vec = Vec::new();
     BufReader::new(key_file)
         .read_to_end(&mut client_key_vec)
-        .expect("Unable to read client key file");
+        .expect("Unable to read key file");
 
     TlsCertificates {
         client_tls: Some(ClientTlsConfig {
@@ -481,6 +627,45 @@ pub(crate) fn build_single_client<T: redis::IntoConnectionInfo>(
     } else {
         redis::Client::open(connection_info)
     }
+}
+
+#[cfg(feature = "tls-rustls")]
+pub(crate) fn build_single_client_with_separate_client_cert<T: redis::IntoConnectionInfo>(
+    connection_info: T,
+    tls_file_params: &TlsFilePaths,
+    client_cert_paths: &redis_test::utils::ClientCertPaths,
+) -> RedisResult<redis::Client> {
+    // Load CA cert for server verification
+    let ca_file = File::open(&tls_file_params.ca_crt).expect("Cannot open CA cert file");
+    let mut root_cert_vec = Vec::new();
+    BufReader::new(ca_file)
+        .read_to_end(&mut root_cert_vec)
+        .expect("Unable to read CA cert file");
+
+    // Load client cert and key for mTLS authentication
+    let cert_file =
+        File::open(&client_cert_paths.client_crt).expect("Cannot open client cert file");
+    let mut client_cert_vec = Vec::new();
+    BufReader::new(cert_file)
+        .read_to_end(&mut client_cert_vec)
+        .expect("Unable to read client cert file");
+
+    let key_file = File::open(&client_cert_paths.client_key).expect("Cannot open client key file");
+    let mut client_key_vec = Vec::new();
+    BufReader::new(key_file)
+        .read_to_end(&mut client_key_vec)
+        .expect("Unable to read client key file");
+
+    redis::Client::build_with_tls(
+        connection_info,
+        TlsCertificates {
+            client_tls: Some(ClientTlsConfig {
+                client_cert: client_cert_vec,
+                client_key: client_key_vec,
+            }),
+            root_cert: Some(root_cert_vec),
+        },
+    )
 }
 
 #[cfg(not(feature = "tls-rustls"))]

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -181,9 +181,9 @@ impl TestContext {
             ConnectionAddr::TcpTls { .. } => addr, // Already TLS
             ConnectionAddr::Unix(_) => {
                 // Unix sockets don't support TLS - fall back to TCP+TLS
-                // Use the same default host that RedisServer::get_addr() would use for TCP
+                // Use the same default host that get_addr() would use for TCP
                 ConnectionAddr::TcpTls {
-                    host: RedisServer::get_default_host(),
+                    host: redis_test::server::get_default_host(),
                     port: redis_port,
                     insecure: true,
                     tls_params: None,
@@ -488,15 +488,19 @@ fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
 }
 
 /// Get the Redis server version by running `redis-server --version`.
-pub fn get_redis_binary_version() -> Version {
+/// Returns `None` if the binary is not available.
+pub fn get_redis_binary_version() -> Option<Version> {
     use std::process::Command;
 
-    let output = Command::new(
-        std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string()),
-    )
-    .arg("--version")
-    .output()
-    .expect("Failed to execute redis-server --version");
+    let binary = std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
+
+    let output = match Command::new(&binary).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => {
+            eprintln!("Failed to execute redis-server --version");
+            return None;
+        }
+    };
 
     let full_string =
         String::from_utf8(output.stdout).expect("Invalid UTF-8 in redis-server version output");
@@ -514,7 +518,7 @@ pub fn get_redis_binary_version() -> Version {
         .collect();
 
     assert_eq!(versions.len(), 3, "Expected version format x.y.z");
-    (versions[0], versions[1], versions[2])
+    Some((versions[0], versions[1], versions[2]))
 }
 
 pub fn is_major_version(expected_version: u16, version: Version) -> bool {
@@ -553,7 +557,7 @@ macro_rules! run_test_if_version_supported {
 }
 
 /// Macro to run tests only if the version of the Redis binary meets the minimum requirement.
-/// If the version is insufficient, the test is skipped with a message.
+/// If the binary is not available or the version is insufficient, the test is skipped with a message.
 ///
 /// # Example
 /// ```rust,no_run
@@ -568,14 +572,22 @@ macro_rules! run_test_if_version_supported {
 #[macro_export]
 macro_rules! run_test_if_redis_binary_version_supported {
     ($minimum_required_version:expr) => {{
-        let redis_version = $crate::get_redis_binary_version();
-
-        if redis_version < *$minimum_required_version {
-            eprintln!(
-                "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-                redis_version, $minimum_required_version
-            );
-            return;
+        match $crate::get_redis_binary_version() {
+            None => {
+                eprintln!(
+                    "Skipping the test because the Redis binary was not found."
+                );
+                return;
+            }
+            Some(redis_version) => {
+                if redis_version < *$minimum_required_version {
+                    eprintln!(
+                        "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
+                        redis_version, $minimum_required_version
+                    );
+                    return;
+                }
+            }
         }
     }};
 }

--- a/redis/tests/test_tls_cert_auth.rs
+++ b/redis/tests/test_tls_cert_auth.rs
@@ -1,0 +1,219 @@
+//! Tests for Redis 8.6+ TLS certificate-based automatic authentication
+//!
+//! Redis 8.6 introduces automatic client authentication using TLS certificates.
+//! When configured with `tls-auth-clients-user CN`, Redis extracts the Common Name (CN)
+//! from the client's TLS certificate and uses it to authenticate the client as an ACL user.
+//!
+//! These tests verify:
+//! - Automatic authentication when CN matches an existing ACL user
+//! - Fallback to "default" user when CN doesn't match any ACL user
+//! - ACL permissions are correctly enforced based on the authenticated user
+
+#![cfg(feature = "tls-rustls")]
+
+use redis::acl::Rule;
+use redis::{Commands, RedisResult};
+use tempfile::TempDir;
+
+mod support;
+use crate::support::*;
+use redis_test::utils::{ClientCertPaths, build_client_cert_with_custom_cn};
+
+/// Helper struct to manage cert-based auth testing with a single Redis server
+struct CertAuthTestContext {
+    server_ctx: TestContext,
+    client_cert_paths: ClientCertPaths,
+    server_tls_paths: redis_test::utils::TlsFilePaths,
+    _tempdir: TempDir,
+}
+
+impl CertAuthTestContext {
+    /// Create a connection using the server certificate (for setup operations)
+    fn setup_connection(&self) -> redis::Connection {
+        self.server_ctx.connection()
+    }
+
+    /// Create a connection using the client certificate (for cert auth testing)
+    fn cert_auth_connection(&self) -> redis::Connection {
+        use support::build_single_client_with_separate_client_cert;
+
+        let client = build_single_client_with_separate_client_cert(
+            self.server_ctx.server.connection_info(),
+            &self.server_tls_paths,
+            &self.client_cert_paths,
+        )
+        .expect("Failed to create client with client certificate");
+
+        client
+            .get_connection()
+            .expect("Failed to get connection with client certificate")
+    }
+}
+
+/// Helper function to create a cert-based auth test context
+/// Returns a single server with the ability to create two types of connections:
+/// 1. Setup connection using server certificate (for creating ACL users)
+/// 2. Cert auth connection using client certificate with custom CN
+fn create_cert_auth_context_with_username(username: &str) -> CertAuthTestContext {
+    use redis_test::utils::build_keys_and_certs_for_tls;
+    use tempfile::TempDir;
+
+    // Create a temporary directory for certificates
+    let tempdir = TempDir::new().expect("Failed to create temp dir");
+
+    // Generate CA and server certificates
+    let tls_paths = build_keys_and_certs_for_tls(&tempdir);
+
+    // The ca.key path is needed and it should be in the same directory as ca.crt
+    let ca_key_path = tempdir.path().join("ca.key");
+
+    // Generate client certificate with custom CN
+    let client_cert_paths =
+        build_client_cert_with_custom_cn(&tempdir, username, &tls_paths.ca_crt, &ca_key_path);
+
+    // Create a single server context with cert-based auth enabled
+    let server_ctx = TestContext::new_with_cert_auth(tls_paths.clone());
+
+    CertAuthTestContext {
+        server_ctx,
+        client_cert_paths,
+        server_tls_paths: tls_paths,
+        _tempdir: tempdir,
+    }
+}
+
+/// Generate a random username for testing
+fn generate_random_username() -> String {
+    use rand::Rng;
+    format!("testcertuser{}", rand::rng().random_range(10000..99999))
+}
+
+#[test]
+fn test_tls_certificate_authentication_with_matching_acl_user() {
+    // This test verifies that Redis 8.6+ can automatically authenticate a client
+    // based on the Common Name (CN) field in the client's TLS certificate.
+
+    // Check Redis binary version before creating the test context.
+    run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+
+    // Generate a random username for the test.
+    let test_username = generate_random_username();
+
+    // Create a test context with cert-based authentication enabled.
+    let ctx = create_cert_auth_context_with_username(&test_username);
+
+    // First, create the ACL user on the server using the setup connection.
+    let mut setup_conn = ctx.setup_connection();
+
+    // Create ACL user with limited permissions:
+    //  Allow: GET, SET, PING, ACL WHOAMI
+    //  Deny: DEL, FLUSHDB, etc.
+    let result: RedisResult<String> = setup_conn.acl_setuser_rules(
+        &test_username,
+        &[
+            Rule::On,
+            Rule::NoPass,  // No password required (will use cert auth)
+            Rule::AllKeys, // Can access all keys (~*)
+            Rule::AddCommand("GET".to_string()),
+            Rule::AddCommand("SET".to_string()),
+            Rule::AddCommand("PING".to_string()),
+            Rule::AddCommand("ACL|WHOAMI".to_string()),
+        ],
+    );
+
+    assert!(result.is_ok(), "Failed to create ACL user: {:?}", result);
+
+    // Verify that the user was created.
+    let users: Vec<String> = setup_conn.acl_users().expect("Failed to get ACL users");
+    assert!(
+        users.contains(&test_username),
+        "User {test_username} not found in ACL users list"
+    );
+
+    drop(setup_conn);
+
+    // Connect using the client certificate with CN=test_username.
+    // This connection should automatically authenticate as the test user.
+    let mut cert_conn = ctx.cert_auth_connection();
+
+    // Verify that the correct user is authenticated.
+    let whoami: String = cert_conn
+        .acl_whoami()
+        .expect("Failed to execute ACL WHOAMI");
+    assert_eq!(
+        whoami, test_username,
+        "Expected to be authenticated as '{test_username}', but got '{whoami}'"
+    );
+
+    const TEST_KEY: &str = "test_cert_auth_key";
+    const TEST_VALUE: &str = "test_value";
+
+    // Test that the authenticated user can execute only the allowed commands.
+    let _: () = cert_conn
+        .set(TEST_KEY, TEST_VALUE)
+        .expect("SET command should be allowed");
+
+    let value: String = cert_conn
+        .get(TEST_KEY)
+        .expect("GET command should be allowed");
+    assert_eq!(value, TEST_VALUE);
+
+    // Test that the authenticated user CANNOT execute disallowed commands.
+    // The user doesn't have +del permission, so this should fail.
+    let del_result: RedisResult<()> = cert_conn.del(TEST_KEY);
+    assert!(
+        del_result.is_err(),
+        "DEL command should have failed (user doesn't have +del permission)"
+    );
+}
+
+#[test]
+fn test_tls_certificate_authentication_no_matching_user() {
+    // This test verifies that when a client certificate's CN doesn't match
+    // any existing ACL user, Redis falls back to the "default" user.
+
+    // Check Redis binary version before creating the test context.
+    run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+
+    // Generate a random username (that won't have a corresponding ACL user).
+    let test_username = generate_random_username();
+
+    // Create a test context with cert-based authentication enabled.
+    let ctx = create_cert_auth_context_with_username(&test_username);
+
+    // Verify that the user doesn't exist.
+    let mut setup_conn = ctx.setup_connection();
+    let users: Vec<String> = setup_conn.acl_users().expect("Failed to get ACL users");
+    assert!(
+        !users.contains(&test_username),
+        "User {test_username} should not exist for this test"
+    );
+
+    drop(setup_conn);
+
+    // Connect with a certificate that has CN=test_username.
+    // Since the user doesn't exist, the server should fall back to authenticating the user as "default".
+    let mut cert_conn = ctx.cert_auth_connection();
+
+    // Verify that the authenticated user is "default" (fallback behavior).
+    let whoami: String = cert_conn
+        .acl_whoami()
+        .expect("Failed to execute ACL WHOAMI");
+    assert_eq!(
+        whoami, "default",
+        "Expected to fall back to 'default' user, but got '{whoami}'"
+    );
+
+    const TEST_KEY: &str = "test_cert_auth_fallback";
+    const TEST_VALUE: &str = "fallback_value";
+
+    // Verify that the authenticated user can execute commands as the default user.
+    let _: () = cert_conn
+        .set(TEST_KEY, TEST_VALUE)
+        .expect("SET should work as default user");
+
+    let value: String = cert_conn
+        .get(TEST_KEY)
+        .expect("GET should work as default user");
+    assert_eq!(value, TEST_VALUE);
+}


### PR DESCRIPTION
## Summary

This Pull Request implements support for Redis 8.6's new `TLS certificate-based authentication` feature, which allows automatic client authentication by mapping TLS certificate fields (like Common Name) to Redis ACL usernames.

## Motivation

Redis 8.6 introduced the `--tls-auth-clients-user <field>` configuration option that enables automatic user authentication based on TLS certificate fields. This eliminates the need for separate password-based authentication when using mTLS, providing a more seamless and secure authentication flow.

## Changes

### Core Infrastructure (`redis-test/src/server.rs`)
- Added `cert_auth_field: Option<&str>` parameter to `RedisServer::new_with_addr_tls_modules_and_spawner`
- When `Some(field)` is provided, the server spawns with `--tls-auth-clients-user <field>` flag
- Defaults to "CN" (Common Name) but extensible to other fields like OIDs in the future

### Certificate Generation (`redis-test/src/utils.rs`)
- Created the `build_client_cert_with_custom_cn()` function, which generates client certificates with custom Common Names

### Test Utilities (`redis/tests/support/mod.rs`)
- Added `TestContext::new_with_cert_auth(tls_files)` - uses CN field by default
- Added `TestContext::new_with_cert_auth_field(tls_files, field)` - for custom certificate fields
- Updated certificate loading helpers to support separate client certificates


## Testing
### Integration Tests (`redis/tests/test_tls_cert_auth.rs`)
- **Test 1**: Successful authentication when client cert CN matches Redis ACL username
- **Test 2**: Connection failure when no ACL user matches the certificate CN
- Both tests verify proper mTLS handshake and authentication behavior

## Relevant documentation:
- TLS: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/