### PR TITLE
Add XNACK command for Redis streams

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2044,8 +2044,18 @@ implement_commands! {
     /// the next `XREADGROUP ... CLAIM`. `ids` not present in the PEL are
     /// silently skipped; the returned count reflects only ids actually NACKed.
     ///
-    /// `mode` selects how the per-message delivery counter is adjusted:
-    /// see [`streams::StreamNackMode`].
+    /// `options` carries the required NACK mode, which selects how the per-message
+    /// delivery counter is adjusted. See [`streams::StreamNackMode`] and [`streams::StreamNackOptions`].
+    ///
+    /// ```no_run
+    /// use redis::{Commands, RedisResult};
+    /// use redis::streams::{StreamNackMode, StreamNackOptions};
+    /// let client = redis::Client::open("redis://127.0.0.1/0").unwrap();
+    /// let mut con = client.get_connection().unwrap();
+    ///
+    /// let opts = StreamNackOptions::new(StreamNackMode::Fail);
+    /// let nacked: RedisResult<usize> = con.xnack("k1", "g1", &["1-1", "1-2"], &opts);
+    /// ```
     ///
     /// ```text
     /// XNACK <key> <group> <SILENT|FAIL|FATAL> IDS <numids> <id> [<id> ...]
@@ -2053,16 +2063,16 @@ implement_commands! {
     /// [Redis Docs](https://redis.io/commands/XNACK)
     #[cfg(feature = "streams")]
     #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
-    fn xnack<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs>(
+    fn xnack<K: ToSingleRedisArg, G: ToSingleRedisArg, ID: ToSingleRedisArg>(
         key: K,
         group: G,
-        mode: streams::StreamNackMode,
-        ids: &'a [ID]
+        ids: &'a [ID],
+        options: &'a streams::StreamNackOptions
     ) -> (usize) {
         cmd("XNACK")
             .arg(key)
             .arg(group)
-            .arg(mode)
+            .arg(options)
             .arg("IDS")
             .arg(ids.len())
             .arg(ids)

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -2036,6 +2036,39 @@ implement_commands! {
             .take()
     }
 
+    /// Negatively acknowledge (NACK) one or more pending stream messages.
+    ///
+    /// `ids` that are present in the consumer group's PEL are moved to the
+    /// head of the PEL and marked as unowned (last consumer is set to an
+    /// empty string), so they are prioritized over idle pending messages on
+    /// the next `XREADGROUP ... CLAIM`. `ids` not present in the PEL are
+    /// silently skipped; the returned count reflects only ids actually NACKed.
+    ///
+    /// `mode` selects how the per-message delivery counter is adjusted:
+    /// see [`streams::StreamNackMode`].
+    ///
+    /// ```text
+    /// XNACK <key> <group> <SILENT|FAIL|FATAL> IDS <numids> <id> [<id> ...]
+    /// ```
+    /// [Redis Docs](https://redis.io/commands/XNACK)
+    #[cfg(feature = "streams")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+    fn xnack<K: ToRedisArgs, G: ToRedisArgs, ID: ToRedisArgs>(
+        key: K,
+        group: G,
+        mode: streams::StreamNackMode,
+        ids: &'a [ID]
+    ) -> (usize) {
+        cmd("XNACK")
+            .arg(key)
+            .arg(group)
+            .arg(mode)
+            .arg("IDS")
+            .arg(ids.len())
+            .arg(ids)
+            .take()
+    }
+
 
     /// Add a stream message by `key`. Use `*` as the `id` for the current timestamp.
     ///

--- a/redis/src/commands/streams.rs
+++ b/redis/src/commands/streams.rs
@@ -1519,6 +1519,49 @@ impl FromRedisValue for XDelExStatusCode {
     }
 }
 
+/// Mode for the [`xnack`] command.
+///
+/// Selects how the server adjusts the per-message delivery counter when a
+/// consumer NACKs (negatively acknowledges) one or more pending messages.
+/// See [`xnack`] for the full PEL semantics (re-ordering, ownership reset).
+///
+/// [`xnack`]: ../trait.Commands.html#method.xnack
+#[cfg(feature = "streams")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum StreamNackMode {
+    /// The consumer is NACKing due to internal errors or shutdown,
+    /// not because the message itself is problematic.
+    /// The delivery counter of each specified message is decremented by 1.
+    Silent,
+    /// The message causes problems for this consumer but may succeed for other consumers.
+    /// The delivery counter is left unchanged.
+    Fail,
+    /// The message is malformed/poison-pill/suspected-malicious.
+    /// The delivery counter is pinned to a sentinel value (`i64::MAX`) that
+    /// survives subsequent re-deliveries, so the message remains identifiable
+    /// as previously-FATAL for downstream tooling.
+    Fatal,
+}
+
+#[cfg(feature = "streams")]
+impl ToRedisArgs for StreamNackMode {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            StreamNackMode::Silent => out.write_arg(b"SILENT"),
+            StreamNackMode::Fail => out.write_arg(b"FAIL"),
+            StreamNackMode::Fatal => out.write_arg(b"FATAL"),
+        };
+    }
+}
+
+#[cfg(feature = "streams")]
+impl ToSingleRedisArg for StreamNackMode {}
+
 /// Status codes returned by the `XACKDEL` command
 #[cfg(feature = "streams")]
 #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]

