### PR TITLE
tests: Stop inflating dimensions during vector set dimension reduction

### DIFF
--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -3889,12 +3889,13 @@ mod basic {
         let key = "test_points_for_auxiliary_commands";
         let non_existent_key = "non_existent_key";
 
-        let points_data: Vec<(&'static str, [f32; 2])> = vec![
-            ("pt:A", [1.0f32, 1.0]),
-            ("pt:B", [-1.0f32, -1.0]),
-            ("pt:C", [-1.0f32, 1.0]),
-            ("pt:D", [1.0f32, -1.0]),
-            ("pt:E", [1.0f32, 0.0]),
+        let points_data: Vec<(&'static str, [f32; 4])> = vec![
+            // The numbers here are abitrary and not used in the test
+            ("pt:A", [0.0, 5.0, 0.0, 5.5]),
+            ("pt:B", [1.0, 6.0, 1.1, 6.6]),
+            ("pt:C", [2.0, 7.0, 2.2, 7.7]),
+            ("pt:D", [3.0, 8.0, 3.3, 8.8]),
+            ("pt:E", [4.0, 9.0, 4.4, 9.9]),
         ];
 
         let point_of_interest = "pt:A";


### PR DESCRIPTION
In `test_vector_sets_auxiliary_commands` the test data's vectors were only 2 entries long, which we "reduced" to 3.

Redis 8.6.3 received a guard against such inflating "reductions" in ea66422 and rejects inflations.

So we now test using vectors with 4 entries and reduce them to 3 entries. This makes tests against 8.6.3 pass (#2095).

As the numbers in the original test looked like they may had a purpose, did not align because of the flipping sign, and had unnecessary type specifiers, we cleaned that up while adding the needed entries.