### PR TITLE
ci: Bump Redis 8.6.2 to Redis 8.8.0

### DIFF
--- a/.github/actions/install-db/action.yml
+++ b/.github/actions/install-db/action.yml
@@ -46,7 +46,16 @@ runs:
         cd "${{ inputs.db-name }}-${{ inputs.db-version }}"
 
         # Build the db (with modules, if possible)
-        BUILD_TLS=yes BUILD_WITH_MODULES=yes make
+        # BUILD_TLS=yes -- enables built-in TLS support for Redis
+        # BUILD_WITH_MODULES=yes -- builds bundles modules for Redis
+        # LTO=0 -- disables link-time optimization for redisearch
+        #   LTO got enabled starting with redisearch 8.8, but relies on
+        #   `rustc`'s `clang` using the same major version as the system
+        #   `clang`. This does not hold for us.
+        #   On 2026-06-01, `ubuntu-latest` is ubuntu 24.04, which uses
+        #   `clang` 18, but `rustc`'s `clang` is 21. So LTO builds would fail
+        #   and we keep LTO disabled (as before).
+        BUILD_TLS=yes BUILD_WITH_MODULES=yes LTO=0 make
 
         # Copy the built executables out
         mv -v "src/${{ inputs.db-name }}-server" "$HOME/db/redis-server"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,9 +34,7 @@ jobs:
             {  db-org: redis, db-name: redis, db-version: 7.0.15, json-module-version: v2.6.22 },
             {  db-org: redis, db-name: redis, db-version: 7.4.9, json-module-version: v2.6.22 },
             {  db-org: redis, db-name: redis, db-version: 8.0.6, json-module-version: bundled },
-            # Although Redis 8.6.3 is available, we lock at 8.6.2 for now, as 8.6.3+ reliably breaks
-            # tests locally and also for CI (see #2095)
-            {  db-org: redis, db-name: redis, db-version: 8.6.2, json-module-version: bundled },
+            {  db-org: redis, db-name: redis, db-version: 8.8.0, json-module-version: bundled },
             {  db-org: valkey-io, db-name: valkey, db-version: 7.2.12, json-module-version: v2.6.22 },
             {  db-org: valkey-io, db-name: valkey, db-version: 8.0.7, json-module-version: v2.6.22 },
             # Skipping ValKey 8.1 as it's too similar to 8.0


### PR DESCRIPTION
Redis 8.8.0 got released. It comes with a new data structure, commands and options. So it's different enough to warrant testing against it.

https://github.com/redis/redis/releases/tag/8.8.0

Closes #2094