--- a/redis/src/commands/streams.rs
+++ b/redis/src/commands/streams.rs
@@ -1562,6 +1562,44 @@ impl ToRedisArgs for StreamNackMode {
 #[cfg(feature = "streams")]
 impl ToSingleRedisArg for StreamNackMode {}
 
+/// Builder options for the [`xnack`] command.
+///
+/// The NACK [`mode`](StreamNackMode) is required by the server, so it is taken by
+/// [`StreamNackOptions::new`] rather than defaulted.
+///
+/// ```rust
+/// use redis::streams::{StreamNackMode, StreamNackOptions};
+///
+/// let opts = StreamNackOptions::new(StreamNackMode::Fail);
+/// ```
+///
+/// [`xnack`]: ../trait.Commands.html#method.xnack
+#[cfg(feature = "streams")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
+#[derive(Debug)]
+pub struct StreamNackOptions {
+    /// Set the `<SILENT|FAIL|FATAL>` cmd arg.
+    mode: StreamNackMode,
+}
+
+#[cfg(feature = "streams")]
+impl StreamNackOptions {
+    /// Create options for NACKing with the given `mode`.
+    pub fn new(mode: StreamNackMode) -> Self {
+        Self { mode }
+    }
+}
+
+#[cfg(feature = "streams")]
+impl ToRedisArgs for StreamNackOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.mode.write_redis_args(out);
+    }
+}
+
 /// Status codes returned by the `XACKDEL` command
 #[cfg(feature = "streams")]
 #[cfg_attr(docsrs, doc(cfg(feature = "streams")))]

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -3089,14 +3089,19 @@ mod xnack_tests {
 
     #[test]
     fn test_xnack_basic_returns_count_of_nacked_messages() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_basic";
         let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 3);
 
         let nacked = con
-            .xnack(stream, GROUP, StreamNackMode::Fail, &ids)
+            .xnack(
+                stream,
+                GROUP,
+                &ids,
+                &StreamNackOptions::new(StreamNackMode::Fail),
+            )
             .unwrap();
         assert_eq!(nacked, 3);
     }
