### PR TITLE
ci: Use targets from Makefile instead of duplicating commands

### DIFF
--- a/.github/actions/lint-and-check/action.yml
+++ b/.github/actions/lint-and-check/action.yml
@@ -26,10 +26,9 @@ runs:
       shell: bash
       run: make lint
 
-    - name: Check features
+    - name: Check runtimes
       shell: bash
       run: |
-        cargo check --workspace --all-targets --all-features
         # Remove dev-dependencies so they do not enable features accidentally
         # https://github.com/rust-lang/cargo/issues/4664
         sed -i '/dev-dependencies/,/dev-dependencies/d' Cargo.toml

--- a/.github/actions/lint-and-check/action.yml
+++ b/.github/actions/lint-and-check/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Build default
       shell: bash
-      run: RUSTFLAGS="-D warnings" cargo build --locked -p redis
+      run: make build
 
     - name: Build all features
       shell: bash

--- a/.github/actions/lint-and-check/action.yml
+++ b/.github/actions/lint-and-check/action.yml
@@ -22,9 +22,9 @@ runs:
       shell: bash
       run: RUSTFLAGS="-D warnings" cargo build --locked -p redis --all-features
 
-    - run: cargo clippy --all-features --all-targets -- -D warnings
-      name: clippy
+    - name: Lint
       shell: bash
+      run: make lint
 
     - name: Check features
       shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -223,8 +223,8 @@ jobs:
         with:
           rust-toolchain: ${{ matrix.config.toolchain }}
 
-      - run: cargo fmt --all -- --check
-        name: fmt
+      - name: Check formatting
+        run: make style-check
 
       - name: doc
         run: cargo doc --all-features --no-deps --document-private-items

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ style-check:
 
 lint:
 	@rustup component add clippy 2> /dev/null
-	cargo clippy --all-features --all --tests --examples -- -D clippy::all -D warnings
+	cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings
 
 fuzz:
 	cd afl/parser/ && \


### PR DESCRIPTION
`clippy`'s invocation differed between CI and the Makefile differed. This
lead to needlessly failing CI runs although a local `make lint`
passed. We harmonize the linter calls to avoid such failures going
forward.

And as CI duplicated some commands from Makefile targets, we switch CI
to use these targets. This should help to keep local checking and CI
in sync.
