### PR TITLE
tests: Delegate version comparison to `TestClusterVersioning` (Version refactor 5/10)

### DIFF
--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -70,6 +70,32 @@ pub trait TestContextVersioning {
     ///
     /// As this function is only meant to be used during testing, it panics upon any issues.
     fn get_version(&self) -> Version;
+
+    /// Returns whether the context's server has at least the given Redis version
+    fn supports(&self, version: &Version) -> bool {
+        self.get_version() >= *version
+    }
+}
+
+/// Skips the current test if it does not support the given Redis version
+///
+/// # Arguments
+///
+/// * `$ctx` - The context the test uses for its servers
+/// * `$minimum_required_version` - The minimum required Redis version
+/// * `$ret` - (Optional. Default: `()`) The value to return to skip the test
+#[macro_export]
+macro_rules! skip_if_context_does_not_support {
+    ($ctx:expr, $minimum_required_version:expr) => {{
+        $crate::skip_if_context_does_not_support!($ctx, $minimum_required_version, ())
+    }};
+    ($ctx:expr, $minimum_required_version:expr, $ret:expr) => {{
+        if !$ctx.supports($minimum_required_version) {
+            eprintln!("Skipping the test because the current version of Redis doesn't match the minimum required version {:?}.",
+            $minimum_required_version);
+            return $ret;
+        }
+    }};
 }
 
 /// Macro to run tests only if the Redis version meets the minimum requirement.
@@ -78,13 +104,8 @@ pub trait TestContextVersioning {
 macro_rules! run_test_if_version_supported {
     ($minimum_required_version:expr) => {{
         let ctx = $crate::support::TestContext::new();
-        let redis_version = ctx.get_version();
 
-        if redis_version < *$minimum_required_version {
-            eprintln!("Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-            redis_version, $minimum_required_version);
-            return;
-        }
+        $crate::skip_if_context_does_not_support!(ctx, $minimum_required_version);
 
         ctx
     }};
@@ -125,3 +146,7 @@ macro_rules! run_test_if_redis_binary_version_supported {
         }
     }};
 }
