### PR TITLE
feat: add Slot type and functions to create Slot / Route with key

### DIFF
--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -118,7 +118,7 @@ use crate::{
             MultipleNodeRoutingInfo, Redirect, ResponsePolicy, RoutingInfo, SingleNodeRoutingInfo,
         },
         slot_cmd,
-        slot_map::{SlotRange, SlotMap},
+        slot_map::{SlotMap, SlotRange},
         topology::parse_slots,
     },
     cmd,

--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -118,7 +118,7 @@ use crate::{
             MultipleNodeRoutingInfo, Redirect, ResponsePolicy, RoutingInfo, SingleNodeRoutingInfo,
         },
         slot_cmd,
-        slot_map::{Slot, SlotMap},
+        slot_map::{SlotRange, SlotMap},
         topology::parse_slots,
     },
     cmd,
@@ -906,7 +906,7 @@ where
                     .req_packed_command(&slot_refresh_cmd)
                     .await
                     .and_then(|value| value.extract_error())?;
-                let v: Vec<Slot> = parse_slots(value, addr.host())?;
+                let v: Vec<SlotRange> = parse_slots(value, addr.host())?;
                 build_slot_map(slots, v)
             }
             .await;
@@ -1048,7 +1048,7 @@ impl fmt::Debug for ConnectionState {
     }
 }
 
-fn build_slot_map(slot_map: &mut SlotMap, slots_data: Vec<Slot>) -> RedisResult<()> {
+fn build_slot_map(slot_map: &mut SlotMap, slots_data: Vec<SlotRange>) -> RedisResult<()> {
     slot_map.clear();
     slot_map.fill_slots(slots_data);
     trace!("{slot_map:?}");

--- a/redis/src/cluster_handling/async_connection/routing.rs
+++ b/redis/src/cluster_handling/async_connection/routing.rs
@@ -155,7 +155,7 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Ok(Some(Route::new_unsafe(12182, SlotAddr::ReplicaOptional)))
+            Ok(Some(Route::new_unchecked(12182, SlotAddr::ReplicaOptional)))
         );
     }
 
@@ -183,7 +183,7 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Ok(Some(Route::new_unsafe(12182, SlotAddr::Master)))
+            Ok(Some(Route::new_unchecked(12182, SlotAddr::Master)))
         );
     }
 

--- a/redis/src/cluster_handling/async_connection/routing.rs
+++ b/redis/src/cluster_handling/async_connection/routing.rs
@@ -139,6 +139,7 @@ pub(super) fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Opti
 #[cfg(test)]
 mod pipeline_routing_tests {
     use super::route_for_pipeline;
+    use crate::cluster_routing::Slot;
     use crate::{
         cluster_routing::{Route, SlotAddr},
         cmd,
@@ -155,7 +156,10 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Ok(Some(Route::new_unchecked(12182, SlotAddr::ReplicaOptional)))
+            Ok(Some(Route::with_slot(
+                Slot::new(12182).unwrap(),
+                SlotAddr::ReplicaOptional
+            )))
         );
     }
 
@@ -183,7 +187,10 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Ok(Some(Route::new_unchecked(12182, SlotAddr::Master)))
+            Ok(Some(Route::with_slot(
+                Slot::new(12182).unwrap(),
+                SlotAddr::Master
+            )))
         );
     }
 
@@ -215,7 +222,10 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Ok(Some(Route::new(12182, SlotAddr::Master)))
+            Ok(Some(Route::with_slot(
+                Slot::new(12182).unwrap(),
+                SlotAddr::Master
+            )))
         );
     }
 }

--- a/redis/src/cluster_handling/async_connection/routing.rs
+++ b/redis/src/cluster_handling/async_connection/routing.rs
@@ -155,7 +155,7 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Ok(Some(Route::new(12182, SlotAddr::ReplicaOptional)))
+            Ok(Some(Route::new_unsafe(12182, SlotAddr::ReplicaOptional)))
         );
     }
 
@@ -183,7 +183,7 @@ mod pipeline_routing_tests {
 
         assert_eq!(
             route_for_pipeline(&pipeline),
-            Ok(Some(Route::new(12182, SlotAddr::Master)))
+            Ok(Some(Route::new_unsafe(12182, SlotAddr::Master)))
         );
     }
 

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -944,10 +944,10 @@ pub struct Route(u16, SlotAddr);
 
 impl Route {
     /// Returns a new Route.
-    /// 
-    /// Since this function allows creating route for non-existing slot, 
+    ///
+    /// Since this function allows creating route for non-existing slot,
     /// it's recommended to use [`with_slot`] instead.
-    /// 
+    ///
     /// [`with_slot`]: Self::with_slot
     pub fn new(slot: u16, slot_addr: SlotAddr) -> Self {
         // TODO: Deprecate and remove this function in the future release

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -827,9 +827,10 @@ impl RoutingInfo {
                 r.arg_idx(2)
                     .and_then(|arg| std::str::from_utf8(arg).ok())
                     .and_then(|slot| slot.parse::<u16>().ok())
+                    .and_then(Slot::new)
                     .map(|slot| {
                         RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(
-                            Route::new_unchecked(slot, SlotAddr::Master),
+                            Route::with_slot(slot, SlotAddr::Master),
                         ))
                     })
             }
@@ -947,10 +948,6 @@ impl Route {
         note = "This function is deprecated because this allows user to create Route with invalid slot number. Use with_slot instead."
     )]
     pub fn new(slot: u16, slot_addr: SlotAddr) -> Self {
-        Self::new_unchecked(slot, slot_addr)
-    }
-
-    pub(crate) fn new_unchecked(slot: u16, slot_addr: SlotAddr) -> Self {
         Self(slot, slot_addr)
     }
 
