### PR TITLE
Add support for the new FPHA storage hint

### DIFF
--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -1,7 +1,9 @@
 use crate::cmd::{Cmd, cmd};
 use crate::connection::ConnectionLike;
 use crate::pipeline::Pipeline;
-use crate::types::{FromRedisValue, RedisResult, ToRedisArgs, ToSingleRedisArg};
+use crate::types::{
+    ExistenceCheck, FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, ToSingleRedisArg,
+};
 
 #[cfg(feature = "cluster")]
 use crate::commands::ClusterPipeline;
@@ -264,6 +266,14 @@ implement_json_commands! {
         cmd("JSON.SET").arg(key).arg(path).arg(serde_json::to_string(value)?).take()
     }
 
+    /// Sets the JSON Value at `path` in `key` with options.
+    ///
+    /// The value (JSON document or FPHA float array) is carried inside `options`
+    /// alongside the optional `NX`/`XX` existence check. See [`JsonSetOptions`].
+    fn json_set_options<K: ToSingleRedisArg, P: ToSingleRedisArg>(key: K, path: P, options: &'a JsonSetOptions) {
+        cmd("JSON.SET").arg(key).arg(path).arg(options).take()
+    }
+
         /// Sets the value at the path per key, for every given tuple.
     fn json_mset<K: ToSingleRedisArg, P: ToSingleRedisArg, V: Serialize>(key_path_values: &'a [(K,P,V)]) {
         let mut cmd = cmd("JSON.MSET");
@@ -302,3 +312,312 @@ impl<T> JsonCommands for T where T: ConnectionLike {}
 
 #[cfg(feature = "aio")]
 impl<T> JsonAsyncCommands for T where T: crate::aio::ConnectionLike + Send + Sized {}
+
+/// Storage-precision tag for the `FPHA` form of `JSON.SET`.
+///
+/// Pairs with an arbitrary `serde::Serialize` payload via
+/// [`JsonSetOptions::fpha_serialize`] to set values whose shape (matrices,
+/// objects with multiple FP-array fields, scalars) cannot be expressed as a
+/// flat [`FphaInput`] slice.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FphaType {
+    /// Server stores lanes as Google brain-float 16 (`bfloat16`).
+    Bf16,
+    /// Server stores lanes as IEEE-754 binary16.
+    Fp16,
+    /// Server stores lanes as IEEE-754 binary32.
+    Fp32,
+    /// Server stores lanes as IEEE-754 binary64.
+    Fp64,
+}
+
+impl ToRedisArgs for FphaType {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            FphaType::Bf16 => out.write_arg(b"BF16"),
+            FphaType::Fp16 => out.write_arg(b"FP16"),
+            FphaType::Fp32 => out.write_arg(b"FP32"),
+            FphaType::Fp64 => out.write_arg(b"FP64"),
+        }
+    }
+}
+
+/// Float-array payload for the `FPHA` form of `JSON.SET`.
+///
+/// Each variant holds a borrowed flat slice of lanes; the variant determines
+/// both the serialized element type and the `FPHA <TYPE>` storage hint sent
+/// to the server. Used together with [`JsonSetOptions::fpha`] when the value
+/// is a flat 1-D vector.
+///
+/// For multi-dimensional payloads (matrices, objects with multiple FP-array
+/// fields, scalars), use [`JsonSetOptions::fpha_serialize`] with an explicit
+/// [`FphaType`] instead.
+#[derive(Clone, Copy, Debug)]
+pub enum FphaInput<'a> {
+    /// Server stores lanes as Google brain-float 16 (`bfloat16`).
+    Bf16(&'a [f32]),
+    /// Server stores lanes as IEEE-754 binary16.
+    Fp16(&'a [f32]),
+    /// Server stores lanes as IEEE-754 binary32.
+    Fp32(&'a [f32]),
+    /// Server stores lanes as IEEE-754 binary64.
+    Fp64(&'a [f64]),
+}
+
+impl FphaInput<'_> {
+    fn fpha_type(&self) -> FphaType {
+        match self {
+            FphaInput::Bf16(_) => FphaType::Bf16,
+            FphaInput::Fp16(_) => FphaType::Fp16,
+            FphaInput::Fp32(_) => FphaType::Fp32,
+            FphaInput::Fp64(_) => FphaType::Fp64,
+        }
+    }
+
+    fn serialize_json(&self) -> RedisResult<String> {
+        match *self {
+            FphaInput::Bf16(s) | FphaInput::Fp16(s) | FphaInput::Fp32(s) => {
+                serde_json::to_string(s)
+            }
+            FphaInput::Fp64(s) => serde_json::to_string(s),
+        }
+        .map_err(Into::into)
+    }
+}
+
+/// Options for the [`JSON.SET`](https://redis.io/commands/json.set) command.
+///
+/// Carries the value to write (either a JSON document or an [`FphaInput`]
+/// float-array payload) together with an optional `NX`/`XX` existence check.
+///
+/// # Example
+/// ```rust,no_run
+/// use redis::{ExistenceCheck, JsonCommands, JsonSetOptions};
+/// use serde_json::json;
+/// # fn do_something() -> redis::RedisResult<()> {
+/// let client = redis::Client::open("redis://127.0.0.1/")?;
+/// let mut con = client.get_connection()?;
+/// let opts = JsonSetOptions::json(&json!({"item": 42}))?
+///     .conditional_set(ExistenceCheck::NX);
+/// let _: () = con.json_set_options("my_key", "$", &opts)?;
+/// # Ok(()) }
+/// ```
+pub struct JsonSetOptions {
+    value: String,
+    fpha_tag: Option<FphaType>,
+    conditional_set: Option<ExistenceCheck>,
+}
+
+impl JsonSetOptions {
+    /// Build options that set `value` as a JSON document.
+    ///
+    /// The value is serialized eagerly via `serde_json`; serialization errors
+    /// surface here rather than at command-dispatch time.
+    pub fn json<V: Serialize + ?Sized>(value: &V) -> RedisResult<Self> {
+        Ok(Self {
+            value: serde_json::to_string(value)?,
+            fpha_tag: None,
+            conditional_set: None,
+        })
+    }
+
+    /// Build options that set the value from a flat float-array payload,
+    /// emitting the trailing `FPHA <TYPE>` tag on the wire.
+    ///
+    /// The lanes are serialized as a JSON array of numbers; `FPHA <TYPE>` is a
+    /// storage hint that tells the server which precision to pack the array as
+    /// internally. The variant of [`FphaInput`] both selects the storage type
+    /// and constrains the data element type, ensuring they match.
+    ///
+    /// For payloads that aren't a flat 1-D vector (matrices, objects with
+    /// multiple FP-array fields, scalars), use [`Self::fpha_serialize`].
+    pub fn fpha(input: FphaInput<'_>) -> RedisResult<Self> {
+        Ok(Self {
+            value: input.serialize_json()?,
+            fpha_tag: Some(input.fpha_type()),
+            conditional_set: None,
+        })
+    }
+
+    /// Build options that serialize an arbitrary value with an `FPHA <TYPE>`
+    /// storage hint.
+    ///
+    /// Unlike [`Self::fpha`], this accepts any [`Serialize`] payload, allowing
+    /// nested arrays (matrices), objects with multiple FP-array fields, or
+    /// scalars. The caller picks the [`FphaType`] explicitly; no compile-time
+    /// pairing of the data element type with the storage hint is enforced.
+    pub fn fpha_serialize<V: Serialize + ?Sized>(value: &V, ty: FphaType) -> RedisResult<Self> {
+        Ok(Self {
+            value: serde_json::to_string(value)?,
+            fpha_tag: Some(ty),
+            conditional_set: None,
+        })
+    }
+
+    /// Apply an `NX` or `XX` existence check to the command.
+    pub fn conditional_set(mut self, existence_check: ExistenceCheck) -> Self {
+        self.conditional_set = Some(existence_check);
+        self
+    }
+}
+
+impl ToRedisArgs for JsonSetOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(self.value.as_bytes());
+        if let Some(ref conditional_set) = self.conditional_set {
+            conditional_set.write_redis_args(out);
+        }
+        if let Some(ref ty) = self.fpha_tag {
+            out.write_arg(b"FPHA");
+            ty.write_redis_args(out);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::{Arg, Cmd, cmd};
+
+    fn simple_args(c: &Cmd) -> Vec<Vec<u8>> {
+        c.args_iter()
+            .map(|a| match a {
+                Arg::Simple(b) => b.to_vec(),
+                Arg::Cursor => b"<CURSOR>".to_vec(),
+            })
+            .collect()
+    }
+
+    fn build(opts: &JsonSetOptions) -> Vec<Vec<u8>> {
+        let mut c = cmd("JSON.SET");
+        c.arg("k").arg("$").arg(opts);
+        simple_args(&c)
+    }
+
+    #[test]
+    fn json_value_writes_serialized_document_only() {
+        let opts = JsonSetOptions::json(&serde_json::json!({"a": 1})).unwrap();
+        assert_eq!(
+            build(&opts),
+            vec![
+                b"JSON.SET".to_vec(),
+                b"k".to_vec(),
+                b"$".to_vec(),
+                br#"{"a":1}"#.to_vec(),
+            ],
+        );
+    }
+
+    #[test]
+    fn json_value_with_nx_appends_existence_check() {
+        let opts = JsonSetOptions::json(&serde_json::json!(1))
+            .unwrap()
+            .conditional_set(ExistenceCheck::NX);
+        let args = build(&opts);
+        assert_eq!(args.last().unwrap(), b"NX");
+        assert_eq!(args.len(), 5);
+    }
+
+    #[test]
+    fn fpha_bf16_writes_json_array_and_appends_type_tag() {
+        let lanes = [1.0_f32, 2.5];
+        let opts = JsonSetOptions::fpha(FphaInput::Bf16(&lanes)).unwrap();
+        let args = build(&opts);
+        // [JSON.SET, k, $, <json>, FPHA, BF16]
+        assert_eq!(args.len(), 6);
+        assert_eq!(args[3], b"[1.0,2.5]");
+        assert_eq!(args[4], b"FPHA");
+        assert_eq!(args[5], b"BF16");
+    }
+
+    #[test]
+    fn fpha_fp32_with_xx_orders_value_then_xx_then_fpha_tag() {
+        let lanes = [1.0_f32, -0.5, 1234.5];
+        let opts = JsonSetOptions::fpha(FphaInput::Fp32(&lanes))
+            .unwrap()
+            .conditional_set(ExistenceCheck::XX);
+        let args = build(&opts);
+        // [JSON.SET, k, $, <json>, XX, FPHA, FP32]
+        assert_eq!(args.len(), 7);
+        assert_eq!(args[3], b"[1.0,-0.5,1234.5]");
+        assert_eq!(args[4], b"XX");
+        assert_eq!(args[5], b"FPHA");
+        assert_eq!(args[6], b"FP32");
+    }
+
+    #[test]
+    fn fpha_fp64_emits_fp64_tag() {
+        let lanes = [1.0_f64, 2.0, 3.0, 4.0];
+        let opts = JsonSetOptions::fpha(FphaInput::Fp64(&lanes)).unwrap();
+        let args = build(&opts);
+        assert_eq!(args[3], b"[1.0,2.0,3.0,4.0]");
+        assert_eq!(args[5], b"FP64");
+    }
+
+    #[test]
+    fn fpha_fp16_emits_fp16_tag() {
+        let lanes = [1.0_f32; 5];
+        let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
+        let args = build(&opts);
+        assert_eq!(args[3], b"[1.0,1.0,1.0,1.0,1.0]");
+        assert_eq!(args[5], b"FP16");
+    }
+
+    #[test]
+    fn fpha_empty_payload_still_emits_tag() {
+        let opts = JsonSetOptions::fpha(FphaInput::Fp32(&[])).unwrap();
+        let args = build(&opts);
+        assert_eq!(args.len(), 6);
+        assert_eq!(args[3], b"[]");
+        assert_eq!(args[5], b"FP32");
+    }
+
+    #[test]
+    fn fpha_type_matches_variant() {
+        assert_eq!(FphaInput::Bf16(&[]).fpha_type(), FphaType::Bf16);
+        assert_eq!(FphaInput::Fp16(&[]).fpha_type(), FphaType::Fp16);
+        assert_eq!(FphaInput::Fp32(&[]).fpha_type(), FphaType::Fp32);
+        assert_eq!(FphaInput::Fp64(&[]).fpha_type(), FphaType::Fp64);
+    }
+
+    #[test]
+    fn fpha_serialize_with_matrix_emits_nested_json_and_tag() {
+        let matrix: &[&[f32]] = &[&[1.0, 2.5], &[3.0, 4.0]];
+        let opts = JsonSetOptions::fpha_serialize(matrix, FphaType::Bf16).unwrap();
+        let args = build(&opts);
+        assert_eq!(args.len(), 6);
+        assert_eq!(args[3], b"[[1.0,2.5],[3.0,4.0]]");
+        assert_eq!(args[4], b"FPHA");
+        assert_eq!(args[5], b"BF16");
+    }
+
+    #[test]
+    fn fpha_serialize_with_object_emits_serialized_value_and_tag() {
+        let value = serde_json::json!({"weights": [1.0, 2.0], "bias": [0.5]});
+        let opts = JsonSetOptions::fpha_serialize(&value, FphaType::Fp16).unwrap();
+        let args = build(&opts);
+        assert_eq!(args.len(), 6);
+        assert_eq!(args[3], br#"{"bias":[0.5],"weights":[1.0,2.0]}"#);
+        assert_eq!(args[5], b"FP16");
+    }
+
+    #[test]
+    fn fpha_serialize_pairs_with_existence_check() {
+        let opts = JsonSetOptions::fpha_serialize(&[1.0_f32, 2.0], FphaType::Fp32)
+            .unwrap()
+            .conditional_set(ExistenceCheck::NX);
+        let args = build(&opts);
+        // [JSON.SET, k, $, <json>, NX, FPHA, FP32]
+        assert_eq!(args.len(), 7);
+        assert_eq!(args[3], b"[1.0,2.0]");
+        assert_eq!(args[4], b"NX");
+        assert_eq!(args[5], b"FPHA");
+        assert_eq!(args[6], b"FP32");
+    }
+}

--- a/redis/src/commands/json.rs
+++ b/redis/src/commands/json.rs
@@ -1,3 +1,5 @@
+//! Commands and types for working with the RedisJSON module.
+
 use crate::cmd::{Cmd, cmd};
 use crate::connection::ConnectionLike;
 use crate::pipeline::Pipeline;
@@ -268,10 +270,9 @@ implement_json_commands! {
 
     /// Sets the JSON Value at `path` in `key` with options.
     ///
-    /// The value (JSON document or FPHA float array) is carried inside `options`
-    /// alongside the optional `NX`/`XX` existence check. See [`JsonSetOptions`].
-    fn json_set_options<K: ToSingleRedisArg, P: ToSingleRedisArg>(key: K, path: P, options: &'a JsonSetOptions) {
-        cmd("JSON.SET").arg(key).arg(path).arg(options).take()
+    /// `options` carries the optional `NX`/`XX` existence check and the optional `FPHA <TYPE>` storage hint. See [`JsonSetOptions`].
+    fn json_set_options<K: ToSingleRedisArg, P: ToSingleRedisArg, V: Serialize>(key: K, path: P, value: &'a V, options: &'a JsonSetOptions) {
+        cmd("JSON.SET").arg(key).arg(path).arg(serde_json::to_string(value)?).arg(options).take()
     }
 
         /// Sets the value at the path per key, for every given tuple.
@@ -315,11 +316,10 @@ impl<T> JsonAsyncCommands for T where T: crate::aio::ConnectionLike + Send + Siz
 
 /// Storage-precision tag for the `FPHA` form of `JSON.SET`.
 ///
-/// Pairs with an arbitrary `serde::Serialize` payload via
-/// [`JsonSetOptions::fpha_serialize`] to set values whose shape (matrices,
-/// objects with multiple FP-array fields, scalars) cannot be expressed as a
-/// flat [`FphaInput`] slice.
+/// Applied via [`JsonSetOptions::fpha`] instructs the server to pack any floating-point arrays in the payload using the chosen lane precision.
+/// Values that fall outside the chosen type's representable range cause the server to reject the command with `ERR value out of range for <TYPE>`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FphaType {
     /// Server stores lanes as Google brain-float 16 (`bfloat16`).
     Bf16,
@@ -345,121 +345,40 @@ impl ToRedisArgs for FphaType {
     }
 }
 
-/// Float-array payload for the `FPHA` form of `JSON.SET`.
-///
-/// Each variant holds a borrowed flat slice of lanes; the variant determines
-/// both the serialized element type and the `FPHA <TYPE>` storage hint sent
-/// to the server. Used together with [`JsonSetOptions::fpha`] when the value
-/// is a flat 1-D vector.
-///
-/// For multi-dimensional payloads (matrices, objects with multiple FP-array
-/// fields, scalars), use [`JsonSetOptions::fpha_serialize`] with an explicit
-/// [`FphaType`] instead.
-#[derive(Clone, Copy, Debug)]
-pub enum FphaInput<'a> {
-    /// Server stores lanes as Google brain-float 16 (`bfloat16`).
-    Bf16(&'a [f32]),
-    /// Server stores lanes as IEEE-754 binary16.
-    Fp16(&'a [f32]),
-    /// Server stores lanes as IEEE-754 binary32.
-    Fp32(&'a [f32]),
-    /// Server stores lanes as IEEE-754 binary64.
-    Fp64(&'a [f64]),
-}
-
-impl FphaInput<'_> {
-    fn fpha_type(&self) -> FphaType {
-        match self {
-            FphaInput::Bf16(_) => FphaType::Bf16,
-            FphaInput::Fp16(_) => FphaType::Fp16,
-            FphaInput::Fp32(_) => FphaType::Fp32,
-            FphaInput::Fp64(_) => FphaType::Fp64,
-        }
-    }
-
-    fn serialize_json(&self) -> RedisResult<String> {
-        match *self {
-            FphaInput::Bf16(s) | FphaInput::Fp16(s) | FphaInput::Fp32(s) => {
-                serde_json::to_string(s)
-            }
-            FphaInput::Fp64(s) => serde_json::to_string(s),
-        }
-        .map_err(Into::into)
-    }
-}
-
 /// Options for the [`JSON.SET`](https://redis.io/commands/json.set) command.
 ///
-/// Carries the value to write (either a JSON document or an [`FphaInput`]
-/// float-array payload) together with an optional `NX`/`XX` existence check.
+/// Carries the optional `NX`/`XX` existence check and the optional `FPHA <TYPE>` storage hint.
 ///
 /// # Example
 /// ```rust,no_run
-/// use redis::{ExistenceCheck, JsonCommands, JsonSetOptions};
+/// use redis::json::{FphaType, JsonSetOptions};
+/// use redis::{ExistenceCheck, JsonCommands};
 /// use serde_json::json;
 /// # fn do_something() -> redis::RedisResult<()> {
 /// let client = redis::Client::open("redis://127.0.0.1/")?;
 /// let mut con = client.get_connection()?;
-/// let opts = JsonSetOptions::json(&json!({"item": 42}))?
-///     .conditional_set(ExistenceCheck::NX);
-/// let _: () = con.json_set_options("my_key", "$", &opts)?;
+/// let opts = JsonSetOptions::default()
+///     .conditional_set(ExistenceCheck::NX)
+///     .fpha(FphaType::Fp32);
+/// let _: () = con.json_set_options("my_key", "$", &[1.0_f32, 2.0], &opts)?;
 /// # Ok(()) }
 /// ```
+#[derive(Clone, Default)]
 pub struct JsonSetOptions {
-    value: String,
-    fpha_tag: Option<FphaType>,
     conditional_set: Option<ExistenceCheck>,
+    fpha_type: Option<FphaType>,
 }
 
 impl JsonSetOptions {
-    /// Build options that set `value` as a JSON document.
-    ///
-    /// The value is serialized eagerly via `serde_json`; serialization errors
-    /// surface here rather than at command-dispatch time.
-    pub fn json<V: Serialize + ?Sized>(value: &V) -> RedisResult<Self> {
-        Ok(Self {
-            value: serde_json::to_string(value)?,
-            fpha_tag: None,
-            conditional_set: None,
-        })
-    }
-
-    /// Build options that set the value from a flat float-array payload,
-    /// emitting the trailing `FPHA <TYPE>` tag on the wire.
-    ///
-    /// The lanes are serialized as a JSON array of numbers; `FPHA <TYPE>` is a
-    /// storage hint that tells the server which precision to pack the array as
-    /// internally. The variant of [`FphaInput`] both selects the storage type
-    /// and constrains the data element type, ensuring they match.
-    ///
-    /// For payloads that aren't a flat 1-D vector (matrices, objects with
-    /// multiple FP-array fields, scalars), use [`Self::fpha_serialize`].
-    pub fn fpha(input: FphaInput<'_>) -> RedisResult<Self> {
-        Ok(Self {
-            value: input.serialize_json()?,
-            fpha_tag: Some(input.fpha_type()),
-            conditional_set: None,
-        })
-    }
-
-    /// Build options that serialize an arbitrary value with an `FPHA <TYPE>`
-    /// storage hint.
-    ///
-    /// Unlike [`Self::fpha`], this accepts any [`Serialize`] payload, allowing
-    /// nested arrays (matrices), objects with multiple FP-array fields, or
-    /// scalars. The caller picks the [`FphaType`] explicitly; no compile-time
-    /// pairing of the data element type with the storage hint is enforced.
-    pub fn fpha_serialize<V: Serialize + ?Sized>(value: &V, ty: FphaType) -> RedisResult<Self> {
-        Ok(Self {
-            value: serde_json::to_string(value)?,
-            fpha_tag: Some(ty),
-            conditional_set: None,
-        })
-    }
-
     /// Apply an `NX` or `XX` existence check to the command.
     pub fn conditional_set(mut self, existence_check: ExistenceCheck) -> Self {
         self.conditional_set = Some(existence_check);
+        self
+    }
+
+    /// Add an `FPHA <TYPE>` storage hint to the command.
+    pub fn fpha(mut self, fpha_type: FphaType) -> Self {
+        self.fpha_type = Some(fpha_type);
         self
     }
 }
@@ -469,11 +388,10 @@ impl ToRedisArgs for JsonSetOptions {
     where
         W: ?Sized + RedisWrite,
     {
-        out.write_arg(self.value.as_bytes());
         if let Some(ref conditional_set) = self.conditional_set {
             conditional_set.write_redis_args(out);
         }
-        if let Some(ref ty) = self.fpha_tag {
+        if let Some(ref ty) = self.fpha_type {
             out.write_arg(b"FPHA");
             ty.write_redis_args(out);
         }
@@ -494,17 +412,19 @@ mod tests {
             .collect()
     }
 
-    fn build(opts: &JsonSetOptions) -> Vec<Vec<u8>> {
+    fn build<V: Serialize + ?Sized>(value: &V, opts: &JsonSetOptions) -> Vec<Vec<u8>> {
         let mut c = cmd("JSON.SET");
-        c.arg("k").arg("$").arg(opts);
+        c.arg("k")
+            .arg("$")
+            .arg(serde_json::to_string(value).unwrap())
+            .arg(opts);
         simple_args(&c)
     }
 
     #[test]
-    fn json_value_writes_serialized_document_only() {
-        let opts = JsonSetOptions::json(&serde_json::json!({"a": 1})).unwrap();
+    fn json_value_with_default_options_writes_serialized_document_only() {
         assert_eq!(
-            build(&opts),
+            build(&serde_json::json!({"a": 1}), &JsonSetOptions::default()),
             vec![
                 b"JSON.SET".to_vec(),
                 b"k".to_vec(),
@@ -515,34 +435,49 @@ mod tests {
     }
 
     #[test]
-    fn json_value_with_nx_appends_existence_check() {
-        let opts = JsonSetOptions::json(&serde_json::json!(1))
-            .unwrap()
+    fn json_set_options_builder_is_order_independent() {
+        let a = JsonSetOptions::default()
+            .conditional_set(ExistenceCheck::NX)
+            .fpha(FphaType::Fp64);
+        let b = JsonSetOptions::default()
+            .fpha(FphaType::Fp64)
             .conditional_set(ExistenceCheck::NX);
-        let args = build(&opts);
-        assert_eq!(args.last().unwrap(), b"NX");
+        assert_eq!(build(&[1.0_f64], &a), build(&[1.0_f64], &b));
+    }
+
+    #[test]
+    fn fpha_type_writes_expected_bytes() {
+        for (ty, expected) in [
+            (FphaType::Bf16, b"BF16".as_slice()),
+            (FphaType::Fp16, b"FP16".as_slice()),
+            (FphaType::Fp32, b"FP32".as_slice()),
+            (FphaType::Fp64, b"FP64".as_slice()),
+        ] {
+            let args = build(&[0.0_f32], &JsonSetOptions::default().fpha(ty));
+            assert_eq!(args.len(), 6);
+            assert_eq!(args[4], b"FPHA");
+            assert_eq!(args[5], expected);
+        }
+    }
+
+    #[test]
+    fn conditional_set_nx_appends_existence_check() {
+        let args = build(
+            &serde_json::json!(1),
+            &JsonSetOptions::default().conditional_set(ExistenceCheck::NX),
+        );
         assert_eq!(args.len(), 5);
+        assert_eq!(args.last().unwrap(), b"NX");
     }
 
     #[test]
-    fn fpha_bf16_writes_json_array_and_appends_type_tag() {
-        let lanes = [1.0_f32, 2.5];
-        let opts = JsonSetOptions::fpha(FphaInput::Bf16(&lanes)).unwrap();
-        let args = build(&opts);
-        // [JSON.SET, k, $, <json>, FPHA, BF16]
-        assert_eq!(args.len(), 6);
-        assert_eq!(args[3], b"[1.0,2.5]");
-        assert_eq!(args[4], b"FPHA");
-        assert_eq!(args[5], b"BF16");
-    }
-
-    #[test]
-    fn fpha_fp32_with_xx_orders_value_then_xx_then_fpha_tag() {
-        let lanes = [1.0_f32, -0.5, 1234.5];
-        let opts = JsonSetOptions::fpha(FphaInput::Fp32(&lanes))
-            .unwrap()
-            .conditional_set(ExistenceCheck::XX);
-        let args = build(&opts);
+    fn fpha_with_existence_check_orders_value_then_existence_check_then_fpha_type() {
+        let args = build(
+            &[1.0_f32, -0.5, 1234.5],
+            &JsonSetOptions::default()
+                .conditional_set(ExistenceCheck::XX)
+                .fpha(FphaType::Fp32),
+        );
         // [JSON.SET, k, $, <json>, XX, FPHA, FP32]
         assert_eq!(args.len(), 7);
         assert_eq!(args[3], b"[1.0,-0.5,1234.5]");
@@ -552,45 +487,18 @@ mod tests {
     }
 
     #[test]
-    fn fpha_fp64_emits_fp64_tag() {
-        let lanes = [1.0_f64, 2.0, 3.0, 4.0];
-        let opts = JsonSetOptions::fpha(FphaInput::Fp64(&lanes)).unwrap();
-        let args = build(&opts);
-        assert_eq!(args[3], b"[1.0,2.0,3.0,4.0]");
-        assert_eq!(args[5], b"FP64");
-    }
-
-    #[test]
-    fn fpha_fp16_emits_fp16_tag() {
-        let lanes = [1.0_f32; 5];
-        let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
-        let args = build(&opts);
-        assert_eq!(args[3], b"[1.0,1.0,1.0,1.0,1.0]");
-        assert_eq!(args[5], b"FP16");
-    }
-
-    #[test]
-    fn fpha_empty_payload_still_emits_tag() {
-        let opts = JsonSetOptions::fpha(FphaInput::Fp32(&[])).unwrap();
-        let args = build(&opts);
+    fn fpha_empty_payload_still_emits_fpha_type() {
+        let args = build(&[0_f32; 0], &JsonSetOptions::default().fpha(FphaType::Fp32));
         assert_eq!(args.len(), 6);
         assert_eq!(args[3], b"[]");
+        assert_eq!(args[4], b"FPHA");
         assert_eq!(args[5], b"FP32");
     }
 
     #[test]
-    fn fpha_type_matches_variant() {
-        assert_eq!(FphaInput::Bf16(&[]).fpha_type(), FphaType::Bf16);
-        assert_eq!(FphaInput::Fp16(&[]).fpha_type(), FphaType::Fp16);
-        assert_eq!(FphaInput::Fp32(&[]).fpha_type(), FphaType::Fp32);
-        assert_eq!(FphaInput::Fp64(&[]).fpha_type(), FphaType::Fp64);
-    }
-
-    #[test]
-    fn fpha_serialize_with_matrix_emits_nested_json_and_tag() {
+    fn fpha_with_matrix_emits_nested_json_and_fpha_type() {
         let matrix: &[&[f32]] = &[&[1.0, 2.5], &[3.0, 4.0]];
-        let opts = JsonSetOptions::fpha_serialize(matrix, FphaType::Bf16).unwrap();
-        let args = build(&opts);
+        let args = build(matrix, &JsonSetOptions::default().fpha(FphaType::Bf16));
         assert_eq!(args.len(), 6);
         assert_eq!(args[3], b"[[1.0,2.5],[3.0,4.0]]");
         assert_eq!(args[4], b"FPHA");
@@ -598,26 +506,11 @@ mod tests {
     }
 
     #[test]
-    fn fpha_serialize_with_object_emits_serialized_value_and_tag() {
+    fn json_object_properly_serialized_with_value_and_fpha_type() {
         let value = serde_json::json!({"weights": [1.0, 2.0], "bias": [0.5]});
-        let opts = JsonSetOptions::fpha_serialize(&value, FphaType::Fp16).unwrap();
-        let args = build(&opts);
-        assert_eq!(args.len(), 6);
+        let args = build(&value, &JsonSetOptions::default().fpha(FphaType::Fp16));
         assert_eq!(args[3], br#"{"bias":[0.5],"weights":[1.0,2.0]}"#);
+        assert_eq!(args[4], b"FPHA");
         assert_eq!(args[5], b"FP16");
-    }
-
-    #[test]
-    fn fpha_serialize_pairs_with_existence_check() {
-        let opts = JsonSetOptions::fpha_serialize(&[1.0_f32, 2.0], FphaType::Fp32)
-            .unwrap()
-            .conditional_set(ExistenceCheck::NX);
-        let args = build(&opts);
-        // [JSON.SET, k, $, <json>, NX, FPHA, FP32]
-        assert_eq!(args.len(), 7);
-        assert_eq!(args[3], b"[1.0,2.0]");
-        assert_eq!(args[4], b"NX");
-        assert_eq!(args[5], b"FPHA");
-        assert_eq!(args[6], b"FP32");
     }
 }

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -24,7 +24,7 @@ mod macros;
 mod json;
 
 #[cfg(feature = "json")]
-pub use json::JsonCommands;
+pub use json::{FphaInput, FphaType, JsonCommands, JsonSetOptions};
 
 #[cfg(all(feature = "json", feature = "aio"))]
 pub use json::JsonAsyncCommands;

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -21,10 +21,10 @@ mod macros;
 
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-mod json;
+pub mod json;
 
 #[cfg(feature = "json")]
-pub use json::{FphaInput, FphaType, JsonCommands, JsonSetOptions};
+pub use json::JsonCommands;
 
 #[cfg(all(feature = "json", feature = "aio"))]
 pub use json::JsonAsyncCommands;

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -747,7 +747,7 @@ pub mod bloom;
 
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-pub use crate::commands::JsonCommands;
+pub use crate::commands::{FphaInput, FphaType, JsonCommands, JsonSetOptions};
 
 #[cfg(all(feature = "json", feature = "aio"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "json", feature = "aio"))))]

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -747,7 +747,7 @@ pub mod bloom;
 
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-pub use crate::commands::{FphaInput, FphaType, JsonCommands, JsonSetOptions};
+pub use crate::commands::{JsonCommands, json};
 
 #[cfg(all(feature = "json", feature = "aio"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "json", feature = "aio"))))]

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -14,6 +14,7 @@ pub const REDIS_CE_8_4: Component = ("redis", (8, 3, 224));
 pub const REDIS_CE_8_6: Component = ("redis", (8, 6, 0));
 pub const REDIS_CE_8_8: Component = ("redis", (8, 8, 0));
 
+pub const REDIS_JSON_8_8: Component = ("ReJSON", (8, 8, 0));
 pub const REDIS_BLOOM_ANY: Component = ("redis:bf", (0, 0, 0));
 
 // Valkey forked off at Redis 7.2.4 and still reports its Redis version 7.2.4. So tests that run

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -12,6 +12,7 @@ pub const REDIS_CE_8_0: Component = ("redis", (8, 0, 0));
 pub const REDIS_CE_8_2: Component = ("redis", (8, 1, 240));
 pub const REDIS_CE_8_4: Component = ("redis", (8, 3, 224));
 pub const REDIS_CE_8_6: Component = ("redis", (8, 6, 0));
+pub const REDIS_CE_8_8: Component = ("redis", (8, 8, 0));
 
 pub const REDIS_BLOOM_ANY: Component = ("redis:bf", (0, 0, 0));
 
@@ -322,10 +323,23 @@ macro_rules! skip_if_context_does_not_support {
 /// # Returns
 ///
 /// A [`TestContext`], if `$component` is available
+///
+/// # Example
+///
+/// Without modules:
+/// ```ignore
+/// let ctx = run_test_if_version_supported!(REDIS_CE_8_0);
+/// ```
+///
+/// With modules:
+/// ```ignore
+/// let ctx = run_test_if_version_supported!(REDIS_CE_8_0, &[Module::Search]);
+/// ```
 #[macro_export]
 macro_rules! run_test_if_version_supported {
-    ($component:expr) => {{
-        let ctx = $crate::support::TestContext::new();
+    ($component:expr) => {{ run_test_if_version_supported!($component, &[]) }};
+    ($component:expr, $modules:expr) => {{
+        let ctx = $crate::support::TestContext::with_modules($modules);
 
         $crate::skip_if_context_does_not_support!(ctx, $component);
 

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -1,8 +1,11 @@
 #![cfg(feature = "json")]
 
-use redis::{Commands, JsonCommands, ValueType};
+use redis::{
+    Commands, ExistenceCheck, FphaInput, FphaType, JsonCommands, JsonSetOptions, ValueType,
+};
 use std::assert_eq;
 use std::collections::HashMap;
+use std::f32::consts::PI;
 
 use redis::{
     ErrorKind, RedisResult,
@@ -537,4 +540,354 @@ fn test_module_json_type() {
     // Checking the type of the key as a whole
     let key_type: RedisResult<ValueType> = con.key_type(TEST_KEY);
     assert_eq!(key_type, Ok(ValueType::JSON));
+}
+
+#[test]
+fn test_module_json_set_options_json_value() {
+    let ctx = TestContext::with_modules(&[Module::Json]);
+    let mut con = ctx.connection();
+
+    let opts = JsonSetOptions::json(&json!({"a": 1, "b": [2, 3]})).unwrap();
+    let set_result: RedisResult<bool> = con.json_set_options(TEST_KEY, "$", &opts);
+    assert_eq!(set_result, Ok(true));
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok(r#"[{"a":1,"b":[2,3]}]"#.to_string()));
+}
+
+#[test]
+fn test_module_json_set_options_nx_xx() {
+    let ctx = TestContext::with_modules(&[Module::Json]);
+    let mut con = ctx.connection();
+
+    // XX on a missing key should not create the key.
+    let opts_xx = JsonSetOptions::json(&json!({"v": 0}))
+        .unwrap()
+        .conditional_set(ExistenceCheck::XX);
+    let _: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts_xx);
+    let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
+    assert_eq!(key_exists, Ok(false));
+
+    // NX on a fresh key should succeed.
+    let opts_nx = JsonSetOptions::json(&json!({"v": 1}))
+        .unwrap()
+        .conditional_set(ExistenceCheck::NX);
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts_nx),
+        Ok(true),
+    );
+    let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
+    assert_eq!(key_exists, Ok(true));
+
+    // NX again must be a no-op because the key exists.
+    let opts_nx = JsonSetOptions::json(&json!({"v": 999}))
+        .unwrap()
+        .conditional_set(ExistenceCheck::NX);
+    let _: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts_nx);
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$.v");
+    assert_eq!(get_result, Ok("[1]".to_string()));
+
+    // XX on the existing key should succeed and overwrite the value.
+    let opts_xx = JsonSetOptions::json(&json!({"v": 2}))
+        .unwrap()
+        .conditional_set(ExistenceCheck::XX);
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts_xx),
+        Ok(true),
+    );
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$.v");
+    assert_eq!(get_result, Ok("[2]".to_string()));
+}
+
+// FPHA integration tests.
+
+// The value travels as a JSON array of numbers.
+// The `FPHA <TYPE>` token is a storage hint that asks the server to pack the array internally as bf16/fp16/fp32/fp64 lanes.
+// Round-trip via `JSON.GET` returns the array as a JSON array of numbers.
+#[rstest::rstest]
+#[case::fp32(FphaInput::Fp32(&[1.0_f32, 2.0, -3.5]))]
+#[case::fp64(FphaInput::Fp64(&[1.0_f64, 2.0, -3.5]))]
+#[case::bf16(FphaInput::Bf16(&[1.0_f32, 2.0, -3.5]))]
+#[case::fp16(FphaInput::Fp16(&[1.0_f32, 2.0, -3.5]))]
+fn test_module_json_set_fpha_roundtrip(#[case] input: FphaInput<'static>) {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let opts = JsonSetOptions::fpha(input).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[1.0,2.0,-3.5]]".to_string()));
+}
+
+#[test]
+fn test_module_json_set_fpha_empty_payload() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let opts = JsonSetOptions::fpha(FphaInput::Fp32(&[])).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[]]".to_string()));
+}
+
+#[test]
+fn test_module_json_set_fpha_with_existence_check() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    // XX against a missing key must not create it.
+    let lanes = [1.0_f32];
+    let opts_xx = JsonSetOptions::fpha(FphaInput::Fp32(&lanes))
+        .unwrap()
+        .conditional_set(ExistenceCheck::XX);
+    let _: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts_xx);
+    let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
+    assert_eq!(key_exists, Ok(false));
+
+    // NX on the same missing key creates it.
+    let lanes = [1.0_f32, 2.0, 3.0];
+    let opts_nx = JsonSetOptions::fpha(FphaInput::Fp32(&lanes))
+        .unwrap()
+        .conditional_set(ExistenceCheck::NX);
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts_nx),
+        Ok(true),
+    );
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[1.0,2.0,3.0]]".to_string()));
+}
+
+// FP16 storage range is ±65504.
+// A value outside that range must be rejected by the server with an out-of-range error.
+#[test]
+fn test_module_json_set_fpha_fp16_overflow() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [70000.0_f32];
+    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
+    let set_result: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts);
+    assert!(
+        set_result.is_err(),
+        "expected server error, got {set_result:?}"
+    );
+
+    let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
+    assert_eq!(key_exists, Ok(false));
+}
+
+// Per the FPHA docs:
+// "If at least one value in the FP array does not fit the FPHA type, the command errors."
+
+// Verify that a single out-of-range element in an otherwise valid payload rejects the whole command and leaves the key untouched.
+#[test]
+fn test_module_json_set_fpha_fp16_partial_overflow() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [1.0_f32, 2.0, 70000.0, 3.0];
+    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
+    let set_result: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts);
+    assert!(
+        set_result.is_err(),
+        "expected server error, got {set_result:?}"
+    );
+
+    let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
+    assert_eq!(key_exists, Ok(false));
+}
+
+// 65504 is the largest finite value representable in IEEE-754 binary16.
+#[test]
+fn test_module_json_set_fpha_fp16_max_boundary() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [65504.0_f32];
+    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[65504.0]]".to_string()));
+}
+
+// 3.4e38 is near the largest finite value representable in IEEE-754 binary32.
+#[test]
+fn test_module_json_set_fpha_fp32_max_boundary() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [3.4e38_f32];
+    let opts = JsonSetOptions::fpha(FphaInput::Fp32(&lanes)).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[3.4e38]]".to_string()));
+}
+
+// 2^20 (= 1048576) is exactly representable in bf16 and well above FP16's ±65504 limit.
+// The same value would be rejected under FPHA FP16 but under FPHA BF16 it round-trips losslessly.
+#[test]
+fn test_module_json_set_fpha_bf16_above_fp16_range() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [1048576.0_f32];
+    let opts = JsonSetOptions::fpha(FphaInput::Bf16(&lanes)).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[1048576.0]]".to_string()));
+}
+
+// Values that serde_json emits in scientific notation must be accepted by the server and round-tripped back as scientific notation.
+// Note: serde emits `6.022e+23` while the server omits the `+`.
+#[test]
+fn test_module_json_set_fpha_fp32_scientific_notation() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [1e-10_f32, 6.022e23_f32];
+    let opts = JsonSetOptions::fpha(FphaInput::Fp32(&lanes)).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[1e-10,6.022e23]]".to_string()));
+}
+
+// Demonstrate the lossy nature of FPHA BF16 storage.
+
+// bf16 has a 7-bit mantissa.
+// Around 100 its step size is 0.5, so 100.7 snaps to 100.5
+// pi (3.1415927) snaps to 3.14.
+#[test]
+fn test_module_json_set_fpha_bf16_truncation() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [100.7_f32, PI];
+    let opts = JsonSetOptions::fpha(FphaInput::Bf16(&lanes)).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[100.5,3.14]]".to_string()));
+}
+
+// fp16 has a 10-bit mantissa, so it preserves more precision than bf16.
+// Around 1.0 its step size is ~0.001, which snaps 1.0009766 to 1.001, pi still snaps to 3.14.
+#[test]
+fn test_module_json_set_fpha_fp16_truncation() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let lanes = [1.0009766_f32, PI];
+    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[1.001,3.14]]".to_string()));
+}
+
+// `JsonSetOptions::fpha_serialize` accepts arbitrary serializable values.
+// A 2-D matrix exercises the docs' "all FP arrays in value" wording - the hint is applied to every inner array.
+// With BF16, 100.7 snaps to 100.5 and pi snaps to 3.14 within their respective inner arrays.
+#[test]
+fn test_module_json_set_fpha_serialize_matrix() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let matrix: &[&[f32]] = &[&[1.0, 100.7], &[PI, 4.0]];
+    let opts = JsonSetOptions::fpha_serialize(matrix, FphaType::Bf16).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[[[1.0,100.5],[3.14,4.0]]]".to_string()));
+}
+
+// An object holding multiple FP-array fields gets the storage hint applied to each field independently.
+#[test]
+fn test_module_json_set_fpha_serialize_object_with_array_fields() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let value = serde_json::json!({"weights": [1.0, 2.0, 3.0], "bias": [0.5, 0.25]});
+    let opts = JsonSetOptions::fpha_serialize(&value, FphaType::Fp16).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    // `serde_json::Value::Object` is a BTreeMap, so keys serialize in
+    // alphabetical order (`bias` before `weights`) regardless of input order.
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(
+        get_result,
+        Ok(r#"[{"bias":[0.5,0.25],"weights":[1.0,2.0,3.0]}]"#.to_string()),
+    );
+}
+
+// Per the FPHA docs:
+// "If at least one value in the FP array does not fit the FPHA type, the command errors."
+
+// Verify that a single out-of-range value causes the entire command to fail without modifying the key, even when the offending value appears in a nested array.
+#[test]
+fn test_module_json_set_fpha_serialize_nested_partial_overflow() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let matrix: &[&[f32]] = &[&[1.0, 2.0], &[70000.0, 3.0]];
+    let opts = JsonSetOptions::fpha_serialize(matrix, FphaType::Fp16).unwrap();
+    let set_result: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts);
+    assert!(
+        set_result.is_err(),
+        "expected server error, got {set_result:?}"
+    );
+
+    let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
+    assert_eq!(key_exists, Ok(false));
+}
+
+// A scalar (not an array) is also a valid FPHA payload server-side.
+#[test]
+fn test_module_json_set_fpha_serialize_scalar() {
+    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let mut con = ctx.connection();
+
+    let opts = JsonSetOptions::fpha_serialize(&1.5_f32, FphaType::Fp32).unwrap();
+    assert_eq!(
+        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        Ok(true),
+    );
+
+    let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
+    assert_eq!(get_result, Ok("[1.5]".to_string()));
 }

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -1,8 +1,7 @@
 #![cfg(feature = "json")]
 
