### PR TITLE
ci: Bump Valkey to 7.2.13, 8.0.9, and 9.0.4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,10 +35,11 @@ jobs:
             {  db-org: redis, db-name: redis, db-version: 7.4.9, json-module-version: v2.6.22 },
             {  db-org: redis, db-name: redis, db-version: 8.0.6, json-module-version: bundled },
             {  db-org: redis, db-name: redis, db-version: 8.8.0, json-module-version: bundled },
-            {  db-org: valkey-io, db-name: valkey, db-version: 7.2.12, json-module-version: v2.6.22 },
-            {  db-org: valkey-io, db-name: valkey, db-version: 8.0.7, json-module-version: v2.6.22 },
+            {  db-org: valkey-io, db-name: valkey, db-version: 7.2.13, json-module-version: v2.6.22 },
+            {  db-org: valkey-io, db-name: valkey, db-version: 8.0.9, json-module-version: v2.6.22 },
             # Skipping ValKey 8.1 as it's too similar to 8.0
-            {  db-org: valkey-io, db-name: valkey, db-version: 9.0.3, json-module-version: v2.6.22 },
+            {  db-org: valkey-io, db-name: valkey, db-version: 9.0.4, json-module-version: v2.6.22 },
+            # Skipping ValKey 9.1 as it's too similar to 9.0
           ]
 
     steps:


### PR DESCRIPTION
The bumped patch versions contain mostly security fixes. But we bump them nonetheless to stay on top of things.

https://github.com/valkey-io/valkey/releases/tag/7.2.13
https://github.com/valkey-io/valkey/releases/tag/8.0.8 (revoked)
https://github.com/valkey-io/valkey/releases/tag/8.0.9
https://github.com/valkey-io/valkey/releases/tag/9.0.4