@@ -3106,13 +3111,14 @@ mod xnack_tests {
     #[case(StreamNackMode::Fail)]
     #[case(StreamNackMode::Fatal)]
     fn test_xnack_marks_message_as_unowned(#[case] mode: StreamNackMode) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_unowned";
         let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 3);
 
-        con.xnack(stream, GROUP, mode, &ids).unwrap();
+        con.xnack(stream, GROUP, &ids, &StreamNackOptions::new(mode))
+            .unwrap();
 
         // After NACK the messages remain in the PEL but are unowned, so their last consumer should be an empty string.
         let reply = con.xpending_count(stream, GROUP, "-", "+", 3).unwrap();
@@ -3124,7 +3130,7 @@ mod xnack_tests {
 
     #[test]
     fn test_xnack_silent_decrements_delivery_counter() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_silent_counter";
@@ -3135,8 +3141,13 @@ mod xnack_tests {
         assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), 1);
 
         // Verify that a SILENT NACK decrements the counter.
-        con.xnack(stream, GROUP, StreamNackMode::Silent, &[id.as_str()])
-            .unwrap();
+        con.xnack(
+            stream,
+            GROUP,
+            &[id.as_str()],
+            &StreamNackOptions::new(StreamNackMode::Silent),
+        )
+        .unwrap();
         assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), 0);
 
         // Re-delivering via XREADGROUP CLAIM increments the counter back to 1.
