### PR TITLE
Add support for the HOTKEYS commands

### DIFF
--- a/redis/src/commands/hotkeys.rs
+++ b/redis/src/commands/hotkeys.rs
@@ -1,0 +1,906 @@
+//! Defines types to use with the HOTKEYS commands.
+//!
+//! The HOTKEYS command is a stateful, node-local command requiring session affinity.
+//! It should only be used on standalone clients (Connection, MultiplexedConnection, etc.)
+//! and NOT on cluster clients (ClusterConnection).
+//!
+//! # Command Syntax (Redis 8.6.0+)
+//!
+//! ```text
+//! HOTKEYS START METRICS count [CPU] [NET] [COUNT k] [DURATION seconds] [SAMPLE ratio] [SLOTS count slot [slot ...]]
+//! HOTKEYS GET
+//! HOTKEYS STOP
+//! HOTKEYS RESET
+//! ```
+//!
+//! # Using HOTKEYS in Cluster Mode
+//!
+//! While the high-level `HotkeysCommands` trait is not available on `ClusterConnection`,
+//! HOTKEYS commands can still be used on individual cluster nodes by using `route_command` with
+//! explicit node routing:
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "cluster")]
+//! # {
+//! use redis::cluster::ClusterClient;
+//! use redis::cluster_routing::{RoutingInfo, SingleNodeRoutingInfo};
+//! use redis::{cmd, FromRedisValue, HotkeysOptions, HotkeysResponse};
+//!
+//! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/"];
+//! let client = ClusterClient::new(nodes).unwrap();
+//! let mut connection = client.get_connection().unwrap();
+//!
+//! // Route to a specific node
+//! let routing = RoutingInfo::SingleNode(SingleNodeRoutingInfo::ByAddress {
+//!     host: "127.0.0.1".to_string(),
+//!     port: 6379,
+//! });
+//!
+//! // Start tracking on that specific node - track keys by CPU time percentage
+//! let opts = HotkeysOptions::new_with_cpu();
+//! let _ = connection.route_command(
+//!     &cmd("HOTKEYS").arg("START").arg(opts),
+//!     routing.clone()
+//! ).unwrap();
+//!
+//! // ... perform operations ...
+//!
+//! // Get metrics from the same node
+//! let value = connection.route_command(
+//!     &cmd("HOTKEYS").arg("GET"),
+//!     routing.clone()
+//! ).unwrap();
+//! let response = HotkeysResponse::from_redis_value(value).unwrap();
+//!
+//! // Stop tracking on that node
+//! let _ = connection.route_command(
+//!     &cmd("HOTKEYS").arg("STOP"),
+//!     routing
+//! ).unwrap();
+//! # }
+//! ```
+
+use crate::errors::ParsingError;
+use crate::types::{FromRedisValue, RedisWrite, ToRedisArgs, Value};
+use std::collections::HashMap;
+
+/// Minimum value for the COUNT parameter of HOTKEYS START.
+pub const HOTKEYS_COUNT_MIN: u64 = 1;
+/// Maximum value for the COUNT parameter of HOTKEYS START.
+pub const HOTKEYS_COUNT_MAX: u64 = 64;
+
+/// Options for the HOTKEYS START command.
+///
+/// At least one of `cpu` or `net` must be enabled to specify which metrics to collect.
+/// The `METRICS count` is automatically derived from how many metric types are enabled.
+///
+/// Use [`HotkeysOptions::new_with_cpu()`] or [`HotkeysOptions::new_with_net()`] constructors to create
+/// valid options with at least one metric enabled.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use redis::{HotkeysOptions, HotkeysCommands};
+///
+/// # fn example() -> redis::RedisResult<()> {
+/// let client = redis::Client::open("redis://127.0.0.1/")?;
+/// let mut con = client.get_connection()?;
+///
+/// // Track hotkeys by both CPU and network usage for 60 seconds
+/// let opts = HotkeysOptions::new_with_cpu()
+///     .and_net()
+///     .with_duration_secs(60);
+///
+/// con.hotkeys_start(opts)?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug)]
+pub struct HotkeysOptions {
+    /// Track hotkeys by CPU time percentage
+    cpu: bool,
+    /// Track hotkeys by network bytes percentage
+    net: bool,
+    /// Value of K for top-K hotkeys tracking (optional COUNT parameter)
+    count_k: Option<u64>,
+    /// Duration in seconds for tracking (optional DURATION parameter)
+    duration_secs: Option<u64>,
+    /// Sampling ratio for probabilistic tracking (optional SAMPLE parameter)
+    sample_ratio: Option<u64>,
+    /// Specific slots to track in cluster mode (optional SLOTS parameter)
+    slots: Option<Vec<u16>>,
+}
+
+impl HotkeysOptions {
+    /// Creates options to track hotkeys by CPU time percentage.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use redis::HotkeysOptions;
+    ///
+    /// // Track hotkeys by CPU time
+    /// let opts = HotkeysOptions::new_with_cpu();
+    ///
+    /// // Track by both CPU and network
+    /// let opts = HotkeysOptions::new_with_cpu().and_net();
+    /// ```
+    pub fn new_with_cpu() -> Self {
+        Self {
+            cpu: true,
+            net: false,
+            count_k: None,
+            duration_secs: None,
+            sample_ratio: None,
+            slots: None,
+        }
+    }
+
+    /// Creates options to track hotkeys by network bytes percentage.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use redis::HotkeysOptions;
+    ///
+    /// // Track hotkeys by network bytes
+    /// let opts = HotkeysOptions::new_with_net();
+    ///
+    /// // Track by both network and CPU
+    /// let opts = HotkeysOptions::new_with_net().and_cpu();
+    /// ```
+    pub fn new_with_net() -> Self {
+        Self {
+            cpu: false,
+            net: true,
+            count_k: None,
+            duration_secs: None,
+            sample_ratio: None,
+            slots: None,
+        }
+    }
+
+    /// Also track hotkeys by CPU time percentage.
+    ///
+    /// Used when both metrics are needed and the options were created using [`HotkeysOptions::new_with_net()`]
+    pub fn and_cpu(mut self) -> Self {
+        self.cpu = true;
+        self
+    }
+
+    /// Also track hotkeys by network bytes percentage.
+    ///
+    /// Used when both metrics are needed and the options were created using [`HotkeysOptions::new_with_cpu()`]
+    pub fn and_net(mut self) -> Self {
+        self.net = true;
+        self
+    }
+
+    /// Returns the number of metrics being tracked.
+    fn metrics_count(&self) -> u64 {
+        self.cpu as u64 + self.net as u64
+    }
+
+    /// Set the value of K for top-K hotkeys tracking.
+    ///
+    /// This is the COUNT parameter in the Redis command.
+    ///
+    /// # Errors
+    /// Returns an error if `k` is not in the valid range `1..=64`
+    /// (see [`HOTKEYS_COUNT_MIN`] and [`HOTKEYS_COUNT_MAX`]).
+    pub fn with_count(mut self, k: u64) -> Result<Self, String> {
+        if !(HOTKEYS_COUNT_MIN..=HOTKEYS_COUNT_MAX).contains(&k) {
+            return Err(format!(
+                "COUNT must be between {HOTKEYS_COUNT_MIN} and {HOTKEYS_COUNT_MAX}, got: {k}"
+            ));
+        }
+        self.count_k = Some(k);
+        Ok(self)
+    }
+
+    /// Set the duration in seconds for how long tracking should run.
+    ///
+    /// After this time period, tracking will automatically stop.
+    /// If not specified, tracking continues until manually stopped with HOTKEYS STOP.
+    pub fn with_duration_secs(mut self, seconds: u64) -> Self {
+        self.duration_secs = Some(seconds);
+        self
+    }
+
+    /// Set the sampling ratio for probabilistic tracking.
+    ///
+    /// Each key is sampled with probability 1/ratio. Higher values reduce
+    /// performance impact but may miss some hotkeys. Lower values provide
+    /// more accurate results but with higher performance cost.
+    pub fn with_sample_ratio(mut self, ratio: u64) -> Self {
+        self.sample_ratio = Some(ratio);
+        self
+    }
+
+    /// Set specific hash slots to track in a cluster environment.
+    ///
+    /// Only keys that hash to the specified slots will be tracked.
+    /// Useful for tracking hotkeys on specific shards in a Redis cluster.
+    ///
+    /// Note: Using SLOTS when not in cluster mode will result in an error.
+    pub fn with_slots(mut self, slots: Vec<u16>) -> Self {
+        self.slots = Some(slots);
+        self
+    }
+}
+
+impl ToRedisArgs for HotkeysOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        // METRICS count [CPU] [NET] - required
+        out.write_arg(b"METRICS");
+        out.write_arg_fmt(self.metrics_count());
+
+        if self.cpu {
+            out.write_arg(b"CPU");
+        }
+
+        if self.net {
+            out.write_arg(b"NET");
+        }
+
+        // Optional: COUNT k
+        if let Some(k) = self.count_k {
+            out.write_arg(b"COUNT");
+            out.write_arg_fmt(k);
+        }
+
+        // Optional: DURATION seconds
+        if let Some(secs) = self.duration_secs {
+            out.write_arg(b"DURATION");
+            out.write_arg_fmt(secs);
+        }
+
+        // Optional: SAMPLE ratio
+        if let Some(ratio) = self.sample_ratio {
+            out.write_arg(b"SAMPLE");
+            out.write_arg_fmt(ratio);
+        }
+
+        // Optional: SLOTS count slot [slot ...]
+        if let Some(ref slots) = self.slots {
+            out.write_arg(b"SLOTS");
+            out.write_arg_fmt(slots.len());
+            for slot in slots {
+                out.write_arg_fmt(slot);
+            }
+        }
+    }
+
+    fn num_of_args(&self) -> usize {
+        // METRICS + count
+        let mut n = 2;
+        n += self.cpu as usize;
+        n += self.net as usize;
+        if self.count_k.is_some() {
+            n += 2;
+        }
+        if self.duration_secs.is_some() {
+            n += 2;
+        }
+        if self.sample_ratio.is_some() {
+            n += 2;
+        }
+        if let Some(ref slots) = self.slots {
+            // SLOTS + count + one arg per slot
+            n += 2 + slots.len();
+        }
+        n
+    }
+}
+
+/// A single hotkey entry with its metric value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HotKeyEntry {
+    /// The key name.
+    pub key: String,
+    /// The metric value (CPU time in microseconds or network bytes, depending on context).
+    pub value: u64,
+}
+
+/// Represents a range of slots.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SlotRange {
+    /// Start of the slot range (inclusive).
+    pub start: u16,
+    /// End of the slot range (inclusive).
+    pub end: u16,
+}
+
+/// Response from the HOTKEYS GET command.
+///
+/// Contains information about the hotkeys tracking session,
+/// including tracking metadata, performance statistics, and lists of top K
+/// hot keys sorted by the metrics specified in HOTKEYS START.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct HotkeysResponse {
+    /// Whether tracking is currently active (1) or stopped (0).
+    pub tracking_active: bool,
+    /// The sampling ratio used during tracking.
+    pub sample_ratio: u64,
+    /// Array of selected slot ranges.
+    pub selected_slots: Vec<SlotRange>,
+    /// CPU time in microseconds for all commands on all slots.
+    pub all_commands_all_slots_us: u64,
+    /// Network bytes for all commands on all slots.
+    pub net_bytes_all_commands_all_slots: u64,
+    /// Unix timestamp in milliseconds when tracking started.
+    pub collection_start_time_unix_ms: u64,
+    /// Duration of tracking in milliseconds.
+    pub collection_duration_ms: u64,
+    /// User CPU time used in milliseconds (only when CPU metric was specified).
+    pub total_cpu_time_user_ms: Option<u64>,
+    /// System CPU time used in milliseconds (only when CPU metric was specified).
+    pub total_cpu_time_sys_ms: Option<u64>,
+    /// Total network bytes processed (only when NET metric was specified).
+    pub total_net_bytes: Option<u64>,
+    /// Array of hotkeys sorted by CPU time in microseconds (only when CPU metric was specified).
+    pub by_cpu_time_us: Option<Vec<HotKeyEntry>>,
+    /// Array of hotkeys sorted by network bytes (only when NET metric was specified).
+    pub by_net_bytes: Option<Vec<HotKeyEntry>>,
+
+    // Cluster-specific fields (when SLOTS was used)
+    /// CPU time in microseconds for sampled commands in selected slots (cluster mode with SAMPLE).
+    pub sampled_commands_selected_slots_us: Option<u64>,
+    /// CPU time in microseconds for all commands in selected slots (cluster mode).
+    pub all_commands_selected_slots_us: Option<u64>,
+    /// Network bytes for sampled commands in selected slots (cluster mode with SAMPLE).
+    pub net_bytes_sampled_commands_selected_slots: Option<u64>,
+    /// Network bytes for all commands on selected slots (cluster mode).
+    pub net_bytes_all_commands_selected_slots: Option<u64>,
+}
+
+/// Helper to strip surrounding quotes from a string if present
+fn strip_quotes(s: String) -> String {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s
+    }
+}
+
+/// Helper function to parse a key-value pair array into HotKeyEntry vec
+fn parse_hotkey_entries(arr: &[Value]) -> Result<Vec<HotKeyEntry>, ParsingError> {
+    use crate::types::from_redis_value_ref;
+
+    let mut entries = Vec::with_capacity(arr.len() / 2);
+
+    let mut iter = arr.iter();
+    while let Some(key_val) = iter.next() {
+        let key: String = from_redis_value_ref(key_val)?;
+        // Strip surrounding quotes if present (Redis returns quoted keys)
+        let key = strip_quotes(key);
+        let value: u64 = iter
+            .next()
+            .ok_or_else(|| ParsingError::from("Expected value after key in hotkey entry"))
+            .and_then(from_redis_value_ref)?;
+
+        entries.push(HotKeyEntry { key, value });
+    }
+
+    Ok(entries)
+}
+
+/// Helper function to parse slot ranges from the selected-slots array
+fn parse_slot_ranges(arr: &[Value]) -> Result<Vec<SlotRange>, ParsingError> {
+    use crate::types::from_redis_value_ref;
+
+    let mut ranges = Vec::with_capacity(arr.len());
+
+    for item in arr {
+        let Value::Array(range_arr) = item else {
+            crate::errors::invalid_type_error!("Expected array for slot range", item);
+        };
+
+        match range_arr.len() {
+            1 => {
+                let slot: u16 = from_redis_value_ref(&range_arr[0])?;
+                ranges.push(SlotRange {
+                    start: slot,
+                    end: slot,
+                });
+            }
+            n if n >= 2 => {
+                let start: u16 = from_redis_value_ref(&range_arr[0])?;
+                let end: u16 = from_redis_value_ref(&range_arr[1])?;
+                ranges.push(SlotRange { start, end });
+            }
+            _ => crate::errors::invalid_type_error!("Empty slot range entry", range_arr),
+        }
+    }
+
+    Ok(ranges)
+}
+
+impl FromRedisValue for HotkeysResponse {
+    fn from_redis_value(v: Value) -> Result<Self, ParsingError> {
+        use crate::types::from_redis_value;
+
+        // Redis 8.6 wraps every HOTKEYS GET response in a single-element outer
+        // array with one entry per tracking session. Unwrap it here so the inner
+        // value (Array of field/value pairs in RESP2, Map in RESP3) can be
+        // parsed uniformly below. The passthrough arm keeps unit-test fixtures
+        // that build the inner value directly working without needing to
+        // mirror the server's outer wrapping.
+        let v = match v {
+            Value::Array(mut arr) if arr.len() == 1 => arr.remove(0),
+            other => other,
+        };
+
+        // The response can be an Array (RESP2) or Map (RESP3)
+        // Parse it into a HashMap for easier field access
+        let mut fields: HashMap<String, Value> = match v {
+            Value::Array(arr) => {
+                // RESP2: flat array with alternating field names and values
+                let mut map = HashMap::new();
+                let mut iter = arr.into_iter();
+                while let Some(key) = iter.next() {
+                    let key_str: String = from_redis_value(key)?;
+                    // Strip surrounding quotes if present (Redis returns quoted keys)
+                    let key_str = strip_quotes(key_str);
+                    if let Some(val) = iter.next() {
+                        map.insert(key_str, val);
+                    }
+                }
+                map
+            }
+            Value::Map(pairs) => {
+                // RESP3: proper map
+                let mut map = HashMap::new();
+                for (k, v) in pairs {
+                    let key_str: String = from_redis_value(k)?;
+                    let key_str = strip_quotes(key_str);
+                    map.insert(key_str, v);
+                }
+                map
+            }
+            _ => {
+                crate::errors::invalid_type_error!(
+                    "Expected array or map response for HOTKEYS GET",
+                    v
+                );
+            }
+        };
+
+        let mut response = HotkeysResponse::default();
+
+        // Parse required fields
+        if let Some(v) = fields.remove("tracking-active") {
+            response.tracking_active = from_redis_value::<i64>(v)? != 0;
+        }
+
+        if let Some(v) = fields.remove("sample-ratio") {
+            response.sample_ratio = from_redis_value(v)?;
+        }
+
+        if let Some(Value::Array(arr)) = fields.remove("selected-slots") {
+            response.selected_slots = parse_slot_ranges(&arr)?;
+        }
+
+        if let Some(v) = fields.remove("all-commands-all-slots-us") {
+            response.all_commands_all_slots_us = from_redis_value(v)?;
+        }
+
+        if let Some(v) = fields.remove("net-bytes-all-commands-all-slots") {
+            response.net_bytes_all_commands_all_slots = from_redis_value(v)?;
+        }
+
+        if let Some(v) = fields.remove("collection-start-time-unix-ms") {
+            response.collection_start_time_unix_ms = from_redis_value(v)?;
+        }
+
+        if let Some(v) = fields.remove("collection-duration-ms") {
+            response.collection_duration_ms = from_redis_value(v)?;
+        }
+
+        // Parse optional CPU-related fields
+        if let Some(v) = fields.remove("total-cpu-time-user-ms") {
+            response.total_cpu_time_user_ms = Some(from_redis_value(v)?);
+        }
+
+        if let Some(v) = fields.remove("total-cpu-time-sys-ms") {
+            response.total_cpu_time_sys_ms = Some(from_redis_value(v)?);
+        }
+
+        if let Some(Value::Array(arr)) = fields.remove("by-cpu-time-us") {
+            response.by_cpu_time_us = Some(parse_hotkey_entries(&arr)?);
+        }
+
+        // Parse optional NET-related fields
+        if let Some(v) = fields.remove("total-net-bytes") {
+            response.total_net_bytes = Some(from_redis_value(v)?);
+        }
+
+        if let Some(Value::Array(arr)) = fields.remove("by-net-bytes") {
+            response.by_net_bytes = Some(parse_hotkey_entries(&arr)?);
+        }
+
+        // Parse cluster-specific fields
+        if let Some(v) = fields.remove("sampled-commands-selected-slots-us") {
+            response.sampled_commands_selected_slots_us = Some(from_redis_value(v)?);
+        }
+
+        if let Some(v) = fields.remove("all-commands-selected-slots-us") {
+            response.all_commands_selected_slots_us = Some(from_redis_value(v)?);
+        }
+
+        if let Some(v) = fields.remove("net-bytes-sampled-commands-selected-slots") {
+            response.net_bytes_sampled_commands_selected_slots = Some(from_redis_value(v)?);
+        }
+
+        if let Some(v) = fields.remove("net-bytes-all-commands-selected-slots") {
+            response.net_bytes_all_commands_selected_slots = Some(from_redis_value(v)?);
+        }
+
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hotkeys_options_cpu_constructor() {
+        let opts = HotkeysOptions::new_with_cpu();
+        assert_eq!(opts.num_of_args(), 3); // METRICS 1 CPU
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"1");
+        assert_eq!(args[2], b"CPU");
+    }
+
+    #[test]
+    fn test_hotkeys_options_net_constructor() {
+        let opts = HotkeysOptions::new_with_net();
+        assert_eq!(opts.num_of_args(), 3); // METRICS 1 NET
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"1");
+        assert_eq!(args[2], b"NET");
+    }
+
+    #[test]
+    fn test_hotkeys_options_cpu_and_net() {
+        let opts = HotkeysOptions::new_with_cpu().and_net();
+        assert_eq!(opts.num_of_args(), 4); // METRICS 2 CPU NET
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 4);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"2");
+        assert_eq!(args[2], b"CPU");
+        assert_eq!(args[3], b"NET");
+    }
+
+    #[test]
+    fn test_hotkeys_options_net_and_cpu() {
+        let opts = HotkeysOptions::new_with_net().and_cpu();
+        assert_eq!(opts.num_of_args(), 4); // METRICS 2 CPU NET
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 4);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"2");
+        // CPU comes before NET in serialization order
+        assert_eq!(args[2], b"CPU");
+        assert_eq!(args[3], b"NET");
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_duration() {
+        let opts = HotkeysOptions::new_with_cpu().with_duration_secs(60);
+        assert_eq!(opts.num_of_args(), 5); // METRICS 1 CPU DURATION 60
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"1");
+        assert_eq!(args[2], b"CPU");
+        assert_eq!(args[3], b"DURATION");
+        assert_eq!(args[4], b"60");
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_count() {
+        let opts = HotkeysOptions::new_with_cpu().with_count(50).unwrap();
+        assert_eq!(opts.num_of_args(), 5); // METRICS 1 CPU COUNT 50
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"1");
+        assert_eq!(args[2], b"CPU");
+        assert_eq!(args[3], b"COUNT");
+        assert_eq!(args[4], b"50");
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_count_min_valid() {
+        let opts = HotkeysOptions::new_with_cpu()
+            .with_count(HOTKEYS_COUNT_MIN)
+            .unwrap();
+        let args = opts.to_redis_args();
+        assert_eq!(args[3], b"COUNT");
+        assert_eq!(args[4], HOTKEYS_COUNT_MIN.to_string().as_bytes());
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_count_max_valid() {
+        let opts = HotkeysOptions::new_with_cpu()
+            .with_count(HOTKEYS_COUNT_MAX)
+            .unwrap();
+        let args = opts.to_redis_args();
+        assert_eq!(args[3], b"COUNT");
+        assert_eq!(args[4], HOTKEYS_COUNT_MAX.to_string().as_bytes());
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_count_too_low() {
+        let result = HotkeysOptions::new_with_cpu().with_count(HOTKEYS_COUNT_MIN - 1);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains(&format!(
+            "COUNT must be between {HOTKEYS_COUNT_MIN} and {HOTKEYS_COUNT_MAX}"
+        )));
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_count_too_high() {
+        let result = HotkeysOptions::new_with_cpu().with_count(HOTKEYS_COUNT_MAX + 1);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains(&format!(
+            "COUNT must be between {HOTKEYS_COUNT_MIN} and {HOTKEYS_COUNT_MAX}"
+        )));
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_sample() {
+        let opts = HotkeysOptions::new_with_cpu().with_sample_ratio(1000);
+        assert_eq!(opts.num_of_args(), 5); // METRICS 1 CPU SAMPLE 1000
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"1");
+        assert_eq!(args[2], b"CPU");
+        assert_eq!(args[3], b"SAMPLE");
+        assert_eq!(args[4], b"1000");
+    }
+
+    #[test]
+    fn test_hotkeys_options_with_slots() {
+        let opts = HotkeysOptions::new_with_cpu().with_slots(vec![0, 100, 200]);
+        assert_eq!(opts.num_of_args(), 8); // METRICS 1 CPU SLOTS 3 0 100 200
+        let args = opts.to_redis_args();
+        assert_eq!(args.len(), 8);
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"1");
+        assert_eq!(args[2], b"CPU");
+        assert_eq!(args[3], b"SLOTS");
+        assert_eq!(args[4], b"3");
+        assert_eq!(args[5], b"0");
+        assert_eq!(args[6], b"100");
+        assert_eq!(args[7], b"200");
+    }
+
+    #[test]
+    fn test_hotkeys_options_full() {
+        let opts = HotkeysOptions::new_with_cpu()
+            .and_net()
+            .with_count(50)
+            .unwrap()
+            .with_duration_secs(120)
+            .with_sample_ratio(500);
+        // METRICS 2 CPU NET COUNT 50 DURATION 120 SAMPLE 500
+        assert_eq!(opts.num_of_args(), 10);
+        let args = opts.to_redis_args();
+        assert_eq!(args[0], b"METRICS");
+        assert_eq!(args[1], b"2");
+        assert_eq!(args[2], b"CPU");
+        assert_eq!(args[3], b"NET");
+        assert_eq!(args[4], b"COUNT");
+        assert_eq!(args[5], b"50");
+        assert_eq!(args[6], b"DURATION");
+        assert_eq!(args[7], b"120");
+        assert_eq!(args[8], b"SAMPLE");
+        assert_eq!(args[9], b"500");
+    }
+
+    #[test]
+    fn test_hotkeys_response_parsing_resp2() {
+        use crate::Value;
+
+        // Simulate RESP2 flat array response
+        let response = Value::Array(vec![
+            Value::BulkString(b"tracking-active".to_vec()),
+            Value::Int(1),
+            Value::BulkString(b"sample-ratio".to_vec()),
+            Value::Int(1),
+            Value::BulkString(b"selected-slots".to_vec()),
+            Value::Array(vec![Value::Array(vec![Value::Int(0), Value::Int(16383)])]),
+            Value::BulkString(b"all-commands-all-slots-us".to_vec()),
+            Value::Int(5000),
+            Value::BulkString(b"net-bytes-all-commands-all-slots".to_vec()),
+            Value::Int(2048),
+            Value::BulkString(b"collection-start-time-unix-ms".to_vec()),
+            Value::Int(1700000000000),
+            Value::BulkString(b"collection-duration-ms".to_vec()),
+            Value::Int(10000),
+            Value::BulkString(b"total-cpu-time-user-ms".to_vec()),
+            Value::Int(100),
+            Value::BulkString(b"total-cpu-time-sys-ms".to_vec()),
+            Value::Int(50),
+            Value::BulkString(b"by-cpu-time-us".to_vec()),
+            Value::Array(vec![
+                Value::BulkString(b"key1".to_vec()),
+                Value::Int(1500),
+                Value::BulkString(b"key2".to_vec()),
+                Value::Int(750),
+            ]),
+        ]);
+
+        let result = HotkeysResponse::from_redis_value(response).unwrap();
+
+        assert!(result.tracking_active);
+        assert_eq!(result.sample_ratio, 1);
+        assert_eq!(result.selected_slots.len(), 1);
+        assert_eq!(result.selected_slots[0].start, 0);
+        assert_eq!(result.selected_slots[0].end, 16383);
+        assert_eq!(result.all_commands_all_slots_us, 5000);
+        assert_eq!(result.net_bytes_all_commands_all_slots, 2048);
+        assert_eq!(result.collection_start_time_unix_ms, 1700000000000);
+        assert_eq!(result.collection_duration_ms, 10000);
+        assert_eq!(result.total_cpu_time_user_ms, Some(100));
+        assert_eq!(result.total_cpu_time_sys_ms, Some(50));
+
+        let cpu_keys = result.by_cpu_time_us.unwrap();
+        assert_eq!(cpu_keys.len(), 2);
+        assert_eq!(cpu_keys[0].key, "key1");
+        assert_eq!(cpu_keys[0].value, 1500);
+        assert_eq!(cpu_keys[1].key, "key2");
+        assert_eq!(cpu_keys[1].value, 750);
+    }
+
+    #[test]
+    fn test_hotkeys_response_parsing_resp3() {
+        use crate::Value;
+
+        // Simulate RESP3 map response.
+        let response = Value::Map(vec![
+            (
+                Value::BulkString(b"tracking-active".to_vec()),
+                Value::Int(1),
+            ),
+            (Value::BulkString(b"sample-ratio".to_vec()), Value::Int(1)),
+            (
+                Value::BulkString(b"selected-slots".to_vec()),
+                Value::Array(vec![Value::Array(vec![Value::Int(0), Value::Int(16383)])]),
+            ),
+            (
+                Value::BulkString(b"all-commands-all-slots-us".to_vec()),
+                Value::Int(5000),
+            ),
+            (
+                Value::BulkString(b"all-commands-selected-slots-us".to_vec()),
+                Value::Int(4000),
+            ),
+            (
+                Value::BulkString(b"net-bytes-all-commands-all-slots".to_vec()),
+                Value::Int(2048),
+            ),
+            (
+                Value::BulkString(b"net-bytes-all-commands-selected-slots".to_vec()),
+                Value::Int(1024),
+            ),
+            (
+                Value::BulkString(b"collection-start-time-unix-ms".to_vec()),
+                Value::Int(1700000000000),
+            ),
+            (
+                Value::BulkString(b"collection-duration-ms".to_vec()),
+                Value::Int(10000),
+            ),
+            (
+                Value::BulkString(b"total-cpu-time-user-ms".to_vec()),
+                Value::Int(100),
+            ),
+            (
+                Value::BulkString(b"total-cpu-time-sys-ms".to_vec()),
+                Value::Int(50),
+            ),
+            (
+                Value::BulkString(b"by-cpu-time-us".to_vec()),
+                Value::Array(vec![
+                    Value::BulkString(b"key1".to_vec()),
+                    Value::Int(1500),
+                    Value::BulkString(b"key2".to_vec()),
+                    Value::Int(750),
+                ]),
+            ),
+        ]);
+
+        let result = HotkeysResponse::from_redis_value(response).unwrap();
+
+        assert!(result.tracking_active);
+        assert_eq!(result.sample_ratio, 1);
+        assert_eq!(result.selected_slots.len(), 1);
+        assert_eq!(result.selected_slots[0].start, 0);
+        assert_eq!(result.selected_slots[0].end, 16383);
+        assert_eq!(result.all_commands_all_slots_us, 5000);
+        assert_eq!(result.all_commands_selected_slots_us, Some(4000));
+        assert_eq!(result.net_bytes_all_commands_all_slots, 2048);
+        assert_eq!(result.net_bytes_all_commands_selected_slots, Some(1024));
+        assert_eq!(result.collection_start_time_unix_ms, 1700000000000);
+        assert_eq!(result.collection_duration_ms, 10000);
+        assert_eq!(result.total_cpu_time_user_ms, Some(100));
+        assert_eq!(result.total_cpu_time_sys_ms, Some(50));
+
+        let cpu_keys = result.by_cpu_time_us.unwrap();
+        assert_eq!(cpu_keys.len(), 2);
+        assert_eq!(cpu_keys[0].key, "key1");
+        assert_eq!(cpu_keys[0].value, 1500);
+        assert_eq!(cpu_keys[1].key, "key2");
+        assert_eq!(cpu_keys[1].value, 750);
+    }
+
+    #[test]
+    fn test_hotkeys_response_parsing_with_net() {
+        use crate::Value;
+
+        let response = Value::Array(vec![
+            Value::BulkString(b"tracking-active".to_vec()),
+            Value::Int(0),
+            Value::BulkString(b"sample-ratio".to_vec()),
+            Value::Int(1),
+            Value::BulkString(b"selected-slots".to_vec()),
+            Value::Array(vec![]),
+            Value::BulkString(b"all-commands-all-slots-us".to_vec()),
+            Value::Int(0),
+            Value::BulkString(b"net-bytes-all-commands-all-slots".to_vec()),
+            Value::Int(4096),
+            Value::BulkString(b"collection-start-time-unix-ms".to_vec()),
+            Value::Int(1700000000000),
+            Value::BulkString(b"collection-duration-ms".to_vec()),
+            Value::Int(5000),
+            Value::BulkString(b"total-net-bytes".to_vec()),
+            Value::Int(8192),
+            Value::BulkString(b"by-net-bytes".to_vec()),
+            Value::Array(vec![
+                Value::BulkString(b"bigkey".to_vec()),
+                Value::Int(4096),
+                Value::BulkString(b"smallkey".to_vec()),
+                Value::Int(256),
+            ]),
+        ]);
+
+        let result = HotkeysResponse::from_redis_value(response).unwrap();
+
+        assert!(!result.tracking_active);
+        assert_eq!(result.total_net_bytes, Some(8192));
+
+        let net_keys = result.by_net_bytes.unwrap();
+        assert_eq!(net_keys.len(), 2);
+        assert_eq!(net_keys[0].key, "bigkey");
+        assert_eq!(net_keys[0].value, 4096);
+        assert_eq!(net_keys[1].key, "smallkey");
+        assert_eq!(net_keys[1].value, 256);
+    }
+
+    #[test]
+    fn test_hotkeys_response_nil() {
+        use crate::Value;
+        use crate::types::from_redis_value;
+
+        // Redis returns `Nil` for HOTKEYS GET when there is no active tracking
+        // session (e.g. never started, stopped, or reset). `hotkeys_get` decodes
+        // into `Option<HotkeysResponse>`, so `Nil` must surface as `None` rather
+        // than a default-constructed response.
+        let response = Value::Nil;
+        let result: Option<HotkeysResponse> = from_redis_value(response).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/redis/src/commands/hotkeys.rs
+++ b/redis/src/commands/hotkeys.rs
@@ -16,8 +16,12 @@
 //! # Using HOTKEYS in Cluster Mode
 //!
 //! While the high-level `HotkeysCommands` trait is not available on `ClusterConnection`,
-//! HOTKEYS commands can still be used on individual cluster nodes by using `route_command` with
-//! explicit node routing:
+//! HOTKEYS commands can still be used in cluster mode through `route_command` with
+//! explicit routing. Two patterns are useful:
+//!
+//! ## Routing to a single node
+//!
+//! Useful for inspecting a specific shard, e.g. when investigating a known hot slot.
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "cluster")]
@@ -59,6 +63,67 @@
 //! ).unwrap();
 //! # }
 //! ```