-use redis::{
-    Commands, ExistenceCheck, FphaInput, FphaType, JsonCommands, JsonSetOptions, ValueType,
-};
+use redis::json::{FphaType, JsonSetOptions};
+use redis::{Commands, ExistenceCheck, JsonCommands, ValueType};
 use std::assert_eq;
 use std::collections::HashMap;
 use std::f32::consts::PI;
@@ -547,8 +546,12 @@ fn test_module_json_set_options_json_value() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     let mut con = ctx.connection();
 
-    let opts = JsonSetOptions::json(&json!({"a": 1, "b": [2, 3]})).unwrap();
-    let set_result: RedisResult<bool> = con.json_set_options(TEST_KEY, "$", &opts);
+    let set_result: RedisResult<bool> = con.json_set_options(
+        TEST_KEY,
+        "$",
+        &json!({"a": 1, "b": [2, 3]}),
+        &JsonSetOptions::default(),
+    );
     assert_eq!(set_result, Ok(true));
 
     let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
@@ -560,39 +563,32 @@ fn test_module_json_set_options_nx_xx() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     let mut con = ctx.connection();
 
+    let opts_xx = JsonSetOptions::default().conditional_set(ExistenceCheck::XX);
+    let opts_nx = JsonSetOptions::default().conditional_set(ExistenceCheck::NX);
+
     // XX on a missing key should not create the key.
