### PR TITLE
Support bb8 pool for sentinel client

### DIFF
--- a/redis/src/bb8.rs
+++ b/redis/src/bb8.rs
@@ -4,6 +4,9 @@ use crate::{Client, Cmd, RedisError};
 #[cfg(feature = "cluster-async")]
 use crate::{cluster::ClusterClient, cluster_async::ClusterConnection};
 
+#[cfg(all(feature = "bb8", feature = "tokio-comp", feature = "sentinel"))]
+use crate::sentinel::AsyncLockedSentinelClient;
+
 macro_rules! impl_bb8_manage_connection {
     ($client:ty, $connectioin:ty, $get_conn:expr) => {
         impl bb8::ManageConnection for $client {
@@ -42,6 +45,9 @@ impl_bb8_manage_connection!(
     ClusterClient::get_async_connection
 );
 
-// TODO: support bb8 for sentinel client which required
-// [`crate::sentinel::LockedSentinelClient`] implement async method of
-// `get_multiplexed_async_connection`.
+#[cfg(all(feature = "bb8", feature = "tokio-comp", feature = "sentinel"))]
+impl_bb8_manage_connection!(
+    AsyncLockedSentinelClient,
+    MultiplexedConnection,
+    AsyncLockedSentinelClient::get_async_connection
+);

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1093,6 +1093,30 @@ impl LockedSentinelClient {
     }
 }
 
+#[cfg(all(feature = "bb8", feature = "tokio-comp", feature = "sentinel"))]
+use tokio::sync::Mutex as TokioMutex;
+
+/// AsyncLockedSentinelClient is a wrapper around SentinelClient usable in bb8.
+// [internal comment]: bb8 is based on r2d2 so it came with the same constrainst
+// this was added since SentinelClient requires &mut ref for get_connection()
+// and we can't use it like this inside the r2d2 Manager, which requires a shared reference.
+#[cfg(all(feature = "bb8", feature = "tokio-comp", feature = "sentinel"))]
+pub struct AsyncLockedSentinelClient(pub(crate) TokioMutex<SentinelClient>);
+
+#[cfg(all(feature = "bb8", feature = "tokio-comp", feature = "sentinel"))]
+impl AsyncLockedSentinelClient {
+    /// new creates a AsyncLockedSentinelClient by wrapping a new tokio Mutex around the SentinelClient
+    pub fn new(client: SentinelClient) -> Self {
+        Self(TokioMutex::new(client))
+    }
+
+    /// get_async_connection is the override for AsyncLockedSentinelClient to make it possible to
+    /// use get_async_connection with bb8 macro.
+    pub async fn get_async_connection(&self) -> RedisResult<MultiplexedConnection> {
+        self.0.lock().await.get_async_connection().await
+    }
+}
+
 /// A utility wrapping `Sentinel` with an interface similar to [Client].
 ///
 /// Uses the Sentinel type internally. This is a utility to help make it easier

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -1227,3 +1227,76 @@ pub mod pool_tests {
         assert!(try_conn.is_some());
     }
 }
+
+#[cfg(feature = "tokio-comp")]
+pub mod bb8_pool_tests {
+    use super::*;
+    use bb8::Pool;
+    use redis::sentinel::AsyncLockedSentinelClient;
+    use std::collections::HashSet;
+
+    fn parse_client_info(value: &str) -> HashMap<&str, &str> {
+        let info_map: std::collections::HashMap<&str, &str> = value
+            .split(" ")
+            .filter_map(|line| line.split_once('='))
+            .collect();
+        info_map
+    }
+
+    #[tokio::test]
+    async fn test_sentinel_client() {
+        let master_name = "master1";
+        let context = TestSentinelContext::new(2, 3, 3);
+        let master_client = SentinelClient::build(
+            context.sentinels_connection_info().clone(),
+            String::from(master_name),
+            Some(context.sentinel_node_connection_info()),
+            redis::sentinel::SentinelServerType::Master,
+        )
+        .unwrap();
+
+        let pool = Pool::builder()
+            .max_size(5)
+            .connection_timeout(Duration::from_secs(3))
+            .build(AsyncLockedSentinelClient::new(master_client))
+            .await
+            .unwrap();
+
+        let mut conns = Vec::new();
+        for i in 0..5 {
+            let conn = pool.get().await.unwrap();
+            assert_eq!(pool.state().connections, i + 1);
+            conns.push(conn);
+        }
+
+        // since max_size is 5 and we haven't freed any connection this try should fail
+        let try_conn = pool.get().await;
+        assert!(try_conn.is_err());
+
+        let mut client_id_set = HashSet::new();
+
+        for mut conn in conns {
+            let client_info_str: String = redis::cmd("CLIENT")
+                .arg("INFO")
+                .query_async(&mut *conn)
+                .await
+                .unwrap();
+
+            let client_info_parsed = parse_client_info(client_info_str.as_str());
+
+            // assert if all connections have different IDs
+            assert!(client_id_set.insert(client_info_parsed.get("id").unwrap().to_string()));
+
+            let info: String = redis::cmd("INFO")
+                .arg("REPLICATION")
+                .query_async(&mut *conn)
+                .await
+                .unwrap();
+            assert_is_master_role(info)
+        }
+
+        // since previous connections are freed, this should work
+        let try_conn = pool.get().await;
+        assert!(try_conn.is_ok());
+    }
+}


### PR DESCRIPTION
Goal is to enable for the user to use `bb8::Pool` with a `SentinelClient`

Usage:
```rust
    let client = SentinelClient::build(
        vec!["redis://127.0.0.1:26379/"],
        String::from("master1"),
        Some(SentinelNodeConnectionInfo::default()),
        SentinelServerType::Master,
    )
    .unwrap();

    let pool = bb8::Pool::builder()
        .max_size(5)
        .connection_timeout(Duration::from_secs(3))
        .build(AsyncLockedSentinelClient::new(client))
        .await
        .unwrap();
```

Support only `tokio`async runtime since `bb8` does not support `smol` because of internal use of `tokio::time::interval_at`

