### PR TITLE
feat: add ?Sized bound to impl AsyncPushSender for std::sync::Arc<T>

### DIFF
--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -223,7 +223,7 @@ impl AsyncPushSender for std::sync::mpsc::Sender<PushInfo> {
 
 impl<T> AsyncPushSender for std::sync::Arc<T>
 where
-    T: AsyncPushSender,
+    T: AsyncPushSender + ?Sized,
 {
     fn send(&self, info: PushInfo) -> Result<(), SendError> {
         self.as_ref().send(info)


### PR DESCRIPTION
fix #2090