-    let opts_xx = JsonSetOptions::json(&json!({"v": 0}))
-        .unwrap()
-        .conditional_set(ExistenceCheck::XX);
-    let _: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts_xx);
+    let _: RedisResult<redis::Value> =
+        con.json_set_options(TEST_KEY, "$", &json!({"v": 0}), &opts_xx);
     let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
     assert_eq!(key_exists, Ok(false));
 
     // NX on a fresh key should succeed.
-    let opts_nx = JsonSetOptions::json(&json!({"v": 1}))
-        .unwrap()
-        .conditional_set(ExistenceCheck::NX);
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts_nx),
+        con.json_set_options::<_, _, _, bool>(TEST_KEY, "$", &json!({"v": 1}), &opts_nx),
         Ok(true),
     );
     let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
     assert_eq!(key_exists, Ok(true));
 
     // NX again must be a no-op because the key exists.
-    let opts_nx = JsonSetOptions::json(&json!({"v": 999}))
-        .unwrap()
-        .conditional_set(ExistenceCheck::NX);
-    let _: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts_nx);
+    let _: RedisResult<redis::Value> =
+        con.json_set_options(TEST_KEY, "$", &json!({"v": 999}), &opts_nx);
     let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$.v");
     assert_eq!(get_result, Ok("[1]".to_string()));
 
     // XX on the existing key should succeed and overwrite the value.
