### PR TITLE
tests: Clean up getting versions

### DIFF
--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -6,9 +6,10 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use crate::support::{build_single_client, start_tls_crypto_provider};
-use assert_matches::assert_matches;
+use redis::Connection;
 use redis::ConnectionInfo;
 use redis::ProtocolVersion;
+use redis::RedisResult;
 #[cfg(feature = "cluster-async")]
 use redis::aio::ConnectionLike;
 #[cfg(feature = "cluster-async")]
@@ -169,16 +170,24 @@ impl TestClusterContext {
         panic!("failed waiting for cluster to be ready");
     }
 
+    /// Gets a single direct connection to the given server
+    ///
+    /// # Arguments
+    ///
+    /// * `server` - The server to connect to
+    pub fn build_single_client_connection(&self, server: &RedisServer) -> RedisResult<Connection> {
+        let client = build_single_client(
+            server.connection_info(),
+            &self.cluster.tls_paths,
+            self.mtls_enabled,
+        )?;
+
+        client.get_connection()
+    }
+
     pub fn disable_default_user(&self) {
         for server in &self.cluster.servers {
-            let client = build_single_client(
-                server.connection_info(),
-                &self.cluster.tls_paths,
-                self.mtls_enabled,
-            )
-            .unwrap();
-
-            let mut con = client.get_connection().unwrap();
+            let mut con = self.build_single_client_connection(server).unwrap();
             redis::cmd("ACL")
                 .arg("SETUSER")
                 .arg("default")
@@ -187,14 +196,21 @@ impl TestClusterContext {
                 .unwrap();
 
             // subsequent unauthenticated command should fail:
-            if let Ok(mut con) = client.get_connection() {
-                assert_matches!(redis::cmd("PING").exec(&mut con), Err(_));
+            if let Ok(mut con) = self.build_single_client_connection(server) {
+                redis::cmd("PING").exec(&mut con).unwrap_err();
             }
         }
     }
 
+    /// Gets the Redis version of the first server in the cluster
+    ///
+    /// # Panics
+    ///
+    /// As this function is only meant to be used during testing, it panics upon any issues.
     pub fn get_version(&self) -> super::Version {
-        let mut conn = self.connection();
+        let server = self.cluster.servers.first().unwrap();
+        let mut conn = self.build_single_client_connection(server).unwrap();
+
         super::get_version(&mut conn)
     }
 

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -518,15 +518,6 @@ pub fn get_redis_binary_version() -> Option<Version> {
     Some((versions[0], versions[1], versions[2]))
 }
 
-pub fn is_major_version(expected_version: u16, version: Version) -> bool {
-    expected_version <= version.0
-}
-
-pub fn is_version(expected_major_minor: (u16, u16), version: Version) -> bool {
-    expected_major_minor.0 < version.0
-        || (expected_major_minor.0 == version.0 && expected_major_minor.1 <= version.1)
-}
-
 // Redis version constants for version-gated tests
 pub const REDIS_VERSION_CE_7_0: Version = (7, 0, 0);
 pub const REDIS_VERSION_CE_7_2: Version = (7, 2, 0);

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2354,16 +2354,8 @@ mod cluster_async {
     mod pubsub {
         use super::*;
 
-        async fn check_if_redis_6(conn: &mut ClusterConnection) -> bool {
-            let response = conn
-                .route_command(
-                    cmd("INFO").arg("server").to_owned(),
-                    RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random),
-                )
-                .await
-                .unwrap();
-            let info = from_redis_value::<InfoDict>(response).unwrap();
-            parse_version(info).0 == 6
+        fn check_if_redis_6(ctx: &TestClusterContext) -> bool {
+            ctx.get_version().0 == 6
         }
 
         async fn subscribe_to_channels(
@@ -2471,7 +2463,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let is_redis_6 = check_if_redis_6(&mut pubsub_conn).await;
+            let is_redis_6 = check_if_redis_6(&ctx);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
 
@@ -2490,7 +2482,7 @@ mod cluster_async {
                 ctx.async_connection_with_config(config.clone()),
                 ctx.async_connection_with_config(config)
             );
-            let is_redis_6 = check_if_redis_6(&mut pubsub_conn).await;
+            let is_redis_6 = check_if_redis_6(&ctx);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
 
@@ -2504,7 +2496,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            if check_if_redis_6(&mut pubsub_conn).await {
+            if check_if_redis_6(&ctx) {
                 return;
             }
 
@@ -2530,7 +2522,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let is_redis_6 = check_if_redis_6(&mut pubsub_conn).await;
+            let is_redis_6 = check_if_redis_6(&ctx);
 
             let _: () = pubsub_conn.subscribe("regular-phonewave").await.unwrap();
             let push = get_push(&mut rx).await;
@@ -2619,7 +2611,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let is_redis_6 = check_if_redis_6(&mut pubsub_conn).await;
+            let is_redis_6 = check_if_redis_6(&ctx);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
 
@@ -2645,7 +2637,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let is_redis_6 = check_if_redis_6(&mut pubsub_conn).await;
+            let is_redis_6 = check_if_redis_6(&ctx);
 
             let _: () = pubsub_conn
                 .subscribe(&[
@@ -2773,7 +2765,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let is_redis_6 = check_if_redis_6(&mut pubsub_conn).await;
+            let is_redis_6 = check_if_redis_6(&ctx);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, is_redis_6).await;
 

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -317,8 +317,7 @@ mod hotkeys_cluster {
     /// Returns `(cluster_ctx, primary_info, hot_key, target_slot)`.
     ///
     /// The version check is performed via a direct standalone connection to a single
-    /// primary; `TestClusterContext::get_version()` would broadcast `INFO` to every
-    /// node and fail to parse the multi-node map response.
+    /// primary
     fn setup_cluster_and_target(
         protocol: ProtocolVersion,
     ) -> Option<(TestClusterContext, ConnectionInfo, String, u16)> {
@@ -330,9 +329,7 @@ mod hotkeys_cluster {
         let port = port_of(info.addr());
         let mut direct = direct_connection(info.clone(), protocol);
 
-        let server_info: redis::InfoDict =
-            redis::Cmd::new().arg("INFO").query(&mut direct).unwrap();
-        let version = parse_version(server_info);
+        let version = cluster_ctx.get_version();
         if version < REDIS_VERSION_CE_8_6 {
             eprintln!("Skipping: Redis version {version:?} < {REDIS_VERSION_CE_8_6:?}");
             return None;


### PR DESCRIPTION
This is precursory work for #2118 and cleans up unused functions,
repairs `TestClusterContext::get_version`, and moves all custom
version getting behind `get_version`.
