### PR TITLE
Makefile: Drop noop `e` from module test selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,12 @@ test-module:
 	@echo "===================================================================="
 	@echo "Testing RESP2 with module support enabled (currently only RedisJSON)"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features e -E 'test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 cargo nextest run -p redis --locked --all-features -E 'test(test_module)'
 
 	@echo "===================================================================="
 	@echo "Testing RESP3 with module support enabled (currently only RedisJSON)"
 	@echo "===================================================================="
-	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features e -E 'test(test_module)'
+	@RUSTFLAGS="-D warnings" REDISRS_SERVER_TYPE=tcp RUST_BACKTRACE=1 PROTOCOL=RESP3 cargo nextest run -p redis --all-features -E 'test(test_module)'
 
 test-single: test
 


### PR DESCRIPTION
The `e` got added in 0891022 when migrating to `nextest`.

But it seems it was here by accident, as `e` is not a flag; it simply selects all tests that contain `e`. As all our tests contain the word `test`, it selects all tests and does not add value.

So we drop the `e`.