-    let opts_xx = JsonSetOptions::json(&json!({"v": 2}))
-        .unwrap()
-        .conditional_set(ExistenceCheck::XX);
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts_xx),
+        con.json_set_options::<_, _, _, bool>(TEST_KEY, "$", &json!({"v": 2}), &opts_xx),
         Ok(true),
     );
     let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$.v");
@@ -605,17 +601,22 @@ fn test_module_json_set_options_nx_xx() {
 // The `FPHA <TYPE>` token is a storage hint that asks the server to pack the array internally as bf16/fp16/fp32/fp64 lanes.
 // Round-trip via `JSON.GET` returns the array as a JSON array of numbers.
 #[rstest::rstest]
-#[case::fp32(FphaInput::Fp32(&[1.0_f32, 2.0, -3.5]))]
-#[case::fp64(FphaInput::Fp64(&[1.0_f64, 2.0, -3.5]))]
-#[case::bf16(FphaInput::Bf16(&[1.0_f32, 2.0, -3.5]))]
-#[case::fp16(FphaInput::Fp16(&[1.0_f32, 2.0, -3.5]))]
-fn test_module_json_set_fpha_roundtrip(#[case] input: FphaInput<'static>) {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+#[case::fp32(FphaType::Fp32)]
+#[case::fp64(FphaType::Fp64)]
+#[case::bf16(FphaType::Bf16)]
+#[case::fp16(FphaType::Fp16)]
+fn test_module_json_set_fpha_roundtrip(#[case] fpha_type: FphaType) {
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let opts = JsonSetOptions::fpha(input).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[1.0_f32, 2.0, -3.5],
+            &JsonSetOptions::default().fpha(fpha_type)
+        ),
         Ok(true),
     );
 
@@ -625,12 +626,17 @@ fn test_module_json_set_fpha_roundtrip(#[case] input: FphaInput<'static>) {
 
 #[test]
 fn test_module_json_set_fpha_empty_payload() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let opts = JsonSetOptions::fpha(FphaInput::Fp32(&[])).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[0_f32; 0],
+            &JsonSetOptions::default().fpha(FphaType::Fp32)
+        ),
         Ok(true),
     );
 