+//!
+//! ## Routing to all primaries (cluster-wide tracking)
+//!
+//! For cluster-wide observability the natural pattern is to fan the command out to
+//! every primary so each shard tracks its own keys. `START` and `STOP` can use
+//! [`ResponsePolicy::AllSucceeded`](crate::cluster_routing::ResponsePolicy::AllSucceeded)
+//! to assert every node accepted the command. `GET` should be issued without a
+//! response policy: the response is then a [`Value::Map`] keyed by node address,
+//! and each entry is parsed with [`HotkeysResponse::from_redis_value`].
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "cluster")]
+//! # {
+//! use redis::cluster::ClusterClient;
+//! use redis::cluster_routing::{
+//!     MultipleNodeRoutingInfo, ResponsePolicy, RoutingInfo,
+//! };
+//! use redis::{cmd, from_redis_value, FromRedisValue, HotkeysOptions, HotkeysResponse, Value};
+//!
+//! let nodes = vec!["redis://127.0.0.1:6379/", "redis://127.0.0.1:6378/"];
+//! let client = ClusterClient::new(nodes).unwrap();
+//! let mut connection = client.get_connection().unwrap();
+//!
+//! // START on every primary and require success everywhere.
+//! // `with_slots` is not used in here and each primary tracks the keys for the slots it owns.
+//! let start_opts = HotkeysOptions::new_with_cpu().and_net();
+//! let _ = connection.route_command(
+//!     &cmd("HOTKEYS").arg("START").arg(&start_opts),
+//!     RoutingInfo::MultiNode((
+//!         MultipleNodeRoutingInfo::AllMasters,
+//!         Some(ResponsePolicy::AllSucceeded),
+//!     )),
+//! ).unwrap();
+//!
+//! // ... perform operations ...
+//!
+//! // GET from every primary with no policy.
+//! // The cluster client will get back the per-node responses.
+//! let value = connection.route_command(
+//!     &cmd("HOTKEYS").arg("GET"),
+//!     RoutingInfo::MultiNode((MultipleNodeRoutingInfo::AllMasters, None)),
+//! ).unwrap();
+//! if let Value::Map(per_node) = value {
+//!     for (addr_val, response_val) in per_node {
+//!         let addr: String = from_redis_value(addr_val).unwrap();
+//!         let snapshot = HotkeysResponse::from_redis_value(response_val).unwrap();
+//!         println!("node {addr}: {} hot keys by CPU",
+//!             snapshot.by_cpu_time_us.as_ref().map(|v| v.len()).unwrap_or(0));
+//!     }
+//! }
+//!
+//! // STOP on every primary.
+//! let _ = connection.route_command(
+//!     &cmd("HOTKEYS").arg("STOP"),
+//!     RoutingInfo::MultiNode((
+//!         MultipleNodeRoutingInfo::AllMasters,
+//!         Some(ResponsePolicy::AllSucceeded),
+//!     )),
+//! ).unwrap();
+//! # }
+//! ```
 
 use crate::errors::ParsingError;
 use crate::types::{FromRedisValue, RedisWrite, ToRedisArgs, Value};