@@ -3156,7 +3167,7 @@ mod xnack_tests {
 
     #[test]
     fn test_xnack_fail_keeps_delivery_counter() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_fail_counter";
@@ -3166,8 +3177,13 @@ mod xnack_tests {
         assert_eq!(initial_delivery_counter, 1);
 
         // Verify that FAIL leaves the delivery counter unchanged.
-        con.xnack(stream, GROUP, StreamNackMode::Fail, &[id.as_str()])
-            .unwrap();
+        con.xnack(
+            stream,
+            GROUP,
+            &[id.as_str()],
+            &StreamNackOptions::new(StreamNackMode::Fail),
+        )
+        .unwrap();
         let delivery_counter_after_nack = pel_times_delivered(&mut con, stream, GROUP, id);
         assert_eq!(delivery_counter_after_nack, initial_delivery_counter);
 
@@ -3191,7 +3207,7 @@ mod xnack_tests {
 
     #[test]
     fn test_xnack_fatal_marks_delivery_counter_as_sentinel() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_fatal_counter";
@@ -3200,8 +3216,13 @@ mod xnack_tests {
 
         // After a FATAL XNACK, the server pins the delivery counter to a sentinel (i64::MAX)
         // so it remains identifiable as "previously fatal" even after subsequent re-deliveries.
-        con.xnack(stream, GROUP, StreamNackMode::Fatal, &[id.as_str()])
-            .unwrap();
+        con.xnack(
+            stream,
+            GROUP,
+            &[id.as_str()],
+            &StreamNackOptions::new(StreamNackMode::Fatal),
+        )
+        .unwrap();
         let sentinel = i64::MAX as usize;
         assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), sentinel);
 
@@ -3222,7 +3243,7 @@ mod xnack_tests {
 
     #[test]
     fn test_xnack_prioritized_at_pel_head_when_claiming() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_priority";
@@ -3232,8 +3253,13 @@ mod xnack_tests {
         // NACK the 3rd entry.
         // NACKed messages are placed at the head of the PEL (FIFO over NACKed messages, then idle pending messages).
         let nacked_id = ids[2].clone();
-        con.xnack(stream, GROUP, StreamNackMode::Fail, &[nacked_id.as_str()])
-            .unwrap();
+        con.xnack(
+            stream,
+            GROUP,
+            &[nacked_id.as_str()],
+            &StreamNackOptions::new(StreamNackMode::Fail),
+        )
+        .unwrap();
 
         // Sleep so the remaining (non-NACKed) entries qualify under min-idle-time.
         sleep(Duration::from_millis(5));
@@ -3261,7 +3287,7 @@ mod xnack_tests {
     #[test]
     fn test_xnack_ignores_unknown_ids_and_returns_zero() {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_on_an_unknown_id";
@@ -3269,8 +3295,13 @@ mod xnack_tests {
 
         // The following id is not in the group's PEL as it was never delivered to any consumer so it should be ignored.
         assert_eq!(
-            con.xnack(stream, GROUP, Fail, &[NON_EXISTENT_MESSAGE_ID])
-                .unwrap(),
+            con.xnack(
+                stream,
+                GROUP,
+                &[NON_EXISTENT_MESSAGE_ID],
+                &StreamNackOptions::new(Fail)
+            )
+            .unwrap(),
             0
         );
     }
@@ -3278,7 +3309,7 @@ mod xnack_tests {
     #[test]
     fn test_xnack_only_affects_known_ids() {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_only_affects_known_ids";
@@ -3286,19 +3317,23 @@ mod xnack_tests {
 
         // Verify that only the real ids are nacked.
         let identifiers = vec![ids[0].as_str(), NON_EXISTENT_MESSAGE_ID, ids[1].as_str()];
-        assert_eq!(con.xnack(stream, GROUP, Fail, &identifiers).unwrap(), 2);
+        assert_eq!(
+            con.xnack(stream, GROUP, &identifiers, &StreamNackOptions::new(Fail))
+                .unwrap(),
+            2
+        );
     }
 
     #[test]
     fn test_xnack_nonexistent_stream_errors() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let result = con.xnack(
             "non_existent_stream",
             GROUP,
-            StreamNackMode::Fail,
             &[NON_EXISTENT_MESSAGE_ID],
+            &StreamNackOptions::new(StreamNackMode::Fail),
         );
 
         assert!(
@@ -3309,7 +3344,7 @@ mod xnack_tests {
 
     #[test]
     fn test_xnack_nonexistent_group_errors() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_nogroup";
@@ -3317,8 +3352,8 @@ mod xnack_tests {
         let result = con.xnack(
             stream,
             "missing_group",
-            StreamNackMode::Fail,
             &[NON_EXISTENT_MESSAGE_ID],
+            &StreamNackOptions::new(StreamNackMode::Fail),
         );
         assert!(
             result.is_err(),
@@ -3329,14 +3364,28 @@ mod xnack_tests {
     #[test]
     fn test_xnack_idempotent_double_nack() {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         let stream = "test_xnack_double";
         let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 1);
 
-        let first = con.xnack(stream, GROUP, Fail, &[ids[0].as_str()]).unwrap();
-        let second = con.xnack(stream, GROUP, Fail, &[ids[0].as_str()]).unwrap();
+        let first = con
+            .xnack(
+                stream,
+                GROUP,
+                &[ids[0].as_str()],
+                &StreamNackOptions::new(Fail),
+            )
+            .unwrap();
+        let second = con
+            .xnack(
+                stream,
+                GROUP,
+                &[ids[0].as_str()],
+                &StreamNackOptions::new(Fail),
+            )
+            .unwrap();
         assert_eq!(first, 1);
         assert_eq!(second, 1);
     }
@@ -3344,7 +3393,7 @@ mod xnack_tests {
     #[test]
     fn test_xnack_fifo_ordering_among_multiple_nacked_messages() {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         /*
@@ -3354,10 +3403,20 @@ mod xnack_tests {
         let stream = "test_xnack_fifo";
         let delivered = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 4);
 
-        con.xnack(stream, GROUP, Fail, &[delivered[2].as_str()])
-            .unwrap();
-        con.xnack(stream, GROUP, Fail, &[delivered[0].as_str()])
-            .unwrap();
+        con.xnack(
+            stream,
+            GROUP,
+            &[delivered[2].as_str()],
+            &StreamNackOptions::new(Fail),
+        )
+        .unwrap();
+        con.xnack(
+            stream,
+            GROUP,
+            &[delivered[0].as_str()],
+            &StreamNackOptions::new(Fail),
+        )
+        .unwrap();
 
         // Sleep so the remaining (non-NACKed) entries qualify under min-idle-time.
         sleep(Duration::from_millis(5));
@@ -3389,7 +3448,7 @@ mod xnack_tests {
     #[test]
     fn test_xnack_three_tier_delivery_order() {
         use StreamNackMode::*;
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
         let mut con = ctx.connection();
 
         // Tier 1: a delivered and NACKed entry.
@@ -3397,8 +3456,13 @@ mod xnack_tests {
         // Tier 3: entries past the group's last-delivered-id, which were never delivered.
         let stream = "test_xnack_three_tiers";
         let delivered = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 2);
-        con.xnack(stream, GROUP, Fail, &[delivered[0].as_str()])
-            .unwrap();
+        con.xnack(
+            stream,
+            GROUP,
+            &[delivered[0].as_str()],
+            &StreamNackOptions::new(Fail),
+        )
+        .unwrap();
 
         // Sleep to make the second entry qualify under min-idle-time.
         sleep(Duration::from_millis(5));

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -3043,3 +3043,396 @@ mod idempotency_tests {
         );
     }
 }
+
+mod xnack_tests {
+    use super::*;
+    use rstest::rstest;
+
+    const GROUP: &str = "xnack_group";
+    const CONSUMER: &str = "xnack_consumer1";
+    const CONSUMER2: &str = "xnack_consumer2";
+    const NON_EXISTENT_MESSAGE_ID: &str = "9999999-0";
+
+    // Create a stream with `n` entries delivered to `consumer` and return the list of delivered ids.
+    fn xnack_setup_pending(
+        con: &mut Connection,
+        stream: &str,
+        group: &str,
+        consumer: &str,
+        n: i32,
+    ) -> Vec<String> {
+        con.xgroup_create_mkstream(stream, group, "$").unwrap();
+        xadd_keyrange(con, stream, 0, n);
+        let reply = con
+            .xread_options(
+                &[stream],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(group, consumer)
+                    .count(n as usize),
+            )
+            .unwrap()
+            .unwrap();
+        reply.keys[0].ids.iter().map(|s| s.id.clone()).collect()
+    }
+
+    // Read the delivery counter for the given id from the group's PEL.
+    fn pel_times_delivered(con: &mut Connection, stream: &str, group: &str, id: &str) -> usize {
+        let reply = con.xpending_count(stream, group, "-", "+", 100).unwrap();
+        reply
+            .ids
+            .into_iter()
+            .find(|e| e.id == id)
+            .unwrap_or_else(|| panic!("id {id} not present in PEL"))
+            .times_delivered
+    }
+
+    #[test]
+    fn test_xnack_basic_returns_count_of_nacked_messages() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_basic";
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 3);
+
+        let nacked = con
+            .xnack(stream, GROUP, StreamNackMode::Fail, &ids)
+            .unwrap();
+        assert_eq!(nacked, 3);
+    }
+
+    #[rstest]
+    #[case(StreamNackMode::Silent)]
+    #[case(StreamNackMode::Fail)]
+    #[case(StreamNackMode::Fatal)]
+    fn test_xnack_marks_message_as_unowned(#[case] mode: StreamNackMode) {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_unowned";
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 3);
+
+        con.xnack(stream, GROUP, mode, &ids).unwrap();
+
+        // After NACK the messages remain in the PEL but are unowned, so their last consumer should be an empty string.
+        let reply = con.xpending_count(stream, GROUP, "-", "+", 3).unwrap();
+        assert_eq!(reply.ids.len(), 3);
+        for entry in &reply.ids {
+            assert_eq!(entry.consumer, "");
+        }
+    }
+
+    #[test]
+    fn test_xnack_silent_decrements_delivery_counter() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_silent_counter";
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 1);
+        let id = &ids[0];
+
+        // After the initial XREADGROUP the delivery counter is 1.
+        assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), 1);
+
+        // Verify that a SILENT NACK decrements the counter.
+        con.xnack(stream, GROUP, StreamNackMode::Silent, &[id.as_str()])
+            .unwrap();
+        assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), 0);
+
+        // Re-delivering via XREADGROUP CLAIM increments the counter back to 1.
+        let reply = con
+            .xread_options(
+                &[stream],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(GROUP, CONSUMER2)
+                    .claim(0),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(reply.keys[0].ids.len(), 1);
+        assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), 1);
+    }
+
+    #[test]
+    fn test_xnack_fail_keeps_delivery_counter() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_fail_counter";
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 1);
+        let id = &ids[0];
+        let initial_delivery_counter = pel_times_delivered(&mut con, stream, GROUP, id);
+        assert_eq!(initial_delivery_counter, 1);
+
+        // Verify that FAIL leaves the delivery counter unchanged.
+        con.xnack(stream, GROUP, StreamNackMode::Fail, &[id.as_str()])
+            .unwrap();
+        let delivery_counter_after_nack = pel_times_delivered(&mut con, stream, GROUP, id);
+        assert_eq!(delivery_counter_after_nack, initial_delivery_counter);
+
+        // Re-delivery increments the delivery counter.
+        let reply = con
+            .xread_options(
+                &[stream],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(GROUP, CONSUMER2)
+                    .claim(0),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(reply.keys[0].ids.len(), 1);
+        // Verify that the delivery counter was further incremented.
+        let delivery_counter_after_redelivery = pel_times_delivered(&mut con, stream, GROUP, id);
+        assert!(delivery_counter_after_redelivery > delivery_counter_after_nack);
+        assert_ne!(delivery_counter_after_redelivery, i64::MAX as usize);
+    }
+
+    #[test]
+    fn test_xnack_fatal_marks_delivery_counter_as_sentinel() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_fatal_counter";
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 1);
+        let id = &ids[0];
+
+        // After a FATAL XNACK, the server pins the delivery counter to a sentinel (i64::MAX)
+        // so it remains identifiable as "previously fatal" even after subsequent re-deliveries.
+        con.xnack(stream, GROUP, StreamNackMode::Fatal, &[id.as_str()])
+            .unwrap();
+        let sentinel = i64::MAX as usize;
+        assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), sentinel);
+
+        // Verify that even after a re-delivery the delivery counter remains pinned.
+        let reply = con
+            .xread_options(
+                &[stream],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(GROUP, CONSUMER2)
+                    .claim(0),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(reply.keys[0].ids.len(), 1);
+        assert_eq!(pel_times_delivered(&mut con, stream, GROUP, id), sentinel);
+    }
+
+    #[test]
+    fn test_xnack_prioritized_at_pel_head_when_claiming() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_priority";
+        // Deliver 4 entries to the consumer, which should all sit in the PEL in stream order.
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 4);
+
+        // NACK the 3rd entry.
+        // NACKed messages are placed at the head of the PEL (FIFO over NACKed messages, then idle pending messages).
+        let nacked_id = ids[2].clone();
+        con.xnack(stream, GROUP, StreamNackMode::Fail, &[nacked_id.as_str()])
+            .unwrap();
+
+        // Sleep so the remaining (non-NACKed) entries qualify under min-idle-time.
+        sleep(Duration::from_millis(5));
+
+        // Verify that the NACKed message is delivered first followed by the older idle pending entries.
+        let reply = con
+            .xread_options(
+                &[stream],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(GROUP, CONSUMER2)
+                    .claim(3)
+                    .count(4),
+            )
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(reply.keys[0].ids.len(), 4);
+        assert_eq!(
+            reply.keys[0].ids[0].id, nacked_id,
+            "NACKed message should be delivered first"
+        );
+    }
+
+    #[test]
+    fn test_xnack_ignores_unknown_ids_and_returns_zero() {
+        use StreamNackMode::*;
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_on_an_unknown_id";
+        xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 1);
+
+        // The following id is not in the group's PEL as it was never delivered to any consumer so it should be ignored.
+        assert_eq!(
+            con.xnack(stream, GROUP, Fail, &[NON_EXISTENT_MESSAGE_ID])
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_xnack_only_affects_known_ids() {
+        use StreamNackMode::*;
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_only_affects_known_ids";
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 2);
+
+        // Verify that only the real ids are nacked.
+        let identifiers = vec![ids[0].as_str(), NON_EXISTENT_MESSAGE_ID, ids[1].as_str()];
+        assert_eq!(con.xnack(stream, GROUP, Fail, &identifiers).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_xnack_nonexistent_stream_errors() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let result = con.xnack(
+            "non_existent_stream",
+            GROUP,
+            StreamNackMode::Fail,
+            &[NON_EXISTENT_MESSAGE_ID],
+        );
+
+        assert!(
+            result.is_err(),
+            "XNACK on a non-existent stream must error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_xnack_nonexistent_group_errors() {
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_nogroup";
+        con.xadd(stream, "*", &[("key", "val")]).unwrap();
+        let result = con.xnack(
+            stream,
+            "missing_group",
+            StreamNackMode::Fail,
+            &[NON_EXISTENT_MESSAGE_ID],
+        );
+        assert!(
+            result.is_err(),
+            "XNACK on a missing group must error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_xnack_idempotent_double_nack() {
+        use StreamNackMode::*;
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        let stream = "test_xnack_double";
+        let ids = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 1);
+
+        let first = con.xnack(stream, GROUP, Fail, &[ids[0].as_str()]).unwrap();
+        let second = con.xnack(stream, GROUP, Fail, &[ids[0].as_str()]).unwrap();
+        assert_eq!(first, 1);
+        assert_eq!(second, 1);
+    }
+
+    #[test]
+    fn test_xnack_fifo_ordering_among_multiple_nacked_messages() {
+        use StreamNackMode::*;
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        /*
+        Stream entries are delivered in stream order. NACK two of them in a non-stream order (3rd, then 1st).
+        On re-delivery the NACKed entries should come out in NACK order (FIFO), followed by the remaining idle pending entries in stream order.
+        */
+        let stream = "test_xnack_fifo";
+        let delivered = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 4);
+
+        con.xnack(stream, GROUP, Fail, &[delivered[2].as_str()])
+            .unwrap();
+        con.xnack(stream, GROUP, Fail, &[delivered[0].as_str()])
+            .unwrap();
+
+        // Sleep so the remaining (non-NACKed) entries qualify under min-idle-time.
+        sleep(Duration::from_millis(5));
+
+        let reply = con
+            .xread_options(
+                &[stream],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(GROUP, CONSUMER2)
+                    .claim(3)
+                    .count(4),
+            )
+            .unwrap()
+            .unwrap();
+
+        let order: Vec<&str> = reply.keys[0].ids.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(
+            order,
+            vec![
+                delivered[2].as_str(), // tier 1: NACK FIFO, NACKed first
+                delivered[0].as_str(), // tier 1: NACK FIFO, NACKed second
+                delivered[1].as_str(), // tier 2: idle pending in stream order
+                delivered[3].as_str(), // tier 2: idle pending in stream order
+            ],
+        );
+    }
+
+    #[test]
+    fn test_xnack_three_tier_delivery_order() {
+        use StreamNackMode::*;
+        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_8);
+        let mut con = ctx.connection();
+
+        // Tier 1: a delivered and NACKed entry.
+        // Tier 2: a delivered entry, which is not NACKed.
+        // Tier 3: entries past the group's last-delivered-id, which were never delivered.
+        let stream = "test_xnack_three_tiers";
+        let delivered = xnack_setup_pending(&mut con, stream, GROUP, CONSUMER, 2);
+        con.xnack(stream, GROUP, Fail, &[delivered[0].as_str()])
+            .unwrap();
+
+        // Sleep to make the second entry qualify under min-idle-time.
+        sleep(Duration::from_millis(5));
+        let new_a: String = con.xadd(stream, "*", &[("key", "v2")]).unwrap().unwrap();
+        let new_b: String = con.xadd(stream, "*", &[("key", "v3")]).unwrap().unwrap();
+
+        let reply = con
+            .xread_options(
+                &[stream],
+                &[">"],
+                &StreamReadOptions::default()
+                    .group(GROUP, CONSUMER2)
+                    .claim(3)
+                    .count(10),
+            )
+            .unwrap()
+            .unwrap();
+
+        let order: Vec<&str> = reply.keys[0].ids.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(
+            order,
+            vec![
+                delivered[0].as_str(), // tier 1: NACKed
+                delivered[1].as_str(), // tier 2: idle pending
+                new_a.as_str(),        // tier 3 (entry after last-delivered-id): never delivered
+                new_b.as_str(),        // tier 3 (entry after last-delivered-id): never delivered
+            ],
+        );
+        // Tier 1 entries have a delivered_count > 0.
+        assert!(reply.keys[0].ids[0].delivered_count.unwrap() > 0);
+        // Tier 2 entries have a delivered_count > 0.
+        assert!(reply.keys[0].ids[1].delivered_count.unwrap() > 0);
+        // Tier 3 entries should have delivered_count = 0.
+        assert_eq!(reply.keys[0].ids[2].delivered_count, Some(0));
+        assert_eq!(reply.keys[0].ids[3].delivered_count, Some(0));
+    }
+}


### PR DESCRIPTION
# Add XNACK command for Redis streams

## Summary

Add support for the `XNACK` command, introduced in `Redis CE 8.8`. 
`XNACK` lets a consumer negatively acknowledge pending stream messages without leaving them idle in the PEL and waiting for `XPENDING` + `XCLAIM` / `XAUTOCLAIM` redelivery. This makes the messages immediately available to other consumers in the group through `XREADGROUP CLAIM`. Depending on the `NACK`ing option, the delivery counter is adjusted to reflect the reason for the `NACK`.

## Motivation

Applications that use **streams** sometimes cannot handle or fail at handling specific time-sensitive stream messages:
- A consumer may fail to process a claimed message due to internal issues unrelated to the message itself, such as failing to connect to a required external service.
- A resource-constrained consumer may be unable to process certain messages within an acceptable time frame.
This consumer should leave the opportunity of handling this message to other consumers in the consumer group, with minimal delay.
- A consumer may need to shut down and immediately `NACK` all unprocessed messages it had claimed before doing so.

Currently, a consumer cannot `NACK` a message. It can either **ACK** it (`XACK` - marking it as `processed`) or leave it pending (which requires other consumers to handle via `XPENDING`, `XCLAIM / XAUTOCLAIM` or `XREADGROUP ... CLAIM`) and may introduce a long, unnecessary delay. 

`NACK` is beneficial in all of the cases above, as it allows a consumer to make the target messages immediately available for consumption by other consumers in the consumer group.

## Syntax

`XNACK key group <SILENT|FAIL|FATAL> IDS numids id [id ...]`

#### NACK modes

| `streams::StreamNackMode` | Purpose |
|---|---|
|`SILENT` | Used when there are internal errors or the consumer shuts down, not because the message is problematic. The delivery counter of each specified message is decremented by 1 (to undo the increment that occurred when the message was added to the group's PEL).|
|`FAIL` | Used when the message causes problems for the current consumer but may succeed for other consumers (e.g., requires more resources than available). The delivery counter stays the same (it was already incremented by 1 when added to the group's PEL).|
|`FATAL` | Used for invalid or suspected malicious messages. The delivery counter is set to `LLONG_MAX`.|

#### Response:
Returns the number of messages successfully `NACK`ed, regardless of the applied `NackMode`.

## Behavior
`NACK`ed messages are moved to the head of the consumer group's PEL in FIFO order and marked as unowned (last consumer set to ""). This makes them immediately available for claiming by other consumers via `XREADGROUP ... CLAIM` and ensures they are always prioritized over idle pending messages.

When `CLAIM` is specified, `XREADGROUP` delivers messages in the following order:

1. `NACK`ed messages, in `NACK` FIFO order
2. Pending messages idle longer than `min-idle-time`, in stream order
3. Never-delivered entries (only when reading with `>`), in stream order

## Testing
14 integration tests gated on `REDIS_VERSION_CE_8_8` that verify:
- the behavior of the command
- the state of the delivery counter after each of the `NackMode`s
- the PEL ordering
- edge cases (such as non-existent streams or groups or passing invalid message identifiers)

## Compatibility
New code paths are gated on the existing `streams` feature.
No existing public API changes.
Server behavior gated to `Redis CE 8.8+` via the `REDIS_VERSION_CE_8_8` version constant.

## Relevant documentation
https://redis.io/docs/latest/commands/xnack/