@@ -640,25 +646,24 @@ fn test_module_json_set_fpha_empty_payload() {
 
 #[test]
 fn test_module_json_set_fpha_with_existence_check() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
     // XX against a missing key must not create it.
-    let lanes = [1.0_f32];
-    let opts_xx = JsonSetOptions::fpha(FphaInput::Fp32(&lanes))
-        .unwrap()
+    let opts_xx = JsonSetOptions::default()
+        .fpha(FphaType::Fp32)
         .conditional_set(ExistenceCheck::XX);
-    let _: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts_xx);
+    let _: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &[1.0_f32], &opts_xx);
     let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
     assert_eq!(key_exists, Ok(false));
 
     // NX on the same missing key creates it.
-    let lanes = [1.0_f32, 2.0, 3.0];
-    let opts_nx = JsonSetOptions::fpha(FphaInput::Fp32(&lanes))
-        .unwrap()
+    let opts_nx = JsonSetOptions::default()
+        .fpha(FphaType::Fp32)
         .conditional_set(ExistenceCheck::NX);
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts_nx),
+        con.json_set_options::<_, _, _, bool>(TEST_KEY, "$", &[1.0_f32, 2.0, 3.0], &opts_nx),
         Ok(true),
     );
     let get_result: RedisResult<String> = con.json_get(TEST_KEY, "$");