@@ -96,6 +161,7 @@ pub const HOTKEYS_COUNT_MAX: u64 = 64;
 /// # }
 /// ```
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct HotkeysOptions {
     /// Track hotkeys by CPU time percentage
     cpu: bool,
@@ -220,7 +286,21 @@ impl HotkeysOptions {
     /// Set specific hash slots to track in a cluster environment.
     ///
     /// Only keys that hash to the specified slots will be tracked.
-    /// Useful for tracking hotkeys on specific shards in a Redis cluster.
+    /// Useful for narrowing tracking to a subset of the slots owned by a single shard.
+    ///
+    /// # When to use
+    ///
+    /// This option is meaningful only in cluster mode and only with **single-node**
+    /// routing (e.g. [`RoutingInfo::SingleNode`](crate::cluster_routing::RoutingInfo::SingleNode))
+    /// targeting a primary that owns the requested slots. The Redis server will
+    /// reject the command if any of the requested slots are not owned by the
+    /// receiving node.
+    ///
+    /// When fanning the command out to every node (e.g.
+    /// [`MultipleNodeRoutingInfo::AllMasters`](crate::cluster_routing::MultipleNodeRoutingInfo::AllMasters)),
+    /// omit `with_slots` and let each primary track the keys for the slots it
+    /// owns, otherwise every primary that does not own the supplied slot list
+    /// will return an error.
     ///
     /// Note: Using SLOTS when not in cluster mode will result in an error.
     pub fn with_slots(mut self, slots: Vec<u16>) -> Self {
@@ -298,6 +378,7 @@ impl ToRedisArgs for HotkeysOptions {
 
 /// A single hotkey entry with its metric value.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct HotKeyEntry {
     /// The key name.
     pub key: String,
@@ -307,6 +388,7 @@ pub struct HotKeyEntry {
 
 /// Represents a range of slots.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct SlotRange {
     /// Start of the slot range (inclusive).
     pub start: u16,
@@ -320,6 +402,7 @@ pub struct SlotRange {
 /// including tracking metadata, performance statistics, and lists of top K
 /// hot keys sorted by the metrics specified in HOTKEYS START.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
 pub struct HotkeysResponse {
     /// Whether tracking is currently active (1) or stopped (0).
     pub tracking_active: bool,

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -45,6 +45,8 @@ pub mod acl;
 #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]
 pub mod vector_sets;
 
+pub mod hotkeys;
+
 #[cfg(any(feature = "cluster", feature = "cache-aio"))]
 enum Properties {
     ReadOnlyCacheable,
@@ -3730,3 +3732,185 @@ pub fn resp3_hello(connection_info: &RedisConnectionInfo) -> Cmd {
 
     hello_cmd
 }
+
+/// HOTKEYS commands for tracking hot keys on standalone connections (Redis 8.6.0+).
+///
+/// HOTKEYS is a stateful, node-local command requiring session affinity.
+/// It is ONLY implemented for standalone connection types (Connection, MultiplexedConnection, ConnectionManager)
+/// and NOT for cluster clients (ClusterConnection) to prevent session affinity issues.
+///
+/// # Example (Standalone)
+///
+/// ```rust,no_run
+/// use redis::{HotkeysCommands, HotkeysOptions};
+///
+/// # fn example() -> redis::RedisResult<()> {
+/// let client = redis::Client::open("redis://127.0.0.1/")?;
+/// let mut con = client.get_connection()?;
+///
+/// // Start tracking hot keys by CPU time percentage for 60 seconds
+/// let opts = HotkeysOptions::new_with_cpu()
+///     .with_duration_secs(60);
+/// con.hotkeys_start(opts)?;
+///
+/// // ... perform operations ...
+///
+/// // Get hot keys metrics. `None` means no tracking session state is available
+/// // (e.g. reset or never started).
+/// if let Some(response) = con.hotkeys_get()? {
+///     if let Some(cpu_keys) = response.by_cpu_time_us.as_ref() {
+///         for entry in cpu_keys {
+///             println!("Key: {}, CPU time: {}", entry.key, entry.value);
+///         }
+///     }
+/// }
+///
+/// // Stop tracking
+/// con.hotkeys_stop()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Using HOTKEYS in Cluster Mode
+///
+/// For cluster connections, use `route_command` with explicit node routing.
+/// See the documentation on [`HotkeysOptions`](hotkeys::HotkeysOptions) for a complete example.
+pub trait HotkeysCommands: ConnectionLike {
+    /// Start tracking hot keys with the given options.
+    ///
+    /// ```text
+    /// HOTKEYS START METRICS count [CPU] [NET] [COUNT k] [DURATION seconds] [SAMPLE ratio] [SLOTS count slot [slot ...]]
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-start/)
+    fn hotkeys_start(&mut self, opts: hotkeys::HotkeysOptions) -> RedisResult<()>
+    where
+        Self: Sized,
+    {
+        cmd("HOTKEYS").arg("START").arg(opts).query(self)
+    }
+
+    /// Get the current hot keys metrics.
+    ///
+    /// Returns `Some(response)` when a tracking session state is available
+    /// (when there is an active tracking session or when the tracking session has been stopped but not reset)
+    /// and `None` when there is no session state to report (Redis replies `Nil` in that case).
+    ///
+    /// ```text
+    /// HOTKEYS GET
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-get/)
+    fn hotkeys_get(&mut self) -> RedisResult<Option<hotkeys::HotkeysResponse>>
+    where
+        Self: Sized,
+    {
+        cmd("HOTKEYS").arg("GET").query(self)
+    }
+
+    /// Stop tracking hot keys.
+    ///
+    /// Returns `true` if a tracking session was running and has been stopped,
+    /// or `false` if no session was active (Redis replies `Nil` in that case).
+    ///
+    /// ```text
+    /// HOTKEYS STOP
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-stop/)
+    fn hotkeys_stop(&mut self) -> RedisResult<bool>
+    where
+        Self: Sized,
+    {
+        cmd("HOTKEYS").arg("STOP").query(self)
+    }
+
+    /// Reset the hot keys tracking state.
+    ///
+    /// Only valid when no tracking session is currently running.
+    /// Calling RESET while a session is active returns a server error.
+    ///
+    /// ```text
+    /// HOTKEYS RESET
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-reset/)
+    fn hotkeys_reset(&mut self) -> RedisResult<()>
+    where
+        Self: Sized,
+    {
+        cmd("HOTKEYS").arg("RESET").query(self)
+    }
+}
+
+// Implement ONLY for Connection (standalone sync)
+impl HotkeysCommands for Connection {}
+
+/// Async version of HOTKEYS commands for standalone async connections (Redis 8.6.0+).
+///
+/// HOTKEYS is a stateful, node-local command requiring session affinity.
+/// It is ONLY implemented for standalone connection types and NOT for cluster clients.
+#[cfg(feature = "aio")]
+pub trait AsyncHotkeysCommands: crate::aio::ConnectionLike + Send + Sync + Sized {
+    /// Start tracking hot keys with the given options.
+    ///
+    /// ```text
+    /// HOTKEYS START METRICS count [CPU] [NET] [COUNT k] [DURATION seconds] [SAMPLE ratio] [SLOTS count slot [slot ...]]
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-start/)
+    fn hotkeys_start(
+        &mut self,
+        opts: hotkeys::HotkeysOptions,
+    ) -> crate::types::RedisFuture<'_, ()> {
+        Box::pin(async move {
+            cmd("HOTKEYS")
+                .arg("START")
+                .arg(opts)
+                .query_async(self)
+                .await
+        })
+    }
+
+    /// Get the current hot keys metrics.
+    ///
+    /// Returns `Some(response)` when a tracking session state is available
+    /// (when there is an active tracking session or when the tracking session has been stopped but not reset)
+    /// and `None` when there is no session state to report (Redis replies `Nil` in that case).
+    ///
+    /// ```text
+    /// HOTKEYS GET
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-get/)
+    fn hotkeys_get(&mut self) -> crate::types::RedisFuture<'_, Option<hotkeys::HotkeysResponse>> {
+        Box::pin(async move { cmd("HOTKEYS").arg("GET").query_async(self).await })
+    }
+
+    /// Stop tracking hot keys.
+    ///
+    /// Returns `true` if a tracking session was running and has been stopped,
+    /// or `false` if no session was active (Redis replies `Nil` in that case).
+    ///
+    /// ```text
+    /// HOTKEYS STOP
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-stop/)
+    fn hotkeys_stop(&mut self) -> crate::types::RedisFuture<'_, bool> {
+        Box::pin(async move { cmd("HOTKEYS").arg("STOP").query_async(self).await })
+    }
+
+    /// Reset the hot keys tracking state.
+    ///
+    /// Only valid when no tracking session is currently running.
+    /// Calling RESET while a session is active returns a server error.
+    ///
+    /// ```text
+    /// HOTKEYS RESET
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/hotkeys-reset/)
+    fn hotkeys_reset(&mut self) -> crate::types::RedisFuture<'_, ()> {
+        Box::pin(async move { cmd("HOTKEYS").arg("RESET").query_async(self).await })
+    }
+}
+
+// Implement ONLY for standalone async connection types
+#[cfg(feature = "aio")]
+impl AsyncHotkeysCommands for crate::aio::MultiplexedConnection {}
+
+#[cfg(all(feature = "aio", feature = "connection-manager"))]
+impl AsyncHotkeysCommands for crate::aio::ConnectionManager {}

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -640,8 +640,12 @@ pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{Arg, Cmd, Iter, cmd, pack_command, pipe};
 pub use crate::commands::{
     Commands, ControlFlow, CopyOptions, Direction, FlushAllOptions, FlushDbOptions,
-    HashFieldExpirationOptions, LposOptions, MSetOptions, PubSubCommands, ScanOptions, SetOptions,
-    SortedSetAddOptions, TypedCommands, UpdateCheck,
+    HashFieldExpirationOptions, HotkeysCommands, LposOptions, MSetOptions, PubSubCommands,
+    ScanOptions, SetOptions, SortedSetAddOptions, TypedCommands, UpdateCheck,
+    hotkeys::{
+        HOTKEYS_COUNT_MAX, HOTKEYS_COUNT_MIN, HotKeyEntry, HotkeysOptions, HotkeysResponse,
+        SlotRange,
+    },
 };
 pub use crate::connection::{
     Connection, ConnectionAddr, ConnectionInfo, ConnectionLike, IntoConnectionInfo, Msg, PubSub,
@@ -734,6 +738,10 @@ pub use crate::commands::JsonCommands;
 #[cfg(all(feature = "json", feature = "aio"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "json", feature = "aio"))))]
 pub use crate::commands::JsonAsyncCommands;
+
+#[cfg(feature = "aio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
+pub use crate::commands::AsyncHotkeysCommands;
 
 #[cfg(feature = "vector-sets")]
 #[cfg_attr(docsrs, doc(cfg(feature = "vector-sets")))]

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -1,0 +1,749 @@
+#![allow(clippy::let_unit_value)]
+
+#[macro_use]
+mod support;
+
+#[cfg(test)]
+mod hotkeys {
+    use crate::support::*;
+    use redis::{Commands, HotkeysCommands, HotkeysOptions, ProtocolVersion, RedisConnectionInfo};
+    use rstest::rstest;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    const TEST_KEYS_AND_VALUES: [(&str, &str); 3] = [
+        ("test_key_1", "value1"),
+        ("test_key_2", "value2"),
+        ("test_key_3", "value3"),
+    ];
+
+    fn setup_connection_with_protocol(
+        ctx: &TestContext,
+        protocol: ProtocolVersion,
+    ) -> redis::Connection {
+        let connection_info = ctx
+            .server
+            .connection_info()
+            .set_redis_settings(RedisConnectionInfo::default().set_protocol(protocol));
+        let client = redis::Client::open(connection_info).unwrap();
+        client.get_connection().unwrap()
+    }
+
+    fn setup_test_keys_and_make_hot_keys(con: &mut redis::Connection) {
+        for (i, (key, value)) in TEST_KEYS_AND_VALUES.iter().enumerate() {
+            let _: () = con.set(key, value).unwrap();
+            for _ in 0..i * 10 {
+                let _: String = con.get(key).unwrap();
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    pub(super) enum Metric {
+        Cpu,
+        Net,
+        All,
+    }
+
+    impl Metric {
+        pub(super) fn options(self) -> HotkeysOptions {
+            match self {
+                Metric::Cpu => HotkeysOptions::new_with_cpu(),
+                Metric::Net => HotkeysOptions::new_with_net(),
+                Metric::All => HotkeysOptions::new_with_cpu().and_net(),
+            }
+        }
+    }
+
+    impl std::fmt::Display for Metric {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(match self {
+                Metric::Cpu => "CPU",
+                Metric::Net => "NET",
+                Metric::All => "CPU+NET",
+            })
+        }
+    }
+
+    #[rstest]
+    #[case(ProtocolVersion::RESP2)]
+    #[case(ProtocolVersion::RESP3)]
+    fn test_hotkeys_state_machine_behavior(#[case] protocol: ProtocolVersion) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = setup_connection_with_protocol(&ctx, protocol);
+
+        println!("Starting test_hotkeys_state_machine_behavior - Protocol: {protocol:?}");
+
+        // When there isn't an active tracking session:
+        //  STOP returns false
+        assert!(!con.hotkeys_stop().unwrap());
+        //  RESET succeeds as a no-op
+        assert!(con.hotkeys_reset().is_ok());
+        //  GET returns None
+        assert!(con.hotkeys_get().unwrap().is_none());
+
+        // Start a tracking session by CPU.
+        assert!(con.hotkeys_start(HotkeysOptions::new_with_cpu()).is_ok());
+        // When there is a running tracking session START returns an error.
+        assert!(con.hotkeys_start(HotkeysOptions::new_with_net()).is_err());
+
+        // Setup test keys and make some hot keys.
+        setup_test_keys_and_make_hot_keys(&mut con);
+
+        // Get a snapshot of the running session.
+        let tracking_session_snapshot = con.hotkeys_get().unwrap();
+        assert!(tracking_session_snapshot.is_some());
+        let tracking_session_snapshot = tracking_session_snapshot.unwrap();
+        assert!(tracking_session_snapshot.tracking_active);
+        assert!(tracking_session_snapshot.by_cpu_time_us.is_some());
+        assert!(!tracking_session_snapshot.by_cpu_time_us.unwrap().is_empty());
+        assert!(tracking_session_snapshot.by_net_bytes.is_none());
+
+        // RESET only works when no tracking session is running.
+        // With a live session it should return a server error.
+        assert!(con.hotkeys_reset().is_err());
+
+        // STOP should return true when there is a running session.
+        assert!(con.hotkeys_stop().unwrap());
+        // STOP returns false when there is no running session.
+        assert!(!con.hotkeys_stop().unwrap());
+
+        // Get a snapshot of the final state.
+        let final_snapshot = con.hotkeys_get().unwrap();
+        assert!(final_snapshot.is_some());
+        let final_snapshot = final_snapshot.unwrap();
+        assert!(!final_snapshot.tracking_active);
+        assert!(final_snapshot.by_cpu_time_us.is_some());
+        assert!(!final_snapshot.by_cpu_time_us.unwrap().is_empty());
+        assert!(final_snapshot.by_net_bytes.is_none());
+
+        // Verify that starting a new session will override any existing tracking state.
+        assert!(con.hotkeys_start(HotkeysOptions::new_with_cpu()).is_ok());
+        let new_session_snapshot = con.hotkeys_get().unwrap();
+        assert!(new_session_snapshot.is_some());
+        let new_session_snapshot = new_session_snapshot.unwrap();
+        assert!(new_session_snapshot.tracking_active);
+        // The new session should not have any data, since no keys were accessed.
+        // Note: since the tracking session is by CPU, it is expected that the by_cpu_time_us is present but empty.
+        assert!(new_session_snapshot.by_cpu_time_us.is_some());
+        assert!(new_session_snapshot.by_cpu_time_us.unwrap().is_empty());
+        assert!(new_session_snapshot.by_net_bytes.is_none());
+
+        // Stop the new session to enable resetting the state.
+        assert!(con.hotkeys_stop().unwrap());
+
+        // Clear the state and verify that GET returns None.
+        assert!(con.hotkeys_reset().is_ok());
+        assert!(con.hotkeys_get().unwrap().is_none());
+    }
+
+    #[rstest]
+    #[case(ProtocolVersion::RESP2, Metric::Cpu)]
+    #[case(ProtocolVersion::RESP3, Metric::Cpu)]
+    #[case(ProtocolVersion::RESP2, Metric::Net)]
+    #[case(ProtocolVersion::RESP3, Metric::Net)]
+    #[case(ProtocolVersion::RESP2, Metric::All)]
+    #[case(ProtocolVersion::RESP3, Metric::All)]
+    fn test_hotkeys_with_metric(#[case] protocol: ProtocolVersion, #[case] metric: Metric) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = setup_connection_with_protocol(&ctx, protocol);
+
+        println!("Starting test_hotkeys_with_metric - Metric: {metric}, Protocol: {protocol:?}");
+
+        assert!(con.hotkeys_start(metric.options()).is_ok());
+        setup_test_keys_and_make_hot_keys(&mut con);
+
+        let result = con.hotkeys_get().unwrap().unwrap();
+
+        assert!(result.tracking_active);
+        assert_eq!(result.sample_ratio, 1);
+        assert!(result.collection_duration_ms > 0);
+
+        let expect_cpu = matches!(metric, Metric::Cpu);
+        let expect_net = matches!(metric, Metric::Net);
+        let expect_all = matches!(metric, Metric::All);
+
+        assert_eq!(result.by_cpu_time_us.is_some(), expect_cpu || expect_all);
+        assert_eq!(result.by_net_bytes.is_some(), expect_net || expect_all);
+    }
+
+    #[rstest]
+    #[case(ProtocolVersion::RESP2)]
+    #[case(ProtocolVersion::RESP3)]
+    fn test_hotkeys_options_with_duration_and_count(#[case] protocol: ProtocolVersion) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = setup_connection_with_protocol(&ctx, protocol);
+
+        println!("Starting test_hotkeys_options_with_duration_and_count - Protocol: {protocol:?}");
+
+        assert!(
+            con.hotkeys_start(
+                HotkeysOptions::new_with_cpu()
+                    .with_count(2)
+                    .unwrap()
+                    .with_duration_secs(2)
+            )
+            .is_ok()
+        );
+        setup_test_keys_and_make_hot_keys(&mut con);
+        let result = con.hotkeys_get().unwrap().unwrap();
+        assert!(result.tracking_active);
+        assert!(result.by_cpu_time_us.is_some());
+        assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
+
+        sleep(Duration::from_secs(3));
+
+        let result = con.hotkeys_get().unwrap().unwrap();
+        assert!(!result.tracking_active);
+        assert!(result.by_cpu_time_us.is_some());
+        assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
+    }
+
+    #[rstest]
+    #[case(ProtocolVersion::RESP2)]
+    #[case(ProtocolVersion::RESP3)]
+    fn test_hotkeys_options_with_sample_ratio(#[case] protocol: ProtocolVersion) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = setup_connection_with_protocol(&ctx, protocol);
+
+        println!("Starting test_hotkeys_options_with_sample_ratio - Protocol: {protocol:?}");
+
+        const SAMPLE_RATIO: u64 = 100;
+        assert!(
+            con.hotkeys_start(HotkeysOptions::new_with_cpu().with_sample_ratio(SAMPLE_RATIO))
+                .is_ok()
+        );
+
+        let result = con.hotkeys_get().unwrap().unwrap();
+        assert!(result.tracking_active);
+        assert_eq!(result.sample_ratio, SAMPLE_RATIO);
+    }
+
+    #[rstest]
+    #[case(ProtocolVersion::RESP2)]
+    #[case(ProtocolVersion::RESP3)]
+    fn test_hotkeys_start_with_slots_on_standalone_errors(#[case] protocol: ProtocolVersion) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let mut con = setup_connection_with_protocol(&ctx, protocol);
+
+        println!(
+            "Starting test_hotkeys_start_with_slots_on_standalone_errors - Protocol: {protocol:?}"
+        );
+
+        let err = con
+            .hotkeys_start(HotkeysOptions::new_with_cpu().with_slots(vec![100]))
+            .expect_err("SLOTS on a standalone server must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SLOTS parameter cannot be used in non-cluster mode"),
+            "unexpected error for SLOTS on standalone: {msg}",
+        );
+
+        assert!(con.hotkeys_get().unwrap().is_none());
+    }
+}
+
+#[cfg(all(test, feature = "cluster"))]
+mod hotkeys_cluster {
+    use crate::support::*;
+    use redis::cluster::ClusterClientBuilder;
+    use redis::cluster_routing::{Route, RoutingInfo, SingleNodeRoutingInfo, SlotAddr};
+    use redis::{
+        Commands, ConnectionAddr, ConnectionInfo, HotkeysCommands, HotkeysOptions, HotkeysResponse,
+        ProtocolVersion, RedisConnectionInfo, Value, cmd, from_redis_value,
+    };
+    use rstest::rstest;
+
+    /// Open a direct (non-cluster) connection to a specific node using `protocol`.
+    fn direct_connection(info: ConnectionInfo, protocol: ProtocolVersion) -> redis::Connection {
+        let info = info.set_redis_settings(RedisConnectionInfo::default().set_protocol(protocol));
+        redis::Client::open(info).unwrap().get_connection().unwrap()
+    }
+
+    /// Extract the TCP port from a `ConnectionAddr`.
+    fn port_of(addr: &ConnectionAddr) -> u16 {
+        match addr {
+            ConnectionAddr::Tcp(_, p) => *p,
+            ConnectionAddr::TcpTls { port, .. } => *port,
+            _ => panic!("Unsupported address type for cluster tests: {addr:?}"),
+        }
+    }
+
+    /// Return the (start, end) of the first slot range owned by the primary on `port`.
+    fn first_owned_slot_range(con: &mut redis::Connection, port: u16) -> (u16, u16) {
+        let value: Value = cmd("CLUSTER").arg("SLOTS").query(con).unwrap();
+        let Value::Array(ranges) = value else {
+            panic!("Expected array from CLUSTER SLOTS, got {value:?}");
+        };
+        for range in ranges {
+            let Value::Array(fields) = range else {
+                continue;
+            };
+            if fields.len() < 3 {
+                continue;
+            }
+            let start: u16 = from_redis_value(fields[0].clone()).unwrap();
+            let end: u16 = from_redis_value(fields[1].clone()).unwrap();
+            let Value::Array(master) = &fields[2] else {
+                continue;
+            };
+            if master.len() < 2 {
+                continue;
+            }
+            let master_port: u16 = from_redis_value(master[1].clone()).unwrap();
+            if master_port == port {
+                return (start, end);
+            }
+        }
+        panic!("No slot range found for port {port}");
+    }
+
+    /// Find a hash-tagged key whose slot is in the inclusive range `[start, end]`, using `CLUSTER KEYSLOT`.
+    fn find_key_in_range(con: &mut redis::Connection, start: u16, end: u16) -> (String, u16) {
+        for i in 0..50_000u32 {
+            let key = format!("{{hot{i}}}:k");
+            let slot: u16 = cmd("CLUSTER").arg("KEYSLOT").arg(&key).query(con).unwrap();
+            if slot >= start && slot <= end {
+                return (key, slot);
+            }
+        }
+        panic!("Could not find a key hashing to [{start}, {end}]");
+    }
+
+    /// Common setup: build a cluster, pick the first primary, find a key whose slot it owns.
+    /// Returns `(cluster_ctx, primary_info, hot_key, target_slot)`.
+    ///
+    /// The version check is performed via a direct standalone connection to a single
+    /// primary; `TestClusterContext::get_version()` would broadcast `INFO` to every
+    /// node and fail to parse the multi-node map response.
+    fn setup_cluster_and_target(
+        protocol: ProtocolVersion,
+    ) -> Option<(TestClusterContext, ConnectionInfo, String, u16)> {
+        let cluster_ctx = TestClusterContext::new();
+        cluster_ctx.wait_for_cluster_up();
+
+        let server = cluster_ctx.cluster.iter_servers().next().unwrap();
+        let info = server.connection_info();
+        let port = port_of(info.addr());
+        let mut direct = direct_connection(info.clone(), protocol);
+
+        let server_info: redis::InfoDict =
+            redis::Cmd::new().arg("INFO").query(&mut direct).unwrap();
+        let version = parse_version(server_info);
+        if version < REDIS_VERSION_CE_8_6 {
+            eprintln!(
+                "Skipping: Redis version {version:?} < {:?}",
+                REDIS_VERSION_CE_8_6
+            );
+            return None;
+        }
+
+        let (range_start, range_end) = first_owned_slot_range(&mut direct, port);
+        let (hot_key, target_slot) = find_key_in_range(&mut direct, range_start, range_end);
+        println!(
+            "cluster node on port {port} owns slots [{range_start}, {range_end}]; \
+             using key {hot_key} -> slot {target_slot}"
+        );
+
+        Some((cluster_ctx, info, hot_key, target_slot))
+    }
+
+    #[rstest]
+    #[case(ProtocolVersion::RESP2)]
+    #[case(ProtocolVersion::RESP3)]
+    fn test_hotkeys_cluster_with_slots_via_direct_client(#[case] protocol: ProtocolVersion) {
+        println!(
+            "Starting test_hotkeys_cluster_with_slots_via_direct_client - Protocol: {protocol:?}"
+        );
+
+        let Some((_cluster_ctx, info, hot_key, target_slot)) = setup_cluster_and_target(protocol)
+        else {
+            return;
+        };
+
+        let mut con = direct_connection(info, protocol);
+
+        let opts = HotkeysOptions::new_with_cpu()
+            .and_net()
+            .with_slots(vec![target_slot]);
+        con.hotkeys_start(opts).unwrap();
+
+        // Generate activity on the tracked key.
+        let _: () = con.set(&hot_key, "value").unwrap();
+        for _ in 0..50 {
+            let _: String = con.get(&hot_key).unwrap();
+        }
+
+        let snapshot = con.hotkeys_get().unwrap().expect("session is active");
+        assert!(snapshot.tracking_active);
+
+        // SLOTS filter reported back in the response.
+        assert!(
+            snapshot
+                .selected_slots
+                .iter()
+                .any(|r| r.start <= target_slot && target_slot <= r.end),
+            "selected_slots {:?} should include slot {target_slot}",
+            snapshot.selected_slots,
+        );
+
+        // Cluster-only fields populated when SLOTS was used.
+        assert!(snapshot.all_commands_selected_slots_us.is_some());
+        assert!(snapshot.net_bytes_all_commands_selected_slots.is_some());
+
+        // The hot key should appear in both CPU and NET breakdowns.
+        let cpu = snapshot
+            .by_cpu_time_us
+            .as_ref()
+            .expect("CPU metric requested");
+        assert!(cpu.iter().any(|e| e.key == hot_key));
+        let net = snapshot
+            .by_net_bytes
+            .as_ref()
+            .expect("NET metric requested");
+        assert!(net.iter().any(|e| e.key == hot_key));
+    }
+
+    #[rstest]
+    #[case(ProtocolVersion::RESP2)]
+    #[case(ProtocolVersion::RESP3)]
+    fn test_hotkeys_cluster_with_slots_via_cluster_routing(#[case] protocol: ProtocolVersion) {
+        println!(
+            "Starting test_hotkeys_cluster_with_slots_via_cluster_routing - Protocol: {protocol:?}"
+        );
+
+        let Some((cluster_ctx, _info, hot_key, target_slot)) = setup_cluster_and_target(protocol)
+        else {
+            return;
+        };
+
+        // Build a ClusterClient with the requested protocol.
+        let client = ClusterClientBuilder::new(cluster_ctx.nodes.clone())
+            .use_protocol(protocol)
+            .build()
+            .unwrap();
+        let mut cluster_con = client.get_connection().unwrap();
+
+        let routing = RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(Route::new(
+            target_slot,
+            SlotAddr::Master,
+        )));
+
+        // START with SLOTS filter via route_command.
+        let opts = HotkeysOptions::new_with_cpu()
+            .and_net()
+            .with_slots(vec![target_slot]);
+        let mut start_cmd = cmd("HOTKEYS");
+        start_cmd.arg("START").arg(&opts);
+        let start_value = cluster_con
+            .route_command(&start_cmd, routing.clone())
+            .unwrap();
+        assert_eq!(start_value, Value::Okay);
+
+        // Generate activity. ClusterConnection routes the hash-tagged key to its owning primary.
+        let _: () = cluster_con.set(&hot_key, "value").unwrap();
+        for _ in 0..50 {
+            let _: String = cluster_con.get(&hot_key).unwrap();
+        }
+
+        // GET via route_command and parse manually.
+        let mut get_cmd = cmd("HOTKEYS");
+        get_cmd.arg("GET");
+        let get_value = cluster_con
+            .route_command(&get_cmd, routing.clone())
+            .unwrap();
+        let snapshot: Option<HotkeysResponse> = from_redis_value(get_value).unwrap();
+        let snapshot = snapshot.expect("session is active");
+
+        assert!(snapshot.tracking_active);
+        assert!(
+            snapshot
+                .selected_slots
+                .iter()
+                .any(|r| r.start <= target_slot && target_slot <= r.end),
+            "selected_slots {:?} should include slot {target_slot}",
+            snapshot.selected_slots,
+        );
+        assert!(snapshot.all_commands_selected_slots_us.is_some());
+        assert!(snapshot.net_bytes_all_commands_selected_slots.is_some());
+        assert!(
+            snapshot
+                .by_cpu_time_us
+                .as_ref()
+                .expect("CPU metric requested")
+                .iter()
+                .any(|e| e.key == hot_key)
+        );
+        assert!(
+            snapshot
+                .by_net_bytes
+                .as_ref()
+                .expect("NET metric requested")
+                .iter()
+                .any(|e| e.key == hot_key)
+        );
+    }
+}
+
+#[cfg(all(test, feature = "aio"))]
+mod async_hotkeys {
+    use crate::support::*;
+    use redis::{
+        AsyncCommands, AsyncHotkeysCommands, HotkeysOptions, ProtocolVersion, RedisConnectionInfo,
+    };
+    use rstest::rstest;
+    use std::time::Duration;
+
+    const TEST_KEYS_AND_VALUES: [(&str, &str); 3] = [
+        ("async_test_key_1", "value1"),
+        ("async_test_key_2", "value2"),
+        ("async_test_key_3", "value3"),
+    ];
+
+    async fn setup_async_connection_with_protocol(
+        ctx: &TestContext,
+        protocol: ProtocolVersion,
+    ) -> redis::aio::MultiplexedConnection {
+        let connection_info = ctx
+            .server
+            .connection_info()
+            .set_redis_settings(RedisConnectionInfo::default().set_protocol(protocol));
+        let client = redis::Client::open(connection_info).unwrap();
+        client.get_multiplexed_async_connection().await.unwrap()
+    }
+
+    async fn setup_test_keys_and_make_hot_keys(con: &mut redis::aio::MultiplexedConnection) {
+        for (i, (key, value)) in TEST_KEYS_AND_VALUES.iter().enumerate() {
+            let _: () = con.set(key, value).await.unwrap();
+            for _ in 0..i * 10 {
+                let _: String = con.get(key).await.unwrap();
+            }
+        }
+    }
+
+    use super::hotkeys::Metric;
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_hotkeys_state_machine_behavior_async(
+        #[case] runtime: RuntimeType,
+        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
+    ) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+
+        println!("Starting test_hotkeys_state_machine_behavior_async - Protocol: {protocol:?}");
+
+        block_on_all(
+            async move {
+                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
+
+                // When there isn't an active tracking session:
+                //  STOP returns false
+                assert!(!con.hotkeys_stop().await.unwrap());
+                //  RESET succeeds as a no-op
+                assert!(con.hotkeys_reset().await.is_ok());
+                //  GET returns None
+                assert!(con.hotkeys_get().await.unwrap().is_none());
+
+                // Start a tracking session by CPU.
+                assert!(
+                    con.hotkeys_start(HotkeysOptions::new_with_cpu())
+                        .await
+                        .is_ok()
+                );
+                // When there is a running tracking session START returns an error.
+                assert!(
+                    con.hotkeys_start(HotkeysOptions::new_with_net())
+                        .await
+                        .is_err()
+                );
+
+                setup_test_keys_and_make_hot_keys(&mut con).await;
+
+                let snapshot = con.hotkeys_get().await.unwrap().unwrap();
+                assert!(snapshot.tracking_active);
+                assert!(snapshot.by_cpu_time_us.is_some());
+                assert!(!snapshot.by_cpu_time_us.unwrap().is_empty());
+                assert!(snapshot.by_net_bytes.is_none());
+
+                // RESET while a live session exists must error.
+                assert!(con.hotkeys_reset().await.is_err());
+
+                // STOP returns true when a session is running, false afterwards.
+                assert!(con.hotkeys_stop().await.unwrap());
+                assert!(!con.hotkeys_stop().await.unwrap());
+
+                let final_snapshot = con.hotkeys_get().await.unwrap().unwrap();
+                assert!(!final_snapshot.tracking_active);
+                assert!(final_snapshot.by_cpu_time_us.is_some());
+                assert!(!final_snapshot.by_cpu_time_us.unwrap().is_empty());
+                assert!(final_snapshot.by_net_bytes.is_none());
+
+                // Starting a new session overrides any existing tracking state.
+                assert!(
+                    con.hotkeys_start(HotkeysOptions::new_with_cpu())
+                        .await
+                        .is_ok()
+                );
+                let new_snapshot = con.hotkeys_get().await.unwrap().unwrap();
+                assert!(new_snapshot.tracking_active);
+                assert!(new_snapshot.by_cpu_time_us.is_some());
+                assert!(new_snapshot.by_cpu_time_us.unwrap().is_empty());
+                assert!(new_snapshot.by_net_bytes.is_none());
+
+                assert!(con.hotkeys_stop().await.unwrap());
+                assert!(con.hotkeys_reset().await.is_ok());
+                assert!(con.hotkeys_get().await.unwrap().is_none());
+            },
+            runtime,
+        );
+    }
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_hotkeys_with_metric_async(
+        #[case] runtime: RuntimeType,
+        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
+        #[values(Metric::Cpu, Metric::Net, Metric::All)] metric: Metric,
+    ) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+
+        println!(
+            "Starting test_hotkeys_with_metric_async - Metric: {metric}, Protocol: {protocol:?}"
+        );
+
+        block_on_all(
+            async move {
+                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
+
+                assert!(con.hotkeys_start(metric.options()).await.is_ok());
+                setup_test_keys_and_make_hot_keys(&mut con).await;
+
+                let result = con.hotkeys_get().await.unwrap().unwrap();
+                assert!(result.tracking_active);
+                assert_eq!(result.sample_ratio, 1);
+                assert!(result.collection_duration_ms > 0);
+
+                let expect_cpu = matches!(metric, Metric::Cpu);
+                let expect_net = matches!(metric, Metric::Net);
+                let expect_all = matches!(metric, Metric::All);
+
+                assert_eq!(result.by_cpu_time_us.is_some(), expect_cpu || expect_all);
+                assert_eq!(result.by_net_bytes.is_some(), expect_net || expect_all);
+            },
+            runtime,
+        );
+    }
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_hotkeys_options_with_duration_and_count_async(
+        #[case] runtime: RuntimeType,
+        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
+    ) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+
+        println!(
+            "Starting test_hotkeys_options_with_duration_and_count_async - Protocol: {protocol:?}"
+        );
+
+        block_on_all(
+            async move {
+                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
+
+                assert!(
+                    con.hotkeys_start(
+                        HotkeysOptions::new_with_cpu()
+                            .with_count(2)
+                            .unwrap()
+                            .with_duration_secs(2),
+                    )
+                    .await
+                    .is_ok()
+                );
+                setup_test_keys_and_make_hot_keys(&mut con).await;
+                let result = con.hotkeys_get().await.unwrap().unwrap();
+                assert!(result.tracking_active);
+                assert!(result.by_cpu_time_us.is_some());
+                assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
+
+                futures_time::task::sleep(Duration::from_secs(3).into()).await;
+
+                let result = con.hotkeys_get().await.unwrap().unwrap();
+                assert!(!result.tracking_active);
+                assert!(result.by_cpu_time_us.is_some());
+                assert_eq!(result.by_cpu_time_us.unwrap().len(), 2);
+            },
+            runtime,
+        );
+    }
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_hotkeys_options_with_sample_ratio_async(
+        #[case] runtime: RuntimeType,
+        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
+    ) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+
+        println!("Starting test_hotkeys_options_with_sample_ratio_async - Protocol: {protocol:?}");
+
+        block_on_all(
+            async move {
+                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
+
+                const SAMPLE_RATIO: u64 = 100;
+                assert!(
+                    con.hotkeys_start(
+                        HotkeysOptions::new_with_cpu().with_sample_ratio(SAMPLE_RATIO)
+                    )
+                    .await
+                    .is_ok()
+                );
+
+                let result = con.hotkeys_get().await.unwrap().unwrap();
+                assert!(result.tracking_active);
+                assert_eq!(result.sample_ratio, SAMPLE_RATIO);
+            },
+            runtime,
+        );
+    }
+
+    #[rstest]
+    #[cfg_attr(feature = "tokio-comp", case::tokio(RuntimeType::Tokio))]
+    #[cfg_attr(feature = "smol-comp", case::smol(RuntimeType::Smol))]
+    fn test_hotkeys_start_with_slots_on_standalone_errors_async(
+        #[case] runtime: RuntimeType,
+        #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
+    ) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+
+        println!(
+            "Starting test_hotkeys_start_with_slots_on_standalone_errors_async - \
+             Protocol: {protocol:?}"
+        );
+
+        block_on_all(
+            async move {
+                let mut con = setup_async_connection_with_protocol(&ctx, protocol).await;
+
+                let err = con
+                    .hotkeys_start(HotkeysOptions::new_with_cpu().with_slots(vec![100]))
+                    .await
+                    .expect_err("SLOTS on a standalone server must be rejected");
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("SLOTS parameter cannot be used in non-cluster mode"),
+                    "unexpected error for SLOTS on standalone: {msg}",
+                );
+
+                assert!(con.hotkeys_get().await.unwrap().is_none());
+            },
+            runtime,
+        );
+    }
+}

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -247,7 +247,10 @@ mod hotkeys {
 mod hotkeys_cluster {
     use crate::support::*;
     use redis::cluster::ClusterClientBuilder;
-    use redis::cluster_routing::{Route, RoutingInfo, SingleNodeRoutingInfo, SlotAddr};
+    use redis::cluster_routing::{
+        MultipleNodeRoutingInfo, ResponsePolicy, Route, RoutingInfo, SingleNodeRoutingInfo,
+        SlotAddr,
+    };
     use redis::{
         Commands, ConnectionAddr, ConnectionInfo, HotkeysCommands, HotkeysOptions, HotkeysResponse,
         ProtocolVersion, RedisConnectionInfo, Value, cmd, from_redis_value,
@@ -481,6 +484,117 @@ mod hotkeys_cluster {
                 .expect("NET metric requested")
                 .iter()
                 .any(|e| e.key == hot_key)
+        );
+    }
+
+    /// Cluster-wide tracking via fan-out routing to every primary.
+    ///
+    /// Exercises [`MultipleNodeRoutingInfo::AllMasters`]:
+    /// - START / STOP use [`ResponsePolicy::AllSucceeded`] so every primary must accept the command.
+    /// - GET is issued without a response policy. The cluster client returns a
+    ///   [`Value::Map`] keyed by node address, which is then parsed per-node.
+    /// - No `with_slots` filter is supplied and each primary tracks the keys for the slots it owns.
+    #[rstest]
+    #[case(ProtocolVersion::RESP2)]
+    #[case(ProtocolVersion::RESP3)]
+    fn test_hotkeys_cluster_all_primaries_via_cluster_routing(#[case] protocol: ProtocolVersion) {
+        println!(
+            "Starting test_hotkeys_cluster_all_primaries_via_cluster_routing - Protocol: {protocol:?}"
+        );
+
+        let Some((cluster_ctx, _info, hot_key, target_slot)) = setup_cluster_and_target(protocol)
+        else {
+            return;
+        };
+
+        let client = ClusterClientBuilder::new(cluster_ctx.nodes.clone())
+            .use_protocol(protocol)
+            .build()
+            .unwrap();
+        let mut cluster_con = client.get_connection().unwrap();
+
+        // START on every primary. AllSucceeded aggregates per-node replies into a single Okay
+        // and turns any per-node failure into a top-level error. SLOTS is intentionally omitted:
+        // each primary already owns a disjoint subset of the 16384 hash slots, so its tracker
+        // naturally sees only its own keys, and the union across primaries is a cluster-wide view.
+        let fanout_strict = RoutingInfo::MultiNode((
+            MultipleNodeRoutingInfo::AllMasters,
+            Some(ResponsePolicy::AllSucceeded),
+        ));
+        let opts = HotkeysOptions::new_with_cpu().and_net();
+        let mut start_cmd = cmd("HOTKEYS");
+        start_cmd.arg("START").arg(&opts);
+        let start_value = cluster_con
+            .route_command(&start_cmd, fanout_strict.clone())
+            .unwrap();
+        assert_eq!(start_value, Value::Okay);
+
+        // Generate enough activity that the hot key dominates the owning primary's top-K.
+        let _: () = cluster_con.set(&hot_key, "value").unwrap();
+        for _ in 0..50 {
+            let _: String = cluster_con.get(&hot_key).unwrap();
+        }
+
+        // GET via fan-out with response_policy=None: the client returns a Value::Map keyed by
+        // node address, with each entry holding that primary's raw HOTKEYS GET reply.
+        let fanout_per_node = RoutingInfo::MultiNode((MultipleNodeRoutingInfo::AllMasters, None));
+        let mut get_cmd = cmd("HOTKEYS");
+        get_cmd.arg("GET");
+        let get_value = cluster_con
+            .route_command(&get_cmd, fanout_per_node)
+            .unwrap();
+        let Value::Map(per_node) = get_value else {
+            panic!("expected Value::Map for fan-out HOTKEYS GET, got {get_value:?}");
+        };
+        assert_eq!(
+            per_node.len(),
+            cluster_ctx.nodes.len(),
+            "expected one entry per configured primary"
+        );
+
+        // Parse every per-node entry: each must report tracking_active, and at least one
+        // primary - the one owning target_slot - must list hot_key in by_cpu_time_us.
+        let mut hotkey_found = false;
+        for (addr_val, response_val) in per_node {
+            let addr: String = from_redis_value(addr_val).unwrap();
+            let snapshot: HotkeysResponse = from_redis_value(response_val)
+                .unwrap_or_else(|e| panic!("failed to parse response from {addr}: {e:?}"));
+            assert!(
+                snapshot.tracking_active,
+                "node {addr} should have tracking active"
+            );
+            if snapshot
+                .by_cpu_time_us
+                .as_ref()
+                .is_some_and(|cpu| cpu.iter().any(|e| e.key == hot_key))
+            {
+                hotkey_found = true;
+            }
+        }
+        assert!(
+            hotkey_found,
+            "hot key {hot_key} should appear in by-cpu-time on the primary owning slot {target_slot}"
+        );
+
+        // STOP on every primary, again aggregated to a single Okay.
+        let mut stop_cmd = cmd("HOTKEYS");
+        stop_cmd.arg("STOP");
+        let stop_value = cluster_con
+            .route_command(&stop_cmd, fanout_strict.clone())
+            .unwrap();
+        assert_eq!(stop_value, Value::Okay);
+
+        // Controlled failure: with_slots(...) is a server-side filter, not a routing hint.
+        // Broadcasting SLOTS=[target_slot] to every primary forces the non-owning primaries
+        // to reject the command, which AllSucceeded surfaces as a top-level error.
+        let bad_opts = HotkeysOptions::new_with_cpu().with_slots(vec![target_slot]);
+        let mut bad_start_cmd = cmd("HOTKEYS");
+        bad_start_cmd.arg("START").arg(&bad_opts);
+        let bad_result = cluster_con.route_command(&bad_start_cmd, fanout_strict);
+        assert!(
+            bad_result.is_err(),
+            "with_slots([{target_slot}]) + AllMasters + AllSucceeded must fail \
+             because the non-owning primaries reject SLOTS, got {bad_result:?}"
         );
     }
 }


### PR DESCRIPTION
# Add support for the HOTKEYS commands

## Summary

Add support for the new `HOTKEYS` command suite introduced in **Redis 8.6**, which lets clients track the most accessed keys on a node by CPU time and/or network bytes. The implementation covers the four sub-commands (`START`, `GET`, `STOP`, `RESET`) for both synchronous and asynchronous connections, with strong typing for options and responses.

## Motivation

`HOTKEYS` is a stateful, node-local diagnostic tool for identifying hot keys in real-world workloads without the overhead of full key-space scans. Exposing it through the existing `Commands` / `AsyncCommands` style traits gives users an idiomatic way to drive sampling sessions and inspect the structured response, instead of hand-assembling `Cmd` invocations and parsing responses.

## What's included

### New module `redis::commands::hotkeys`

- **`HotkeysOptions`** — builder for `HOTKEYS START` arguments. Exposes:
  - `new_with_cpu()` / `new_with_net()` constructors (at least one metric is required by the server, enforced at construction time).
  - `and_cpu()` / `and_net()` to combine metrics — `METRICS count` is auto-derived from the number of enabled metrics.
  - `with_count(k)` returning `Result<Self, String>`; `k` is range-checked against `[HOTKEYS_COUNT_MIN, HOTKEYS_COUNT_MAX]` (1..=64) before the command leaves the client.
  - `with_duration_secs(s)`, `with_sample_ratio(r)`, `with_slots(slots)`.

- **`HotkeysResponse`**, **`HotKeyEntry`**, **`SlotRange`** — typed view of the `HOTKEYS GET` payload, including:
  - Tracking metadata (`tracking_active`, `sample_ratio`, `collection_start_time_unix_ms`, `collection_duration_ms`).
  - Aggregate stats (`all_commands_all_slots_us`, `net_bytes_all_commands_all_slots`, totals for CPU user/sys and net bytes).
  - Per-metric top-K lists (`by_cpu_time_us`, `by_net_bytes`) gated `Option<...>` based on which metrics were requested.
  - Cluster-only fields populated when `SLOTS` was used (`*_selected_slots_us`, `net_bytes_*_selected_slots`).
- **`FromRedisValue` for `HotkeysResponse`** — handles the server's outer single-element array wrapping under both RESP2 and RESP3.

### New traits

- **`HotkeysCommands`** (sync) on `ConnectionLike`:
  - `hotkeys_start(opts) -> RedisResult<()>`
  - `hotkeys_get() -> RedisResult<Option<HotkeysResponse>>` (returns `None` when no session is available)
  - `hotkeys_stop() -> RedisResult<bool>` (true if a session was running, false otherwise)
  - `hotkeys_reset() -> RedisResult<()>`
- **`AsyncHotkeysCommands`** (gated on `feature = "aio"`) on `aio::ConnectionLike` — mirrors the sync surface with `RedisFuture<'a, T>` returns.

### Re-exports

`HotkeysCommands`, `HotkeysOptions`, `HotkeysResponse`, `HotKeyEntry`, `SlotRange` are exported from the crate root; `AsyncHotkeysCommands` is re-exported under `feature = "aio"`.

## Cluster usage

Notes:

The `HOTKEYS` command must not be exposed on clustered client abstractions or connection pooling clients. Exposing `HOTKEYS` on a `ClusterClient` or similar high-level abstraction would break session affinity because `START` might be routed to one node while `GET` is routed to a different node, resulting in errors or undefined behavior.

The `HOTKEYS` command with its typed response and arguments should only be implemented on standalone client instances that maintain a direct connection to a single Redis node. This ensures that the session affinity requirement is naturally satisfied, as all commands from that client instance will reach the same node.
 
`HOTKEYS` is **node-local** and is intentionally **NOT** wired into `ClusterConnection`'s aggregating path.  Using `HOTKEYS` against a specific cluster node can be done via `route_command` with explicit node routing.

## Tests

A new `redis/tests/test_hotkeys.rs` integration suite plus the unit tests inside `commands/hotkeys.rs` cover:

**Unit (`commands::hotkeys::tests`):**
- option building
- `ToRedisArgs` output
- `COUNT` range validation
- `FromRedisValue` parsing under several response shapes.

**Integration (gated on Redis ≥ 8.6 via `run_test_if_version_supported!`):**

- `hotkeys` mod (sync, RESP2/RESP3):
  - State-machine behavior (`STOP`/`RESET`/`GET`/`START` interactions and error cases).
  - Per-metric coverage (`CPU`, `NET`, `CPU`+`NET`) - verifies the right `Option` fields are populated.
  - `DURATION` + `COUNT` - confirms top-K limit and that `tracking_active` flips to false after the timer expires.
  - `SAMPLE` ratio round-trips through the response.
  - `SLOTS` on standalone is rejected with the expected error.
  
- `async_hotkeys` mod - mirrors the sync suite, parameterized over `RuntimeType` (`tokio` / `smol`) × `ProtocolVersion` (RESP2 / RESP3) via `rstest`.

- `hotkeys_cluster` mod — exercises `SLOTS` filtering both via a direct-node client and via `ClusterConnection::route_command`, asserts `selected_slots` round-trips and that the cluster-only response fields are populated.

## Reference documentation:
HOTKEYS main page: https://redis.io/docs/latest/commands/hotkeys/
[HOTKEYS START](https://redis.io/docs/latest/commands/hotkeys-start/) - Starts hotkeys tracking with specified metrics.
[HOTKEYS STOP](https://redis.io/docs/latest/commands/hotkeys-stop/) - Stops hotkeys tracking but preserves data.
[HOTKEYS GET](https://redis.io/docs/latest/commands/hotkeys-get/) - Returns tracking results and metadata.
[HOTKEYS RESET](https://redis.io/docs/latest/commands/hotkeys-reset/) - Releases resources used for tracking.
