### PR TITLE
tests/version: Parse all available versions (Valkey, modules, ...) (Version refactor 6/10)

### DIFF
--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -5,7 +5,7 @@ use std::convert::identity;
 use std::thread::sleep;
 use std::time::Duration;
 
-use crate::support::{build_single_client, start_tls_crypto_provider};
+use crate::support::{AvailableComponents, build_single_client, start_tls_crypto_provider};
 use redis::Connection;
 use redis::ConnectionInfo;
 use redis::ProtocolVersion;
@@ -217,10 +217,10 @@ impl TestClusterContext {
 }
 
 impl super::TestContextVersioning for TestClusterContext {
-    fn get_version(&self) -> super::Version {
+    fn get_available_components(&self) -> AvailableComponents {
         let server = self.cluster.servers.first().unwrap();
         let mut conn = self.build_single_client_connection(server).unwrap();
 
-        super::get_version(&mut conn)
+        AvailableComponents::from(&mut conn)
     }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -378,9 +378,9 @@ impl TestContext {
 }
 
 impl TestContextVersioning for TestContext {
-    fn get_version(&self) -> Version {
+    fn get_available_components(&self) -> AvailableComponents {
         let mut conn = self.connection();
-        get_version(&mut conn)
+        AvailableComponents::from(&mut conn)
     }
 }
 

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -1,31 +1,186 @@
 //! Tooling to handle server version extraction and matching
 
-use redis::InfoDict;
+use redis::ConnectionLike;
+use std::collections::HashMap;
 
 // Redis version constants for version-gated tests
-pub const REDIS_VERSION_CE_7_0: Version = (7, 0, 0);
-pub const REDIS_VERSION_CE_7_2: Version = (7, 2, 0);
-pub const REDIS_VERSION_CE_7_4: Version = (7, 4, 0);
-pub const REDIS_VERSION_CE_8_0: Version = (8, 0, 0);
-pub const REDIS_VERSION_CE_8_2: Version = (8, 1, 240);
-pub const REDIS_VERSION_CE_8_4: Version = (8, 3, 224);
-pub const REDIS_VERSION_CE_8_6: Version = (8, 6, 0);
+pub const REDIS_VERSION_CE_6_0: Component = ("redis", (6, 0, 0));
+pub const REDIS_VERSION_CE_7_0: Component = ("redis", (7, 0, 0));
+pub const REDIS_VERSION_CE_7_2: Component = ("redis", (7, 2, 0));
+pub const REDIS_VERSION_CE_7_4: Component = ("redis", (7, 4, 0));
+pub const REDIS_VERSION_CE_8_0: Component = ("redis", (8, 0, 0));
+pub const REDIS_VERSION_CE_8_2: Component = ("redis", (8, 1, 240));
+pub const REDIS_VERSION_CE_8_4: Component = ("redis", (8, 3, 224));
+pub const REDIS_VERSION_CE_8_6: Component = ("redis", (8, 6, 0));
 
-pub type Version = (u16, u16, u16);
+/// Version of a software component
+pub type Version = (u32, u32, u32);
 
-pub fn parse_version(info: InfoDict) -> Version {
-    let version: String = info.get("redis_version").unwrap();
-    let versions: Vec<u16> = version
-        .split('.')
-        .map(|version| version.parse::<u16>().unwrap())
-        .collect();
-    assert_eq!(versions.len(), 3);
-    (versions[0], versions[1], versions[2])
+/// Software component name along with its version
+pub type Component<'a> = (&'a str, Version);
+
+#[derive(Clone)]
+pub struct AvailableComponents {
+    /// The available components' versions by their name
+    components: HashMap<String, Version>,
 }
 
-pub fn get_version(conn: &mut impl redis::ConnectionLike) -> Version {
-    let info: InfoDict = redis::Cmd::new().arg("INFO").query(conn).unwrap();
-    parse_version(info)
+impl AvailableComponents {
+    /// Extracts the available/used/usable software components from an `INFO` response
+    ///
+    /// # Panics
+    ///
+    /// This method panics upon issues
+    fn parse_info(info_response: &str) -> HashMap<String, Version> {
+        let mut ret = HashMap::new();
+        for raw_line in info_response.lines() {
+            // Strip off comments
+            let line = raw_line.split("#").next().unwrap();
+
+            // Extract key and value
+            let mut split = line.splitn(2, ":");
+            let (Some(key), Some(value)) = (split.next(), split.next()) else {
+                continue;
+            };
+
+            // Turn into raw component name and version
+            let Some((name, version)) = Self::parse_info_kv(key.trim(), value.trim()) else {
+                continue;
+            };
+
+            // Store them
+            ret.insert(name.to_owned(), version);
+        }
+        ret
+    }
+
+    /// Parses an `INFO` key/value into component raw name and version
+    ///
+    /// # Panics
+    ///
+    /// This method panics upon issues
+    fn parse_info_kv(key: &str, value: &str) -> Option<(String, Version)> {
+        if key.ends_with("_version") {
+            // Direct key/value version (E.g.: `redis_version`, `valkey_version`)
+
+            // Strip the trailing `_version`
+            let name = &key[0..key.len() - 8];
+
+            // Yield the extracted data
+            return Some((name.to_owned(), Self::extract_version(value)));
+        }
+
+        if key == "module" {
+            // Module info line (e.g.: 'module:name=foo,ver=10203,...')
+
+            // Collect the module's options
+            let mut options = HashMap::new();
+            for pair in value.split(",") {
+                let mut inner_split = pair.splitn(2, "=");
+                match (inner_split.next(), inner_split.next()) {
+                    (Some(key), Some(value)) => {
+                        options.insert(key.trim(), value.trim());
+                    }
+                    _ => continue,
+                }
+            }
+
+            // Extract name and version
+            let name = options.get("name")?;
+            let version_str = options.get("ver")?;
+
+            // Yield the extracted data
+            return Some((name.to_string(), Self::extract_version(version_str)));
+        }
+
+        None
+    }
+
+    /// Extracts the version triplet of a `&str`
+    ///
+    /// # Panics
+    ///
+    /// This method panics upon issues
+    fn extract_version(value: &str) -> Version {
+        // Cut-off suffixes (e.g.: the trailing `-rc1` in `1.2.3-rc1`)
+        let number_str = value.split("-").next().unwrap();
+
+        // Convert each number part to a number
+        let numbers = number_str
+            .split('.')
+            .map(|version| version.parse::<u32>().unwrap())
+            .collect::<Vec<_>>();
+
+        // Massage the numbers into a [`Version`]
+        let (major, minor, patch) = match numbers.as_slice() {
+            // Single number case is used for module versions
+            [number] => {
+                let mut rest = *number;
+
+                let patch = rest % 100;
+                rest = (rest - patch) / 100;
+
+                let minor = rest % 100;
+                let major = (rest - minor) / 100;
+
+                (major, minor, patch)
+            }
+
+            // 3 number version is used for main Redis/Valkey/... version
+            [major, minor, patch] => (*major, *minor, *patch),
+            _ => panic!(
+                "version number extraction not implemented for {} parts of '{}'",
+                numbers.len(),
+                value
+            ),
+        };
+
+        // Yield as [`Version`]
+        (major, minor, patch)
+    }
+
+    /// Checks if the instance has the given component in at least the given version
+    pub fn supports(&self, component: Component) -> bool {
+        // Extract the parts we need from the component
+        let (name, requested_version) = component;
+
+        // Get the available version for the component
+        let Some(available_version) = self.components.get(name) else {
+            return false;
+        };
+
+        // Compare versions
+        available_version >= &requested_version
+    }
+}
+
+impl<C: ConnectionLike> From<&mut C> for AvailableComponents {
+    /// Extracts the available/used/usable software components from a connection
+    ///
+    /// # Panics
+    ///
+    /// This method panics upon issues
+    fn from(conn: &mut C) -> Self {
+        // We'd like to use [`InfoDict`]. But it stores only the last value if a key occurs multiple
+        // times. As each module gets reported with another `module` key, we could only get the last
+        // module's information, which is not fit for our use case.
+        // Hence, we have to parse `INFO` manually.
+        let info_response: String = redis::Cmd::new().arg("INFO").query(conn).unwrap();
+
+        let components = Self::parse_info(info_response.as_str());
+
+        Self { components }
+    }
+}
+
+impl<'a> From<&'a AvailableComponents> for Vec<Component<'a>> {
+    fn from(value: &'a AvailableComponents) -> Self {
+        value
+            .components
+            .iter()
+            .map(|(name, version)| (name.as_str(), *version))
+            .collect::<Vec<Component<'a>>>()
+    }
 }
 
 /// Get the Redis server version by running `redis-server --version`.
@@ -52,10 +207,10 @@ pub fn get_redis_binary_version() -> Option<Version> {
         .and_then(|s| s.strip_prefix("v="))
         .expect("Could not find version in redis-server output");
 
-    let versions: Vec<u16> = version_str
+    let versions: Vec<u32> = version_str
         .split('.')
         .take(3)
-        .map(|v| v.parse::<u16>().expect("Failed to parse version number"))
+        .map(|v| v.parse::<u32>().expect("Failed to parse version number"))
         .collect();
 
     assert_eq!(versions.len(), 3, "Expected version format x.y.z");
@@ -64,48 +219,53 @@ pub fn get_redis_binary_version() -> Option<Version> {
 
 /// Server version extraction and matching
 pub trait TestContextVersioning {
-    /// Gets the Redis version for the first server in the context
+    /// Gets the components for the first server in the context
     ///
     /// # Panics
     ///
     /// As this function is only meant to be used during testing, it panics upon any issues.
-    fn get_version(&self) -> Version;
+    fn get_available_components(&self) -> AvailableComponents;
 
-    /// Returns whether the context's server has at least the given Redis version
-    fn supports(&self, version: Version) -> bool {
-        self.get_version() >= version
+    /// Returns whether the context's server has the given component in at least the given version
+    fn supports(&self, component: Component) -> bool {
+        self.get_available_components().supports(component)
     }
 }
 
-/// Skips the current test if it does not support the given Redis version
+/// Skips the current test if it does not support the given component
 ///
 /// # Arguments
 ///
 /// * `$ctx` - The context the test uses for its servers
-/// * `$minimum_required_version` - The minimum required Redis version
+/// * `$component` - The component that has to be present to run the test
 /// * `$ret` - (Optional. Default: `()`) The value to return to skip the test
 #[macro_export]
 macro_rules! skip_if_context_does_not_support {
-    ($ctx:expr, $minimum_required_version:expr) => {{
-        $crate::skip_if_context_does_not_support!($ctx, $minimum_required_version, ())
-    }};
-    ($ctx:expr, $minimum_required_version:expr, $ret:expr) => {{
-        if !$ctx.supports($minimum_required_version) {
-            eprintln!("Skipping the test because the current version of Redis doesn't match the minimum required version {:?}.",
-            $minimum_required_version);
+    ($ctx:expr, $component:expr) => {{ $crate::skip_if_context_does_not_support!($ctx, $component, ()) }};
+    ($ctx:expr, $component:expr, $ret:expr) => {{
+        if !$ctx.supports($component) {
+            eprintln!(
+                "Skipping the test because the running server does not support {:?}.",
+                $component
+            );
             return $ret;
         }
     }};
 }
 
-/// Macro to run tests only if the Redis version meets the minimum requirement.
+/// Macro to run tests only if the default [`TestContext`] supports the given component
+///
 /// If the version is insufficient, the test is skipped with a message.
+///
+/// # Returns
+///
+/// A [`TestContext`], if `$component` is available
 #[macro_export]
 macro_rules! run_test_if_version_supported {
-    ($minimum_required_version:expr) => {{
+    ($component:expr) => {{
         let ctx = $crate::support::TestContext::new();
 
-        $crate::skip_if_context_does_not_support!(ctx, $minimum_required_version);
+        $crate::skip_if_context_does_not_support!(ctx, $component);
 
         ctx
     }};
@@ -135,7 +295,7 @@ macro_rules! run_test_if_redis_binary_version_supported {
                 return;
             }
             Some(redis_version) => {
-                if redis_version < $minimum_required_version {
+                if redis_version < $minimum_required_version.1 {
                     eprintln!(
                         "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
                         redis_version, $minimum_required_version
@@ -148,5 +308,5 @@ macro_rules! run_test_if_redis_binary_version_supported {
 }
 
 // As this module is included in many integration tests, adding unit tests here would also (re)run
-// them during each of those intregration tests. Hence, we move out unit tests of this module into
+// them during each of those integration tests. Hence, we move out unit tests of this module into
 // `test_support.rs`

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -4,96 +4,209 @@
 //! `support` module itself would include (and compile and run) them for each integration test
 //! module. This is unwarranted. So we instead collect them in this module.
 
-use crate::support::{TestContextVersioning, Version};
+use crate::support::{
+    AvailableComponents, Component, REDIS_VERSION_CE_6_0, TestContext, TestContextVersioning,
+};
+use redis_test::{MockCmd, MockRedisConnection};
 
-#[macro_use]
 mod support;
+
+fn build_available_components(input: &str) -> AvailableComponents {
+    let mut conn = MockRedisConnection::new(vec![MockCmd::new(redis::cmd("INFO"), Ok(input))]);
+    AvailableComponents::from(&mut conn)
+}
+
+fn assert_components_eq(components: AvailableComponents, mut expected: Vec<Component>) {
+    let mut actual: Vec<Component> = (&components).into();
+    actual.sort();
+    expected.sort();
+    assert_eq!(actual, expected);
+}
 
 /// Mock implementation of [`TestContextVersioning`] to allow testing default implementations
 struct MockTestContext {
-    /// The version to return during `get_version`
-    version: Version,
+    /// The components to return during `get_available_components`
+    components: AvailableComponents,
 }
 
 impl MockTestContext {
     /// Builds a new instance
-    fn new(version: Version) -> Self {
-        Self { version }
+    fn new(input: &str) -> Self {
+        let components = build_available_components(input);
+        Self { components }
     }
 }
 
 impl TestContextVersioning for MockTestContext {
-    fn get_version(&self) -> Version {
-        self.version
+    fn get_available_components(&self) -> AvailableComponents {
+        self.components.clone()
     }
 }
 
 /// Tries to assure that `support` matches the same version
 #[test]
-fn support_exact_match() {
+fn ctx_supports_exact_match() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports((42, 4711, 23)));
+    assert!(mock.supports(("foo", (42, 4711, 23))));
 }
 
 /// Tries to assure that `support` correctly handles a smaller major number
 #[test]
-fn support_major_smaller() {
+fn ctx_supports_major_smaller() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports((41, 4712, 24)));
+    assert!(mock.supports(("foo", (41, 4712, 24))));
 }
 
 /// Tries to assure that `support` correctly handles a bigger major number
 #[test]
-fn support_major_bigger() {
+fn ctx_supports_major_bigger() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(!mock.supports((43, 4710, 22)));
+    assert!(!mock.supports(("foo", (43, 4710, 22))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major but bigger minor number
 #[test]
-fn support_major_match_minor_smaller() {
+fn ctx_supports_major_match_minor_smaller() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports((42, 4710, 24)));
+    assert!(mock.supports(("foo", (42, 4710, 24))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major but smaller minor number
 #[test]
-fn support_major_match_minor_bigger() {
+fn ctx_supports_major_match_minor_bigger() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(!mock.supports((42, 4712, 22)));
+    assert!(!mock.supports(("foo", (42, 4712, 22))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major and minor but bigger patch number
 #[test]
-fn support_major_match_minor_match_patch_smaller() {
+fn ctx_supports_major_match_minor_match_patch_smaller() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(mock.supports((42, 4711, 22)));
+    assert!(mock.supports(("foo", (42, 4711, 22))));
 }
 
 /// Tries to assure that `support` correctly handles a matching major and minor but smaller patch number
 #[test]
-fn support_major_match_minor_match_patch_bigger() {
+fn ctx_supports_major_match_minor_match_patch_bigger() {
     // The context to check with
-    let mock = MockTestContext::new((42, 4711, 23));
+    let mock = MockTestContext::new("foo_version: 42.4711.23");
 
     // Check for support
-    assert!(!mock.supports((42, 4711, 24)));
+    assert!(!mock.supports(("foo", (42, 4711, 24))));
+}
+
+/// Tries to assure that the current server allows to parse the versions
+#[test]
+fn ctx_live_test_server() {
+    let ctx = TestContext::new();
+    let mut conn = ctx.connection();
+
+    let components = AvailableComponents::from(&mut conn);
+
+    assert!(components.supports(REDIS_VERSION_CE_6_0));
+}
+
+/// Tries to assure versions get correctly extracted from a single number with single digit components
+#[test]
+fn component_parse_single_all_single_digit() {
+    let input = "foo_version: 10203";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (1, 2, 3))]);
+}
+
+/// Tries to assure versions get correctly extracted from a single number with multiple digit components and a suffix
+#[test]
+fn component_parse_single_multiple_digits_suffixed() {
+    let input = "foo_version: 1234567-rc23";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (123, 45, 67))]);
+}
+
+/// Tries to assure versions get correctly extracted from a triplet with single digit components
+#[test]
+fn component_parse_triplet_all_single_digit() {
+    let input = "foo_version: 4.2.6";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (4, 2, 6))]);
+}
+
+/// Tries to assure versions get correctly extracted from a triplet with multiple digit components and a suffix
+#[test]
+fn component_parse_triplet_multiple_digits_suffixed() {
+    let input = "foo_version: 42.4711.23-rc121";
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (42, 4711, 23))]);
+}
+
+/// Tries to assure that a simple server version gets properly extracted from an info response
+#[test]
+fn component_parse_multiline_simple_server_version() {
+    let input = r#"
+bar: baz
+foo_version:4711.23.42
+quux: quuux
+"#;
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (4711, 23, 42))]);
+}
+
+/// Tries to assure that a simple module version gets properly extracted from an info response
+#[test]
+fn component_parse_multiline_simple_module_version() {
+    let input = r#"
+bar: baz
+module:name=foo,ver=47112342
+quux: quuux
+"#;
+
+    let components = build_available_components(input);
+
+    assert_components_eq(components, vec![("foo", (4711, 23, 42))]);
+}
+
+/// Tries to assure that versions properly parse from a complex info response
+#[test]
+fn component_parse_mix() {
+    let input = r#"
+   foo_version   :  2600.3.14159  # with whitespace padding
+#bar_version:1.2.3 # commented out
+this is # partly commented out
+
+   module  :  foo=bar, ver  =  47112342, quux=quuux,  name = baz , baz =
+"#;
+
+    let components = build_available_components(input);
+
+    assert_components_eq(
+        components,
+        vec![("foo", (2600, 3, 14159)), ("baz", (4711, 23, 42))],
+    );
 }


### PR DESCRIPTION
This allows tests to run/skip if it's running on Valkey, on a module,
and on specific versions thereof.

Fixes #2118