@@ -669,15 +674,20 @@ fn test_module_json_set_fpha_with_existence_check() {
 // A value outside that range must be rejected by the server with an out-of-range error.
 #[test]
 fn test_module_json_set_fpha_fp16_overflow() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [70000.0_f32];
-    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
-    let set_result: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts);
+    let set_result: RedisResult<redis::Value> = con.json_set_options(
+        TEST_KEY,
+        "$",
+        &[70000.0_f32],
+        &JsonSetOptions::default().fpha(FphaType::Fp16),
+    );
+    let error = set_result.unwrap_err();
     assert!(
-        set_result.is_err(),
-        "expected server error, got {set_result:?}"
+        error.to_string().contains("out of range for F16"),
+        "unexpected error message: {error}",
     );
 
     let key_exists: RedisResult<bool> = con.exists(TEST_KEY);
@@ -690,12 +700,16 @@ fn test_module_json_set_fpha_fp16_overflow() {
 // Verify that a single out-of-range element in an otherwise valid payload rejects the whole command and leaves the key untouched.
 #[test]
 fn test_module_json_set_fpha_fp16_partial_overflow() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [1.0_f32, 2.0, 70000.0, 3.0];
-    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
-    let set_result: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts);
+    let set_result: RedisResult<redis::Value> = con.json_set_options(
+        TEST_KEY,
+        "$",
+        &[1.0_f32, 2.0, 70000.0, 3.0],
+        &JsonSetOptions::default().fpha(FphaType::Fp16),
+    );
     assert!(
         set_result.is_err(),
         "expected server error, got {set_result:?}"
@@ -708,13 +722,17 @@ fn test_module_json_set_fpha_fp16_partial_overflow() {
 // 65504 is the largest finite value representable in IEEE-754 binary16.
 #[test]
 fn test_module_json_set_fpha_fp16_max_boundary() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [65504.0_f32];
-    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[65504.0_f32],
+            &JsonSetOptions::default().fpha(FphaType::Fp16)
+        ),
         Ok(true),
     );
 
