### PR TITLE
CI: Lock windows build to `windows-2022` runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -297,7 +297,7 @@ jobs:
 
   windows-build:
     needs: [lint, build-and-test, examples]
-    runs-on: windows-latest
+    runs-on: windows-2022  # Locked to `2022` because of #2124
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
The `windows-latest` runner saw an update which broke our builds (actions/runner-images#14017). Until, we find a way to run on the new `windows-latest`, we lock to `windows-2022` as that still builds.

This is a stop-gap measure for #2124.