@@ -1001,14 +998,17 @@ impl Slot {
     pub fn for_key(key: impl AsRef<[u8]>) -> Self {
         // prevent
         fn impl_(key: &[u8]) -> Slot {
-            Slot(crc16::State::<crc16::XMODEM>::calculate(get_hashtag(key).unwrap_or(key)) % SLOT_SIZE)
+            Slot(
+                crc16::State::<crc16::XMODEM>::calculate(get_hashtag(key).unwrap_or(key))
+                    % SLOT_SIZE,
+            )
         }
 
         impl_(key.as_ref())
     }
 
     /// Choose a random slot from `0..SLOT_SIZE` (excluding)
-    fn new_random() -> Self {
+    pub(crate) fn new_random() -> Self {
         let mut rng = rand::rng();
         Self(rng.random_range(0..SLOT_SIZE))
     }

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -944,10 +944,13 @@ pub struct Route(u16, SlotAddr);
 
 impl Route {
     /// Returns a new Route.
-    #[deprecated(
-        note = "This function is deprecated because this allows user to create Route with invalid slot number. Use with_slot instead."
-    )]
+    /// 
+    /// Since this function allows creating route for non-existing slot, 
+    /// it's recommended to use [`with_slot`] instead.
+    /// 
+    /// [`with_slot`]: Self::with_slot
     pub fn new(slot: u16, slot_addr: SlotAddr) -> Self {
+        // TODO: Deprecate and remove this function in the future release
         Self(slot, slot_addr)
     }
 

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -10,20 +10,6 @@ use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::HashMap;
 
-fn slot(key: &[u8]) -> u16 {
-    crc16::State::<crc16::XMODEM>::calculate(key) % SLOT_SIZE
-}
-
-/// Returns the slot that matches `key`.
-pub(crate) fn get_slot(key: &[u8]) -> u16 {
-    let key = match get_hashtag(key) {
-        Some(tag) => tag,
-        None => key,
-    };
-
-    slot(key)
-}
-
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) enum Redirect {
     Moved(NodeAddress),
@@ -441,11 +427,10 @@ pub(crate) fn combine_and_sort_array_results(
 }
 
 fn get_route(is_readonly: bool, key: &[u8]) -> Route {
-    let slot = get_slot(key);
     if is_readonly {
-        Route::new(slot, SlotAddr::ReplicaOptional)
+        Route::with_key(key, SlotAddr::ReplicaOptional)
     } else {
-        Route::new(slot, SlotAddr::Master)
+        Route::with_key(key, SlotAddr::Master)
     }
 }
 
@@ -838,16 +823,16 @@ impl RoutingInfo {
                     .map(|key| RoutingInfo::for_key(cmd, key))
             }
 
-            RouteBy::SecondArgSlot => r
-                .arg_idx(2)
-                .and_then(|arg| std::str::from_utf8(arg).ok())
-                .and_then(|slot| slot.parse::<u16>().ok())
-                .map(|slot| {
-                    RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
-                        slot,
-                        SlotAddr::Master,
-                    )))
-                }),
+            RouteBy::SecondArgSlot => {
+                r.arg_idx(2)
+                    .and_then(|arg| std::str::from_utf8(arg).ok())
+                    .and_then(|slot| slot.parse::<u16>().ok())
+                    .map(|slot| {
+                        RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(
+                            Route::new_unsafe(slot, SlotAddr::Master),
+                        ))
+                    })
+            }
 
             RouteBy::FirstKey => match r.arg_idx(1) {
                 Some(key) => Some(RoutingInfo::for_key(cmd, key)),
@@ -958,8 +943,25 @@ pub struct Route(u16, SlotAddr);
 
 impl Route {
     /// Returns a new Route.
+    #[deprecated(
+        note = "This function is deprecated because this allows user to create Route with invalid slot number. Use with_slot instead."
+    )]
     pub fn new(slot: u16, slot_addr: SlotAddr) -> Self {
+        Self::new_unsafe(slot, slot_addr)
+    }
+
+    pub(crate) fn new_unsafe(slot: u16, slot_addr: SlotAddr) -> Self {
         Self(slot, slot_addr)
+    }
+
+    /// Creates Route for specified slot and SlotAddr
+    pub fn with_slot(slot: Slot, slot_addr: SlotAddr) -> Self {
+        Self(slot.0, slot_addr)
+    }
+
+    /// Craetes Route for specified key and SlotAddr
+    pub fn with_key(key: impl AsRef<[u8]>, slot_addr: SlotAddr) -> Self {
+        Self::with_slot(Slot::for_key(key), slot_addr)
     }
 
     /// Returns the slot number of the route.