@@ -725,13 +743,17 @@ fn test_module_json_set_fpha_fp16_max_boundary() {
 // 3.4e38 is near the largest finite value representable in IEEE-754 binary32.
 #[test]
 fn test_module_json_set_fpha_fp32_max_boundary() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [3.4e38_f32];
-    let opts = JsonSetOptions::fpha(FphaInput::Fp32(&lanes)).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[3.4e38_f32],
+            &JsonSetOptions::default().fpha(FphaType::Fp32)
+        ),
         Ok(true),
     );
 
@@ -743,13 +765,17 @@ fn test_module_json_set_fpha_fp32_max_boundary() {
 // The same value would be rejected under FPHA FP16 but under FPHA BF16 it round-trips losslessly.
 #[test]
 fn test_module_json_set_fpha_bf16_above_fp16_range() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [1048576.0_f32];
-    let opts = JsonSetOptions::fpha(FphaInput::Bf16(&lanes)).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[1048576.0_f32],
+            &JsonSetOptions::default().fpha(FphaType::Bf16)
+        ),
         Ok(true),
     );
 
@@ -761,13 +787,17 @@ fn test_module_json_set_fpha_bf16_above_fp16_range() {
 // Note: serde emits `6.022e+23` while the server omits the `+`.
 #[test]
 fn test_module_json_set_fpha_fp32_scientific_notation() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [1e-10_f32, 6.022e23_f32];
-    let opts = JsonSetOptions::fpha(FphaInput::Fp32(&lanes)).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[1e-10_f32, 6.022e23_f32],
+            &JsonSetOptions::default().fpha(FphaType::Fp32)
+        ),
         Ok(true),
     );
 
@@ -782,13 +812,17 @@ fn test_module_json_set_fpha_fp32_scientific_notation() {
 // pi (3.1415927) snaps to 3.14.
 #[test]
 fn test_module_json_set_fpha_bf16_truncation() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [100.7_f32, PI];
-    let opts = JsonSetOptions::fpha(FphaInput::Bf16(&lanes)).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[100.7_f32, PI],
+            &JsonSetOptions::default().fpha(FphaType::Bf16)
+        ),
         Ok(true),
     );
 
@@ -800,13 +834,17 @@ fn test_module_json_set_fpha_bf16_truncation() {
 // Around 1.0 its step size is ~0.001, which snaps 1.0009766 to 1.001, pi still snaps to 3.14.
 #[test]
 fn test_module_json_set_fpha_fp16_truncation() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let lanes = [1.0009766_f32, PI];
-    let opts = JsonSetOptions::fpha(FphaInput::Fp16(&lanes)).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &[1.0009766_f32, PI],
+            &JsonSetOptions::default().fpha(FphaType::Fp16)
+        ),
         Ok(true),
     );
 
@@ -814,18 +852,23 @@ fn test_module_json_set_fpha_fp16_truncation() {
     assert_eq!(get_result, Ok("[[1.001,3.14]]".to_string()));
 }
 