+
+// As this module is included in many integration tests, adding unit tests here would also (re)run
+// them during each of those intregration tests. Hence, we move out unit tests of this module into
+// `test_support.rs`

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -3503,13 +3503,6 @@ mod basic {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
-        // setup version & input data followed by assertions that take into account Redis version
-        // BZPOPMIN & BZPOPMAX are available from Redis version 5.0.0
-        // BZMPOP is available from Redis version 7.0.0
-
-        let redis_version = ctx.get_version();
-        assert!(redis_version.0 >= 5);
-
         assert_matches!(con.zadd("a", "1a", 1), Ok(_));
         assert_matches!(con.zadd("b", "2b", 2), Ok(_));
         assert_matches!(con.zadd("c", "3c", 3), Ok(_));
@@ -3531,7 +3524,8 @@ mod basic {
             (String::from("b"), String::from("6b"), 6.0)
         );
 
-        if redis_version.0 >= 7 {
+        // BZMPOP is available from Redis version 7.0.0
+        if ctx.supports(&REDIS_VERSION_CE_7_0) {
             let min = con.bzmpop_min(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
             let max = con.bzmpop_max(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
 

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2424,10 +2424,7 @@ mod cluster_async {
     mod pubsub {
         use super::*;
 
-        /// Yields `true` iff Redis is at least version 7
-        fn check_if_supports_redis_7(ctx: &TestClusterContext) -> bool {
-            ctx.get_version() >= REDIS_VERSION_CE_7_0
-        }
+        use crate::skip_if_context_does_not_support;
 
         async fn subscribe_to_channels(
             pubsub_conn: &mut ClusterConnection,
@@ -2534,7 +2531,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2553,7 +2550,7 @@ mod cluster_async {
                 ctx.async_connection_with_config(config.clone()),
                 ctx.async_connection_with_config(config)
             );
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2565,12 +2562,9 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder.use_protocol(ProtocolVersion::RESP3)
             });
+            skip_if_context_does_not_support!(ctx, &REDIS_VERSION_CE_7_0);
 
             let mut pubsub_conn = ctx.async_connection().await;
-            if !check_if_supports_redis_7(&ctx) {
-                return;
-            }
-
             let _: () = pubsub_conn.ssubscribe("foo").await.unwrap();
 
             let res = cmd("pubsub")
@@ -2593,7 +2587,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             let _: () = pubsub_conn.subscribe("regular-phonewave").await.unwrap();
             let push = get_push(&mut rx).await;
@@ -2682,7 +2676,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2708,7 +2702,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             let _: () = pubsub_conn
                 .subscribe(&[
@@ -2836,7 +2830,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = check_if_supports_redis_7(&ctx);
+            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -329,11 +329,7 @@ mod hotkeys_cluster {
         let port = port_of(info.addr());
         let mut direct = direct_connection(info.clone(), protocol);
 
-        let version = cluster_ctx.get_version();
-        if version < REDIS_VERSION_CE_8_6 {
-            eprintln!("Skipping: Redis version {version:?} < {REDIS_VERSION_CE_8_6:?}");
-            return None;
-        }
+        skip_if_context_does_not_support!(cluster_ctx, &REDIS_VERSION_CE_8_6, None);
 
         let (range_start, range_end) = first_owned_slot_range(&mut direct, port);
         let (hot_key, target_slot) = find_key_in_range(&mut direct, range_start, range_end);

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -349,7 +349,7 @@ fn test_module_json_num_incr_by() {
 
     assert_eq!(set_initial, Ok(true));
 
-    if ctx.protocol.supports_resp3() && ctx.get_version() >= REDIS_VERSION_CE_7_0 {
+    if ctx.protocol.supports_resp3() && ctx.supports(&REDIS_VERSION_CE_7_0) {
         // cannot increment a string
         let json_numincrby_a: RedisResult<Vec<Value>> = con.json_num_incr_by(TEST_KEY, "$.a", 2);
         assert_eq!(json_numincrby_a, Ok(vec![Nil]));
@@ -501,7 +501,7 @@ fn test_module_json_type() {
     let json_type_b: RedisResult<Value> = con.json_type(TEST_KEY, "$..a");
     let json_type_c: RedisResult<Value> = con.json_type(TEST_KEY, "$..dummy");
 
-    if ctx.protocol.supports_resp3() && ctx.get_version() >= REDIS_VERSION_CE_7_0 {
+    if ctx.protocol.supports_resp3() && ctx.supports(&REDIS_VERSION_CE_7_0) {
         // In RESP3 current RedisJSON always gives response in an array.
         assert_eq!(
             json_type_a,

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -2290,7 +2290,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_full_entries() {
         .unwrap();
     assert_eq!(reply.claimed, claimed_entries);
 
-    if ctx.get_version().0 > 6 {
+    if ctx.supports(&REDIS_VERSION_CE_7_0) {
         assert_eq!(
             reply.deleted_ids,
             vec![claim.id.clone(), claim_1.id.clone()]
@@ -2344,7 +2344,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
     std::mem::take(&mut claimed_entries[0].map);
     std::mem::take(&mut claimed_entries[1].map);
 
-    if ctx.get_version().0 > 6 {
+    if ctx.supports(&REDIS_VERSION_CE_7_0) {
         assert_eq!(reply.claimed, claimed_entries);
         assert_eq!(
             reply.deleted_ids,

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -1,0 +1,99 @@
+//! (Unit) tests for the support module
+//!
+//! As the `support` module gets included in most integration tests, adding its unit tests to the
+//! `support` module itself would include (and compile and run) them for each integration test
+//! module. This is unwarranted. So we instead collect them in this module.
+
+use crate::support::{TestContextVersioning, Version};
+
+#[macro_use]
+mod support;
+
+/// Mock implementation of [`TestContextVersioning`] to allow testing default implementations
+struct MockTestContext {
+    /// The version to return during `get_version`
+    version: Version,
+}
+
+impl MockTestContext {
+    /// Builds a new instance
+    fn new(version: Version) -> Self {
+        Self { version }
+    }
+}
+
+impl TestContextVersioning for MockTestContext {
+    fn get_version(&self) -> Version {
+        self.version
+    }
+}
+
+/// Tries to assure that `support` matches the same version
+#[test]
+fn support_exact_match() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(42, 4711, 23)));
+}
+
+/// Tries to assure that `support` correctly handles a smaller major number
+#[test]
+fn support_major_smaller() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(41, 4712, 24)));
+}
+
+/// Tries to assure that `support` correctly handles a bigger major number
+#[test]
+fn support_major_bigger() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(!mock.supports(&(43, 4710, 22)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major but bigger minor number
+#[test]
+fn support_major_match_minor_smaller() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(42, 4710, 24)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major but smaller minor number
+#[test]
+fn support_major_match_minor_bigger() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(!mock.supports(&(42, 4712, 22)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major and minor but bigger patch number
+#[test]
+fn support_major_match_minor_match_patch_smaller() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(mock.supports(&(42, 4711, 22)));
+}
+
+/// Tries to assure that `support` correctly handles a matching major and minor but smaller patch number
+#[test]
+fn support_major_match_minor_match_patch_bigger() {
+    // The context to check with
+    let mock = MockTestContext::new((42, 4711, 23));
+
+    // Check for support
+    assert!(!mock.supports(&(42, 4711, 24)));
+}


### PR DESCRIPTION
By delegating version comparison to `TestClusterVersioning`, all version
refactorings can now happen withtin `test::support::version` and no
longer need to mess with the tests' logic.