@@ -974,14 +976,42 @@ impl Route {
 
     /// Returns a new Route for a random primary node
     pub(crate) fn new_random_primary() -> Self {
-        Self::new(random_slot(), SlotAddr::Master)
+        Self::with_slot(Slot::new_random(), SlotAddr::Master)
     }
 }
 
-/// Choose a random slot from `0..SLOT_SIZE` (excluding)
-fn random_slot() -> u16 {
-    let mut rng = rand::rng();
-    rng.random_range(0..SLOT_SIZE)
+/// Defines the valid redis key slot.
+// Type invariant: Slot.0 must be 0..SLOT_SIZE (inclusive lower bound, exclusive upper bound)
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
+pub struct Slot(u16);
+
+impl Slot {
+    /// Creates new slot with precomputed slot number
+    ///
+    /// Returns None if the slot number is out of bounds.
+    pub const fn new(slot: u16) -> Option<Self> {
+        if slot < SLOT_SIZE {
+            Some(Self(slot))
+        } else {
+            None
+        }
+    }
+
+    /// Computes slot number for the specified key
+    pub fn for_key(key: impl AsRef<[u8]>) -> Self {
+        // prevent
+        fn impl_(key: &[u8]) -> Slot {
+            Slot(crc16::State::<crc16::XMODEM>::calculate(get_hashtag(key).unwrap_or(key)) % SLOT_SIZE)
+        }
+
+        impl_(key.as_ref())
+    }
+
+    /// Choose a random slot from `0..SLOT_SIZE` (excluding)
+    fn new_random() -> Self {
+        let mut rng = rand::rng();
+        Self(rng.random_range(0..SLOT_SIZE))
+    }
 }
 
 fn get_hashtag(key: &[u8]) -> Option<&[u8]> {
@@ -999,7 +1029,6 @@ mod tests_routing {
         AggregateOp, MultiSlotArgPattern, MultipleNodeRoutingInfo, ResponsePolicy, Route,
         RoutingInfo, SingleNodeRoutingInfo, SlotAddr, command_for_multi_slot_indices,
     };
-    use crate::cluster_routing::slot;
     use crate::{Value, cmd, parser::parse_redis_value};
     use assert_matches::assert_matches;
     use core::panic;
@@ -1150,7 +1179,7 @@ mod tests_routing {
         assert_eq!(
             RoutingInfo::for_routable(cmd("FCALL").arg("foo").arg(1).arg("mykey")),
             Some(RoutingInfo::SingleNode(
-                SingleNodeRoutingInfo::SpecificNode(Route::new(slot(b"mykey"), SlotAddr::Master))
+                SingleNodeRoutingInfo::SpecificNode(Route::with_key(b"mykey", SlotAddr::Master))
             ))
         );
 
@@ -1161,7 +1190,7 @@ mod tests_routing {
                     .arg(1)
                     .arg("foo"),
                 Some(RoutingInfo::SingleNode(
-                    SingleNodeRoutingInfo::SpecificNode(Route::new(slot(b"foo"), SlotAddr::Master)),
+                    SingleNodeRoutingInfo::SpecificNode(Route::with_key(b"foo", SlotAddr::Master)),
                 )),
             ),
             (
@@ -1172,8 +1201,8 @@ mod tests_routing {
                     .arg("$")
                     .arg("MKSTREAM"),
                 Some(RoutingInfo::SingleNode(
-                    SingleNodeRoutingInfo::SpecificNode(Route::new(
-                        slot(b"mystream"),
+                    SingleNodeRoutingInfo::SpecificNode(Route::with_key(
+                        b"mystream",
                         SlotAddr::Master,
                     )),
                 )),
@@ -1181,8 +1210,8 @@ mod tests_routing {
             (
                 cmd("XINFO").arg("GROUPS").arg("foo"),
                 Some(RoutingInfo::SingleNode(
-                    SingleNodeRoutingInfo::SpecificNode(Route::new(
-                        slot(b"foo"),
+                    SingleNodeRoutingInfo::SpecificNode(Route::with_key(
+                        b"foo",
                         SlotAddr::ReplicaOptional,
                     )),
                 )),
@@ -1195,8 +1224,8 @@ mod tests_routing {
                     .arg("STREAMS")
                     .arg("mystream"),
                 Some(RoutingInfo::SingleNode(
-                    SingleNodeRoutingInfo::SpecificNode(Route::new(
-                        slot(b"mystream"),
+                    SingleNodeRoutingInfo::SpecificNode(Route::with_key(
+                        b"mystream",
                         SlotAddr::Master,
                     )),
                 )),
@@ -1211,8 +1240,8 @@ mod tests_routing {
                     .arg("0-0")
                     .arg("0-0"),
                 Some(RoutingInfo::SingleNode(
-                    SingleNodeRoutingInfo::SpecificNode(Route::new(
-                        slot(b"mystream"),
+                    SingleNodeRoutingInfo::SpecificNode(Route::with_key(
+                        b"mystream",
                         SlotAddr::ReplicaOptional,
                     )),
                 )),

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -829,7 +829,7 @@ impl RoutingInfo {
                     .and_then(|slot| slot.parse::<u16>().ok())
                     .map(|slot| {
                         RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(
-                            Route::new_unsafe(slot, SlotAddr::Master),
+                            Route::new_unchecked(slot, SlotAddr::Master),
                         ))
                     })
             }
@@ -947,10 +947,10 @@ impl Route {
         note = "This function is deprecated because this allows user to create Route with invalid slot number. Use with_slot instead."
     )]
     pub fn new(slot: u16, slot_addr: SlotAddr) -> Self {
-        Self::new_unsafe(slot, slot_addr)
+        Self::new_unchecked(slot, slot_addr)
     }
 
-    pub(crate) fn new_unsafe(slot: u16, slot_addr: SlotAddr) -> Self {
+    pub(crate) fn new_unchecked(slot: u16, slot_addr: SlotAddr) -> Self {
         Self(slot, slot_addr)
     }
 

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -240,26 +240,26 @@ mod tests {
 
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(1, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(1, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(500, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(1000, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(1000, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
                 .slot_addr_for_route(
-                    &Route::new_unsafe(1000, SlotAddr::ReplicaOptional),
+                    &Route::new_unchecked(1000, SlotAddr::ReplicaOptional),
                     Some(&strategy)
                 )
                 .unwrap(),
@@ -267,25 +267,25 @@ mod tests {
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(1001, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(1001, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node2:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(1500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(1500, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node2:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(2000, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(2000, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node2:6379"
         );
         assert!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(2001, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(2001, SlotAddr::Master), Some(&strategy))
                 .is_none()
         );
     }
@@ -301,13 +301,13 @@ mod tests {
 
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(1000, SlotAddr::ReplicaOptional), None)
+                .slot_addr_for_route(&Route::new_unchecked(1000, SlotAddr::ReplicaOptional), None)
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(1000, SlotAddr::ReplicaRequired), None)
+                .slot_addr_for_route(&Route::new_unchecked(1000, SlotAddr::ReplicaRequired), None)
                 .unwrap(),
             "replica1:6379"
         );
@@ -380,8 +380,8 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unsafe(1, SlotAddr::Master), vec![]),
-            (Route::new_unsafe(2001, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unchecked(1, SlotAddr::Master), vec![]),
+            (Route::new_unchecked(2001, SlotAddr::ReplicaOptional), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -396,8 +396,8 @@ mod tests {
     fn test_slot_map_should_ignore_replicas_in_multi_slot_if_no_strategy_is_set() {
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unsafe(1, SlotAddr::Master), vec![]),
-            (Route::new_unsafe(2001, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unchecked(1, SlotAddr::Master), vec![]),
+            (Route::new_unchecked(2001, SlotAddr::ReplicaOptional), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, None)
@@ -415,12 +415,12 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unsafe(1, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unsafe(2001, SlotAddr::Master), vec![]),
-            (Route::new_unsafe(2, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unsafe(2002, SlotAddr::Master), vec![]),
-            (Route::new_unsafe(3, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unsafe(2003, SlotAddr::Master), vec![]),
+            (Route::new_unchecked(1, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unchecked(2001, SlotAddr::Master), vec![]),
+            (Route::new_unchecked(2, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unchecked(2002, SlotAddr::Master), vec![]),
+            (Route::new_unchecked(3, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unchecked(2003, SlotAddr::Master), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -443,10 +443,10 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unsafe(1, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unsafe(5000, SlotAddr::Master), vec![]),
-            (Route::new_unsafe(6000, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unsafe(2002, SlotAddr::Master), vec![]),
+            (Route::new_unchecked(1, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unchecked(5000, SlotAddr::Master), vec![]),
+            (Route::new_unchecked(6000, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unchecked(2002, SlotAddr::Master), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -544,7 +544,7 @@ mod tests {
         assert_eq!(
             slot_map
                 .slot_addr_for_route(
-                    &Route::new_unsafe(500, SlotAddr::ReplicaOptional),
+                    &Route::new_unchecked(500, SlotAddr::ReplicaOptional),
                     Some(&strategy)
                 )
                 .unwrap(),
@@ -555,7 +555,7 @@ mod tests {
         assert_eq!(
             slot_map
                 .slot_addr_for_route(
-                    &Route::new_unsafe(500, SlotAddr::ReplicaRequired),
+                    &Route::new_unchecked(500, SlotAddr::ReplicaRequired),
                     Some(&strategy)
                 )
                 .unwrap(),
@@ -565,7 +565,7 @@ mod tests {
         // Master always returns primary regardless of strategy
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unsafe(500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unchecked(500, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -202,6 +202,7 @@ impl SlotRange {
 mod tests {
     use super::*;
     use crate::cluster_handling::read_routing::ReadRoutingStrategy;
+    use crate::cluster_routing::Slot;
 
     fn addr(s: &str) -> NodeAddress {
         NodeAddress::try_from(s).unwrap()
@@ -240,26 +241,35 @@ mod tests {
 
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(1, SlotAddr::Master), Some(&strategy))
-                .unwrap(),
-            "node1:6379"
-        );
-        assert_eq!(
-            slot_map
-                .slot_addr_for_route(&Route::new_unchecked(500, SlotAddr::Master), Some(&strategy))
-                .unwrap(),
-            "node1:6379"
-        );
-        assert_eq!(
-            slot_map
-                .slot_addr_for_route(&Route::new_unchecked(1000, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(1).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
                 .slot_addr_for_route(
-                    &Route::new_unchecked(1000, SlotAddr::ReplicaOptional),
+                    &Route::with_slot(Slot::new(500).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
+                .unwrap(),
+            "node1:6379"
+        );
+        assert_eq!(
+            slot_map
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(1000).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
+                .unwrap(),
+            "node1:6379"
+        );
+        assert_eq!(
+            slot_map
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(1000).unwrap(), SlotAddr::ReplicaOptional),
                     Some(&strategy)
                 )
                 .unwrap(),
@@ -267,25 +277,37 @@ mod tests {
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(1001, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(1001).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
                 .unwrap(),
             "node2:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(1500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(1500).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
                 .unwrap(),
             "node2:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(2000, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(2000).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
                 .unwrap(),
             "node2:6379"
         );
         assert!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(2001, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(2001).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
                 .is_none()
         );
     }
@@ -301,13 +323,19 @@ mod tests {
 
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(1000, SlotAddr::ReplicaOptional), None)
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(1000).unwrap(), SlotAddr::ReplicaOptional),
+                    None
+                )
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(1000, SlotAddr::ReplicaRequired), None)
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(1000).unwrap(), SlotAddr::ReplicaRequired),
+                    None
+                )
                 .unwrap(),
             "replica1:6379"
         );
@@ -380,8 +408,14 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unchecked(1, SlotAddr::Master), vec![]),
-            (Route::new_unchecked(2001, SlotAddr::ReplicaOptional), vec![]),
+            (
+                Route::with_slot(Slot::new(1).unwrap(), SlotAddr::Master),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(2001).unwrap(), SlotAddr::ReplicaOptional),
+                vec![],
+            ),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -396,8 +430,14 @@ mod tests {
     fn test_slot_map_should_ignore_replicas_in_multi_slot_if_no_strategy_is_set() {
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unchecked(1, SlotAddr::Master), vec![]),
-            (Route::new_unchecked(2001, SlotAddr::ReplicaOptional), vec![]),
+            (
+                Route::with_slot(Slot::new(1).unwrap(), SlotAddr::Master),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(2001).unwrap(), SlotAddr::ReplicaOptional),
+                vec![],
+            ),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, None)
@@ -415,12 +455,30 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unchecked(1, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unchecked(2001, SlotAddr::Master), vec![]),
-            (Route::new_unchecked(2, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unchecked(2002, SlotAddr::Master), vec![]),
-            (Route::new_unchecked(3, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unchecked(2003, SlotAddr::Master), vec![]),
+            (
+                Route::with_slot(Slot::new(1).unwrap(), SlotAddr::ReplicaOptional),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(2001).unwrap(), SlotAddr::Master),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(2).unwrap(), SlotAddr::ReplicaOptional),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(2002).unwrap(), SlotAddr::Master),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(3).unwrap(), SlotAddr::ReplicaOptional),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(2003).unwrap(), SlotAddr::Master),
+                vec![],
+            ),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -443,10 +501,22 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new_unchecked(1, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unchecked(5000, SlotAddr::Master), vec![]),
-            (Route::new_unchecked(6000, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new_unchecked(2002, SlotAddr::Master), vec![]),
+            (
+                Route::with_slot(Slot::new(1).unwrap(), SlotAddr::ReplicaOptional),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(5000).unwrap(), SlotAddr::Master),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(6000).unwrap(), SlotAddr::ReplicaOptional),
+                vec![],
+            ),
+            (
+                Route::with_slot(Slot::new(2002).unwrap(), SlotAddr::Master),
+                vec![],
+            ),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -544,7 +614,7 @@ mod tests {
         assert_eq!(
             slot_map
                 .slot_addr_for_route(
-                    &Route::new_unchecked(500, SlotAddr::ReplicaOptional),
+                    &Route::with_slot(Slot::new(500).unwrap(), SlotAddr::ReplicaOptional),
                     Some(&strategy)
                 )
                 .unwrap(),
@@ -555,7 +625,7 @@ mod tests {
         assert_eq!(
             slot_map
                 .slot_addr_for_route(
-                    &Route::new_unchecked(500, SlotAddr::ReplicaRequired),
+                    &Route::with_slot(Slot::new(500).unwrap(), SlotAddr::ReplicaRequired),
                     Some(&strategy)
                 )
                 .unwrap(),
@@ -565,7 +635,10 @@ mod tests {
         // Master always returns primary regardless of strategy
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new_unchecked(500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::with_slot(Slot::new(500).unwrap(), SlotAddr::Master),
+                    Some(&strategy)
+                )
                 .unwrap(),
             "node1:6379"
         );

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -240,26 +240,26 @@ mod tests {
 
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(1, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(1, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(500, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(1000, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(1000, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
                 .slot_addr_for_route(
-                    &Route::new(1000, SlotAddr::ReplicaOptional),
+                    &Route::new_unsafe(1000, SlotAddr::ReplicaOptional),
                     Some(&strategy)
                 )
                 .unwrap(),
@@ -267,25 +267,25 @@ mod tests {
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(1001, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(1001, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node2:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(1500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(1500, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node2:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(2000, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(2000, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node2:6379"
         );
         assert!(
             slot_map
-                .slot_addr_for_route(&Route::new(2001, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(2001, SlotAddr::Master), Some(&strategy))
                 .is_none()
         );
     }
@@ -301,13 +301,13 @@ mod tests {
 
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(1000, SlotAddr::ReplicaOptional), None)
+                .slot_addr_for_route(&Route::new_unsafe(1000, SlotAddr::ReplicaOptional), None)
                 .unwrap(),
             "node1:6379"
         );
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(1000, SlotAddr::ReplicaRequired), None)
+                .slot_addr_for_route(&Route::new_unsafe(1000, SlotAddr::ReplicaRequired), None)
                 .unwrap(),
             "replica1:6379"
         );
@@ -380,8 +380,8 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new(1, SlotAddr::Master), vec![]),
-            (Route::new(2001, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unsafe(1, SlotAddr::Master), vec![]),
+            (Route::new_unsafe(2001, SlotAddr::ReplicaOptional), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -396,8 +396,8 @@ mod tests {
     fn test_slot_map_should_ignore_replicas_in_multi_slot_if_no_strategy_is_set() {
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new(1, SlotAddr::Master), vec![]),
-            (Route::new(2001, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unsafe(1, SlotAddr::Master), vec![]),
+            (Route::new_unsafe(2001, SlotAddr::ReplicaOptional), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, None)
@@ -415,12 +415,12 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new(1, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new(2001, SlotAddr::Master), vec![]),
-            (Route::new(2, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new(2002, SlotAddr::Master), vec![]),
-            (Route::new(3, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new(2003, SlotAddr::Master), vec![]),
+            (Route::new_unsafe(1, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unsafe(2001, SlotAddr::Master), vec![]),
+            (Route::new_unsafe(2, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unsafe(2002, SlotAddr::Master), vec![]),
+            (Route::new_unsafe(3, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unsafe(2003, SlotAddr::Master), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -443,10 +443,10 @@ mod tests {
         let strategy = FirstReplicaStrategy;
         let slot_map = get_slot_map();
         let routes = vec![
-            (Route::new(1, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new(5000, SlotAddr::Master), vec![]),
-            (Route::new(6000, SlotAddr::ReplicaOptional), vec![]),
-            (Route::new(2002, SlotAddr::Master), vec![]),
+            (Route::new_unsafe(1, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unsafe(5000, SlotAddr::Master), vec![]),
+            (Route::new_unsafe(6000, SlotAddr::ReplicaOptional), vec![]),
+            (Route::new_unsafe(2002, SlotAddr::Master), vec![]),
         ];
         let addresses = slot_map
             .addresses_for_multi_slot(&routes, Some(&strategy))
@@ -543,7 +543,10 @@ mod tests {
         // ReplicaOptional with AlwaysFirstReplica should always return replica1
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(500, SlotAddr::ReplicaOptional), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::new_unsafe(500, SlotAddr::ReplicaOptional),
+                    Some(&strategy)
+                )
                 .unwrap(),
             "replica1:6379"
         );
@@ -551,7 +554,10 @@ mod tests {
         // ReplicaRequired with AlwaysFirstReplica should also return replica1
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(500, SlotAddr::ReplicaRequired), Some(&strategy))
+                .slot_addr_for_route(
+                    &Route::new_unsafe(500, SlotAddr::ReplicaRequired),
+                    Some(&strategy)
+                )
                 .unwrap(),
             "replica1:6379"
         );
@@ -559,7 +565,7 @@ mod tests {
         // Master always returns primary regardless of strategy
         assert_eq!(
             slot_map
-                .slot_addr_for_route(&Route::new(500, SlotAddr::Master), Some(&strategy))
+                .slot_addr_for_route(&Route::new_unsafe(500, SlotAddr::Master), Some(&strategy))
                 .unwrap(),
             "node1:6379"
         );

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -19,7 +19,7 @@ impl SlotMap {
         }
     }
 
-    pub fn from_slots(slots: Vec<Slot>) -> Self {
+    pub fn from_slots(slots: Vec<SlotRange>) -> Self {
         let mut map = SlotRangeMap::new();
         for slot in slots {
             map.insert(slot.start, slot.end, SlotAddrs::from_slot(slot));
@@ -28,7 +28,7 @@ impl SlotMap {
     }
 
     #[cfg(feature = "cluster-async")]
-    pub fn fill_slots(&mut self, slots: Vec<Slot>) {
+    pub fn fill_slots(&mut self, slots: Vec<SlotRange>) {
         for slot in slots {
             self.slots
                 .insert(slot.start, slot.end, SlotAddrs::from_slot(slot));
@@ -118,7 +118,7 @@ impl SlotMap {
     }
 }
 
-/// This is just a simplified version of [`Slot`],
+/// This is just a simplified version of [`SlotRange`],
 /// which stores only the master and optional replica
 /// to avoid the need to choose a replica each time
 /// a command is executed
@@ -162,7 +162,7 @@ impl SlotAddrs {
         }
     }
 
-    pub(crate) fn from_slot(slot: Slot) -> Self {
+    pub(crate) fn from_slot(slot: SlotRange) -> Self {
         SlotAddrs::new(slot.master, slot.replicas)
     }
 }
@@ -180,14 +180,14 @@ impl<'a> IntoIterator for &'a SlotAddrs {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct Slot {
+pub(crate) struct SlotRange {
     pub(crate) start: u16,
     pub(crate) end: u16,
     pub(crate) master: NodeAddress,
     pub(crate) replicas: Vec<NodeAddress>,
 }
 
-impl Slot {
+impl SlotRange {
     pub fn new(s: u16, e: u16, m: NodeAddress, r: Vec<NodeAddress>) -> Self {
         Self {
             start: s,
@@ -224,13 +224,13 @@ mod tests {
     fn test_slot_map_with_strategy() {
         let strategy = FirstReplicaStrategy;
         let slot_map = SlotMap::from_slots(vec![
-            Slot {
+            SlotRange {
                 start: 1,
                 end: 1000,
                 master: addr("node1:6379"),
                 replicas: vec![addr("replica1:6379")],
             },
-            Slot {
+            SlotRange {
                 start: 1001,
                 end: 2000,
                 master: addr("node2:6379"),
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_slot_map_when_no_strategy_is_set() {
-        let slot_map = SlotMap::from_slots(vec![Slot {
+        let slot_map = SlotMap::from_slots(vec![SlotRange {
             start: 1,
             end: 1000,
             master: addr("node1:6379"),
@@ -315,14 +315,14 @@ mod tests {
 
     fn get_slot_map() -> SlotMap {
         SlotMap::from_slots(vec![
-            Slot::new(1, 1000, addr("node1:6379"), vec![addr("replica1:6379")]),
-            Slot::new(
+            SlotRange::new(1, 1000, addr("node1:6379"), vec![addr("replica1:6379")]),
+            SlotRange::new(
                 1002,
                 2000,
                 addr("node2:6379"),
                 vec![addr("replica2:6379"), addr("replica3:6379")],
             ),
-            Slot::new(
+            SlotRange::new(
                 2001,
                 3000,
                 addr("node3:6379"),
@@ -332,7 +332,7 @@ mod tests {
                     addr("replica6:6379"),
                 ],
             ),
-            Slot::new(
+            SlotRange::new(
                 3001,
                 4000,
                 addr("node2:6379"),
@@ -465,8 +465,8 @@ mod tests {
     #[test]
     fn test_slot_map_topology() {
         let slot_map = SlotMap::from_slots(vec![
-            Slot::new(0, 5000, addr("node1:6379"), vec![addr("replica1:6379")]),
-            Slot::new(5001, 10000, addr("node2:6379"), vec![]),
+            SlotRange::new(0, 5000, addr("node1:6379"), vec![addr("replica1:6379")]),
+            SlotRange::new(5001, 10000, addr("node2:6379"), vec![]),
         ]);
         let topo = slot_map.topology();
         assert_eq!(topo.shards().count(), 2);
@@ -533,7 +533,7 @@ mod tests {
         }
 
         let strategy = AlwaysFirstReplica;
-        let slot_map = SlotMap::from_slots(vec![Slot::new(
+        let slot_map = SlotMap::from_slots(vec![SlotRange::new(
             1,
             1000,
             addr("node1:6379"),

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -76,13 +76,13 @@ use super::{
     client::ClusterParams,
     read_routing::ReadRoutingStrategy,
     routing::{Redirect, Route, RoutingInfo},
-    slot_map::{SLOT_SIZE, SlotMap},
+    slot_map::SlotMap,
 };
 use crate::IntoConnectionInfo;
 pub use crate::TlsMode; // Pub for backwards compatibility
 use crate::cluster_handling::{get_connection_info, slot_cmd};
 use crate::cluster_routing::{
-    MultipleNodeRoutingInfo, ResponsePolicy, Routable, SingleNodeRoutingInfo, SlotAddr,
+    MultipleNodeRoutingInfo, ResponsePolicy, Routable, SingleNodeRoutingInfo, Slot, SlotAddr,
 };
 use crate::cmd::{Cmd, cmd};
 use crate::connection::{Connection, ConnectionInfo, ConnectionLike, connect};
@@ -90,7 +90,7 @@ use crate::errors::{ErrorKind, RedisError, RetryMethod};
 use crate::parser::parse_redis_value;
 use crate::types::{HashMap, RedisResult, Value};
 use pipeline::UNROUTABLE_ERROR;
-use rand::{Rng, rng, seq::IteratorRandom};
+use rand::{rng, seq::IteratorRandom};
 
 pub use pipeline::{ClusterPipeline, cluster_pipe};
 
@@ -580,13 +580,9 @@ where
         };
 
         match RoutingInfo::for_routable(cmd) {
-            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => {
-                let mut rng = rng();
-                Ok(addr_for_slot(Route::new_unchecked(
-                    rng.random_range(0..SLOT_SIZE),
-                    SlotAddr::Master,
-                ))?)
-            }
+            Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => Ok(addr_for_slot(
+                Route::with_slot(Slot::new_random(), SlotAddr::Master),
+            )?),
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
                 Ok(addr_for_slot(route)?)
             }

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -582,7 +582,7 @@ where
         match RoutingInfo::for_routable(cmd) {
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => {
                 let mut rng = rng();
-                Ok(addr_for_slot(Route::new(
+                Ok(addr_for_slot(Route::new_unsafe(
                     rng.random_range(0..SLOT_SIZE),
                     SlotAddr::Master,
                 ))?)

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -582,7 +582,7 @@ where
         match RoutingInfo::for_routable(cmd) {
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => {
                 let mut rng = rng();
-                Ok(addr_for_slot(Route::new_unsafe(
+                Ok(addr_for_slot(Route::new_unchecked(
                     rng.random_range(0..SLOT_SIZE),
                     SlotAddr::Master,
                 ))?)

--- a/redis/src/cluster_handling/topology.rs
+++ b/redis/src/cluster_handling/topology.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use arcstr::ArcStr;
 
 use super::NodeAddress;
-use super::slot_map::Slot;
+use super::slot_map::SlotRange;
 use crate::{RedisResult, Value, connection::is_wildcard_address};
 
 // Parse slot data from raw redis value.
@@ -13,7 +13,7 @@ pub(crate) fn parse_slots(
     raw_slot_resp: Value,
     // The DNS address of the node from which `raw_slot_resp` was received.
     addr_of_answering_node: &str,
-) -> RedisResult<Vec<Slot>> {
+) -> RedisResult<Vec<SlotRange>> {
     // Parse response.
     let mut slots = Vec::with_capacity(2);
     let mut hosts = HashSet::<ArcStr>::new();
@@ -95,7 +95,7 @@ pub(crate) fn parse_slots(
             };
             let replicas: Vec<NodeAddress> = iterator.filter_map(try_to_address).collect();
 
-            slots.push(Slot::new(start, end, primary, replicas));
+            slots.push(SlotRange::new(start, end, primary, replicas));
         }
     }
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -193,7 +193,7 @@ mod cluster_async {
         let res2: Option<String> = connection.get("bar").await.unwrap();
         assert_eq!(res2, Some("foo".to_string()));
 
-        let route = Route::new_unsafe(1, SlotAddr::Master);
+        let route = Route::new_unchecked(1, SlotAddr::Master);
         let single_node_route = SingleNodeRoutingInfo::SpecificNode(route);
         let routing = RoutingInfo::SingleNode(single_node_route);
         assert_eq!(

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -193,7 +193,7 @@ mod cluster_async {
         let res2: Option<String> = connection.get("bar").await.unwrap();
         assert_eq!(res2, Some("foo".to_string()));
 
-        let route = Route::new(1, SlotAddr::Master);
+        let route = Route::new_unsafe(1, SlotAddr::Master);
         let single_node_route = SingleNodeRoutingInfo::SpecificNode(route);
         let routing = RoutingInfo::SingleNode(single_node_route);
         assert_eq!(

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -25,7 +25,7 @@ mod cluster_async {
         cluster_read_routing::{RandomReplicaStrategy, RoundRobinReplicaStrategy},
         cluster_routing::{
             MultipleNodeRoutingInfo, ResponsePolicy, Route, RoutingInfo, SingleNodeRoutingInfo,
-            SlotAddr,
+            Slot, SlotAddr,
         },
         cmd, from_redis_value, parse_redis_value, pipe,
     };
@@ -193,7 +193,7 @@ mod cluster_async {
         let res2: Option<String> = connection.get("bar").await.unwrap();
         assert_eq!(res2, Some("foo".to_string()));
 
-        let route = Route::new_unchecked(1, SlotAddr::Master);
+        let route = Route::with_slot(Slot::new(1).unwrap(), SlotAddr::Master);
         let single_node_route = SingleNodeRoutingInfo::SpecificNode(route);
         let routing = RoutingInfo::SingleNode(single_node_route);
         assert_eq!(


### PR DESCRIPTION
Closes #2020

In addition, I deprecated existing `Route::new` function since it allows creating route with invalid slot number.

I've implemented both API proposal from the issue.