-// `JsonSetOptions::fpha_serialize` accepts arbitrary serializable values.
+// The FPHA hint applies to any serializable value, not just flat slices.
 // A 2-D matrix exercises the docs' "all FP arrays in value" wording - the hint is applied to every inner array.
 // With BF16, 100.7 snaps to 100.5 and pi snaps to 3.14 within their respective inner arrays.
 #[test]
-fn test_module_json_set_fpha_serialize_matrix() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+fn test_module_json_set_fpha_matrix() {
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
     let matrix: &[&[f32]] = &[&[1.0, 100.7], &[PI, 4.0]];
-    let opts = JsonSetOptions::fpha_serialize(matrix, FphaType::Bf16).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &matrix,
+            &JsonSetOptions::default().fpha(FphaType::Bf16)
+        ),
         Ok(true),
     );
 
@@ -835,14 +878,18 @@ fn test_module_json_set_fpha_serialize_matrix() {
 
 // An object holding multiple FP-array fields gets the storage hint applied to each field independently.
 #[test]
-fn test_module_json_set_fpha_serialize_object_with_array_fields() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+fn test_module_json_set_fpha_object_with_array_fields() {
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let value = serde_json::json!({"weights": [1.0, 2.0, 3.0], "bias": [0.5, 0.25]});
-    let opts = JsonSetOptions::fpha_serialize(&value, FphaType::Fp16).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &serde_json::json!({"weights": [1.0, 2.0, 3.0], "bias": [0.5, 0.25]}),
+            &JsonSetOptions::default().fpha(FphaType::Fp16)
+        ),
         Ok(true),
     );
 
@@ -860,13 +907,18 @@ fn test_module_json_set_fpha_serialize_object_with_array_fields() {
 
 // Verify that a single out-of-range value causes the entire command to fail without modifying the key, even when the offending value appears in a nested array.
 #[test]
-fn test_module_json_set_fpha_serialize_nested_partial_overflow() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+fn test_module_json_set_fpha_nested_partial_overflow() {
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
     let matrix: &[&[f32]] = &[&[1.0, 2.0], &[70000.0, 3.0]];
-    let opts = JsonSetOptions::fpha_serialize(matrix, FphaType::Fp16).unwrap();
-    let set_result: RedisResult<redis::Value> = con.json_set_options(TEST_KEY, "$", &opts);
+    let set_result: RedisResult<redis::Value> = con.json_set_options(
+        TEST_KEY,
+        "$",
+        &matrix,
+        &JsonSetOptions::default().fpha(FphaType::Fp16),
+    );
     assert!(
         set_result.is_err(),
         "expected server error, got {set_result:?}"
@@ -878,13 +930,18 @@ fn test_module_json_set_fpha_serialize_nested_partial_overflow() {
 
 // A scalar (not an array) is also a valid FPHA payload server-side.
 #[test]
-fn test_module_json_set_fpha_serialize_scalar() {
-    let ctx = run_test_if_version_supported!(REDIS_CE_8_8, &[Module::Json]);
+fn test_module_json_set_fpha_scalar() {
+    let ctx =
+        run_test_if_version_supported!([&[REDIS_CE_8_8][..], &[REDIS_JSON_8_8]], &[Module::Json]);
     let mut con = ctx.connection();
 
-    let opts = JsonSetOptions::fpha_serialize(&1.5_f32, FphaType::Fp32).unwrap();
     assert_eq!(
-        con.json_set_options::<_, _, bool>(TEST_KEY, "$", &opts),
+        con.json_set_options::<_, _, _, bool>(
+            TEST_KEY,
+            "$",
+            &1.5_f32,
+            &JsonSetOptions::default().fpha(FphaType::Fp32)
+        ),
         Ok(true),
     );
 


### PR DESCRIPTION
# Add `JSON.SET` options with `FPHA` storage-hint support

## Summary

Adds a typed options builder for `JSON.SET` that carries an optional `NX`/`XX` existence check and the optional `FPHA <TYPE>` storage hint introduced in `RedisJSON` for `Redis CE 8.8`.

The hint asks the server to pack any floating-point arrays inside the payload using a chosen lane precision (`BF16` / `FP16` / `FP32` / `FP64`), rather than the default storage. The wire format is:

```
JSON.SET <key> <path> <json_value> [NX|XX] [FPHA BF16|FP16|FP32|FP64]
```

## API

Two new public types are re-exported from the crate root behind the existing `json` feature:

| Type | Purpose |
|---|---|
| `JsonSetOptions` | Builder passed to the new `json_set_options` command. |
| `FphaType` | Storage-precision tag (`Bf16` / `Fp16` / `Fp32` / `Fp64`). |

`JsonSetOptions` is a plain struct with two `Option` fields and two builder methods:

```rust
use redis::json::{FphaType, JsonSetOptions};
use redis::{ExistenceCheck, JsonCommands};

// 1. Plain JSON document - parity with existing json_set.
con.json_set_options(key, "$", &json!({"item": 42}),
    &JsonSetOptions::default())?;

// 2. Float-array payload with a storage hint.
con.json_set_options(key, "$", &[1.0_f32, 2.0, -3.5],
    &JsonSetOptions::default().fpha(FphaType::Fp32))?;

// 3. Any Serialize payload (matrix, object, scalar) with a hint.
let matrix: &[&[f32]] = &[&[1.0, 2.0], &[3.0, 4.0]];
con.json_set_options(key, "$", matrix,
    &JsonSetOptions::default().fpha(FphaType::Bf16))?;

// 4. Existence check composes with any of the above.
con.json_set_options(key, "$", &value,
    &JsonSetOptions::default()
        .conditional_set(ExistenceCheck::NX)
        .fpha(FphaType::Fp16))?;
```

### Rules:
The value is passed as a separate argument `(any `V: Serialize`)`.
The options struct only carries command modifiers.
`JsonSetOptions` implements `ToRedisArgs` so the wire format lives in one place.
The existence check (if any) is written first, then `FPHA` + the type tag (if any).
The value is always emitted by `json_set_options` ahead of the options.

## Wire-format examples

| Call | Bytes on the wire |
|---|---|
| `json_set_options(k, "$", &{"a":1}, &default())` | `JSON.SET k $ {"a":1}` |
| `…, &{"a":1}, &default().conditional_set(NX)` | `JSON.SET k $ <json> NX` |
| `…, &[1.0,2.5], &default().fpha(Fp32)` | `JSON.SET k $ [1.0,2.5] FPHA FP32` |
| `…, &v, &default().conditional_set(XX).fpha(Fp32)` | `JSON.SET k $ <json> XX FPHA FP32` |
| `…, matrix, &default().fpha(Bf16)` | `JSON.SET k $ <matrix> FPHA BF16` |

## Server-side validation

`FPHA` range validation is performed by the server on every number inside any JSON array, regardless of nesting depth.
A single out-of-range lane causes the entire `JSON.SET` to be rejected with `value out of range for <TYPE> …` and the key is not created.
Numbers outside arrays (top-level or object-nested scalars) are stored as-is without range checking.

## Testing

- **8 unit tests** on the wire format (argument count, byte-level ordering of `<json>` / `NX`|`XX` / `FPHA <TYPE>`, empty payload, matrix / object serialization, builder order independence).
- **17 integration tests** against `RedisJSON` on `Redis CE 8.8`:
  - Round-trip per FPHA type.
  - Empty payload, NX / XX existence check.
  - Overflow rejections.
  - Boundary values: FP16 max (`±65504.0`), FP32 max (`±3.4028235e38`), BF16 above FP16 normal range.
  - Scientific notation round-trip.
  - Precision truncation: BF16 truncates `100.7 to 100.5` (7-bit mantissa); FP16 preserves `100.7` (10-bit mantissa).
  - Mixed payloads: 2D matrix, object with multiple FP-array fields, scalar, nested partial-overflow rejection.

## Compatibility

- New code paths are gated by the existing `json` cargo feature.
- No existing public API changes: `JsonCommands::json_set` and the `json_set` / `json_set_options` re-exports are additive.
- Server behavior gated to Redis CE 8.8+ via the new `REDIS_VERSION_CE_8_8` test constant

## Relevant documentation

https://redis.io/docs/latest/develop/data-types/json/
https://redis.io/docs/latest/commands/json.set