### PR TITLE
cluster: refresh topology and retry on READONLY errors

### DIFF
--- a/redis/src/cluster_handling/async_connection/request.rs
+++ b/redis/src/cluster_handling/async_connection/request.rs
@@ -263,6 +263,19 @@ pub(crate) fn choose_response<C>(
             (retry, PollFlushAction::RebuildSlots)
         }
 
+        (_, RetryMethod::RefreshSlotsAndRetry) => {
+            let retry = retry_or_send!(|mut request: PendingRequest<C>| {
+                // No redirect address is available (e.g. READONLY), so re-route by slot
+                // against the refreshed topology.
+                request.cmd.reset_routing();
+                Retry::AfterSleep {
+                    request,
+                    sleep_duration,
+                }
+            });
+            (retry, PollFlushAction::RebuildSlots)
+        }
+
         (_, RetryMethod::WaitAndRetry) => (
             retry_or_send!(|request: PendingRequest<C>| {
                 Retry::AfterSleep {
@@ -432,6 +445,35 @@ mod tests {
         let (retry, next) = choose_response(result, request, &retry_params);
 
         assert_eq!(receiver.try_recv(), Ok(Err(to_err(&err_string))));
+        assert!(retry.is_none());
+        assert_eq!(next, PollFlushAction::RebuildSlots);
+    }
+
+    #[test]
+    fn should_refresh_slots_and_retry_on_readonly_error_if_retries_remain() {
+        let err_string = "-READONLY You can't write against a read only replica.\r\n";
+        let err = || single_result(err_string);
+        let (request, mut receiver) = request_and_receiver(0);
+        let result = (OperationTarget::Node { address: ADDRESS }, err());
+        let retry_params = RetryParams::default();
+        let (retry, next) = choose_response(result, request, &retry_params);
+
+        // READONLY has no redirect address, so the request keeps its (slot-based) routing
+        // and is retried after a sleep once the slot map has been rebuilt.
+        if let Some(super::Retry::AfterSleep { request, .. }) = retry {
+            assert!(get_redirect(&request).is_none());
+        } else {
+            panic!("Expected a sleep-then-retry");
+        };
+        assert_eq!(next, PollFlushAction::RebuildSlots);
+        assert_matches!(receiver.try_recv(), Err(_));
+
+        // Once retries are exhausted, the error is surfaced (still rebuilding slots).
+        let (request, mut receiver) = request_and_receiver(retry_params.number_of_retries);
+        let result = (OperationTarget::Node { address: ADDRESS }, err());
+        let (retry, next) = choose_response(result, request, &retry_params);
+
+        assert_eq!(receiver.try_recv(), Ok(Err(to_err(err_string))));
         assert!(retry.is_none());
         assert_eq!(next, PollFlushAction::RebuildSlots);
     }

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -903,6 +903,17 @@ where
                                 .wait_time_for_retry(retries);
                             thread::sleep(sleep_time);
                         }
+                        RetryMethod::RefreshSlotsAndRetry => {
+                            // Stale slot map (e.g. READONLY after failover). Sleep first to give
+                            // the cluster time to converge, then refresh so the retry (by slot,
+                            // hence `redirected` stays None) routes on the freshest topology.
+                            let sleep_time = self
+                                .cluster_params
+                                .retry_params
+                                .wait_time_for_retry(retries);
+                            thread::sleep(sleep_time);
+                            self.refresh_slots()?;
+                        }
                         RetryMethod::Reconnect => {
                             if *self.auto_reconnect.borrow() {
                                 // if the connection is no longer valid, we should remove it.

--- a/redis/src/errors/redis_error.rs
+++ b/redis/src/errors/redis_error.rs
@@ -235,6 +235,9 @@ pub enum RetryMethod {
     MovedRedirect,
     /// Reconnect the initial connection to the master cluster, this is only relevant for clusters.
     ReconnectFromInitialConnections,
+    /// The slot map is stale (e.g. a write hit a node demoted to replica during failover).
+    /// Refresh the topology, then retry by re-routing to the slot's owner. Only relevant for clusters.
+    RefreshSlotsAndRetry,
 }
 
 /// Indicates a general failure in the library.
@@ -399,6 +402,7 @@ impl RedisError {
             RetryMethod::WaitAndRetry => false,
             RetryMethod::AskRedirect => false,
             RetryMethod::MovedRedirect => false,
+            RetryMethod::RefreshSlotsAndRetry => false,
         }
     }
 

--- a/redis/src/errors/server_error.rs
+++ b/redis/src/errors/server_error.rs
@@ -67,8 +67,11 @@ impl ServerErrorKind {
             Self::ClusterDown => RetryMethod::WaitAndRetry,
             Self::BusyLoading => RetryMethod::WaitAndRetry,
 
+            // A write that lands on a node demoted to replica during failover returns READONLY.
+            // The slot map is stale, so refresh topology and retry against the new master.
+            Self::ReadOnly => RetryMethod::RefreshSlotsAndRetry,
+
             Self::ResponseError => RetryMethod::NoRetry,
-            Self::ReadOnly => RetryMethod::NoRetry,
             Self::ExecAbort => RetryMethod::NoRetry,
             Self::NoScript => RetryMethod::NoRetry,
             Self::CrossSlot => RetryMethod::NoRetry,

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -740,17 +740,17 @@ mod cluster {
             let completed = completed.clone();
             move |cmd: &[u8], _| {
                 respond_startup_two_nodes(name, cmd)?;
-                // Error twice with io-error, ensure connection is reestablished w/out calling
-                // other node (i.e., not doing a full slot rebuild)
+                // A genuinely non-retryable server error should be surfaced immediately,
+                // without any retry or slot rebuild.
                 completed.fetch_add(1, Ordering::SeqCst);
-                Err(Err((ServerErrorKind::ReadOnly.into(), "").into()))
+                Err(Err((ServerErrorKind::ResponseError.into(), "").into()))
             }
         });
 
         let result = cmd("GET").arg("test").query::<Option<i32>>(&mut connection);
 
         assert!(
-            matches!(&result, Err(err) if err.kind() == ServerErrorKind::ReadOnly.into()),
+            matches!(&result, Err(err) if err.kind() == ServerErrorKind::ResponseError.into()),
             "{result:?}",
         );
         assert_eq!(completed.load(Ordering::SeqCst), 1);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -748,6 +748,72 @@ mod cluster_async {
     }
 
     #[test]
+    fn test_async_cluster_readonly_error_refreshes_slots_and_retries() {
+        // Simulates a failover: a write lands on a node that has been demoted to a replica,
+        // which returns READONLY. The client should refresh its (stale) slot map and retry
+        // against the slot's new owner, rather than surfacing the error.
+        let name = "readonly_refreshes_slots";
+
+        let requests = atomic::AtomicUsize::new(0);
+        let started = atomic::AtomicBool::new(false);
+        let refreshed = Arc::new(atomic::AtomicBool::new(false));
+        let refreshed_clone = refreshed.clone();
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::new(name, move |cmd: &[u8], port| {
+            if !started.load(atomic::Ordering::SeqCst) {
+                respond_startup(name, cmd)?;
+            }
+            started.store(true, atomic::Ordering::SeqCst);
+
+            if is_connection_check(cmd) {
+                return Err(Ok(redis_value!(simple:"OK")));
+            }
+
+            let i = requests.fetch_add(1, atomic::Ordering::SeqCst);
+
+            match i {
+                // The write hits the demoted (now read-only) node.
+                0 => Err(parse_redis_value(
+                    b"-READONLY You can't write against a read only replica.\r\n",
+                )),
+                _ => {
+                    if contains_slice(cmd, b"CLUSTER") && contains_slice(cmd, b"SLOTS") {
+                        // The READONLY error should trigger exactly one slot refresh.
+                        assert!(!refreshed.swap(true, Ordering::SeqCst));
+                        Err(Ok(redis_value!([
+                            [0, 1, [name, 6379]],
+                            [2, 16383, [name, 6380]]
+                        ])))
+                    } else {
+                        // After refreshing, the slot's owner is the newly promoted primary.
+                        assert_eq!(port, 6380);
+                        assert!(contains_slice(cmd, b"SET"), "{:?}", std::str::from_utf8(cmd));
+                        Err(Ok(Value::Okay))
+                    }
+                }
+            }
+        });
+
+        let value = runtime.block_on(
+            cmd("SET")
+                .arg("test")
+                .arg("value")
+                .query_async::<Value>(&mut connection),
+        );
+
+        assert_eq!(value, Ok(Value::Okay));
+        assert!(
+            refreshed_clone.load(Ordering::SeqCst),
+            "slots should be refreshed"
+        );
+    }
+
+    #[test]
     fn test_async_cluster_tryagain_exhaust_retries() {
         let name = "tryagain_exhaust_retries";
 
@@ -2001,10 +2067,10 @@ mod cluster_async {
             let completed = completed.clone();
             move |cmd: &[u8], _| {
                 respond_startup_two_nodes(name, cmd)?;
-                // Error twice with io-error, ensure connection is reestablished w/out calling
-                // other node (i.e., not doing a full slot rebuild)
+                // A genuinely non-retryable server error should be surfaced immediately,
+                // without any retry or slot rebuild.
                 completed.fetch_add(1, Ordering::SeqCst);
-                Err(Err((ServerErrorKind::ReadOnly.into(), "").into()))
+                Err(Err((ServerErrorKind::ResponseError.into(), "").into()))
             }
         });
 
@@ -2014,7 +2080,7 @@ mod cluster_async {
                 .query_async::<Option<i32>>(&mut connection),
         );
 
-        assert_matches!(&result, Err(err) if err.kind() == ServerErrorKind::ReadOnly.into());
+        assert_matches!(&result, Err(err) if err.kind() == ServerErrorKind::ResponseError.into());
         assert_eq!(completed.load(Ordering::SeqCst), 1);
     }
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -792,7 +792,11 @@ mod cluster_async {
                     } else {
                         // After refreshing, the slot's owner is the newly promoted primary.
                         assert_eq!(port, 6380);
-                        assert!(contains_slice(cmd, b"SET"), "{:?}", std::str::from_utf8(cmd));
+                        assert!(
+                            contains_slice(cmd, b"SET"),
+                            "{:?}",
+                            std::str::from_utf8(cmd)
+                        );
                         Err(Ok(Value::Okay))
                     }
                 }


### PR DESCRIPTION
A write (e.g. EVAL) routed to a node demoted to a replica during failover returns READONLY. Previously this was NoRetry, so the client surfaced the error without refreshing its stale slot map. Now it refreshes topology and retries by slot (sync sleeps before refreshing so the retry uses the converged map), matching go-redis/predis behavior.

I hit this during a failover using Google Cloud MemoryStore and it caused an extended outage.