### PR TITLE
tests/version: Add disjunctive (`OR`) and conjunctive (`AND`) matchers (Version refactor 7/10)

### DIFF
--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -21,6 +21,90 @@ pub type Version = (u32, u32, u32);
 /// Software component name along with its version
 pub type Component<'a> = (&'a str, Version);
 
+/// Matcher for [`Component`]s
+pub struct ComponentMatcher<'a> {
+    conjunctive_parts: Vec<Vec<Component<'a>>>,
+}
+
+impl<'a> ComponentMatcher<'a> {
+    /// Checks if this matcher matches the given available components
+    ///
+    /// # Arguments
+    ///
+    /// * `available_components` - The available components to check against
+    pub fn matches(&self, available_components: &AvailableComponents) -> bool {
+        self.conjunctive_parts.iter().all(|disjunctive_parts| {
+            disjunctive_parts
+                .iter()
+                .any(|component| available_components.supports(*component))
+        })
+    }
+}
+
+/// Matcher for a single [`Component`]
+impl<'a> From<Component<'a>> for ComponentMatcher<'a> {
+    fn from(value: Component<'a>) -> Self {
+        Self {
+            conjunctive_parts: vec![vec![value]],
+        }
+    }
+}
+
+/// Disjuntive (`OR`) matcher for a list of [`Component`]s
+///
+/// If any of the given components are supported, it's a match.
+impl<'a> From<&[Component<'a>]> for ComponentMatcher<'a> {
+    fn from(value: &[Component<'a>]) -> Self {
+        Self {
+            conjunctive_parts: vec![value.to_vec()],
+        }
+    }
+}
+
+/// Conjunctive (`AND`) matcher for a list of disjunctively (`OR`) matched lists of [`Component`]s
+///
+/// If all elements have at least one supported subelement, it's a match.
+impl<'a> From<&[&[Component<'a>]]> for ComponentMatcher<'a> {
+    fn from(value: &[&[Component<'a>]]) -> Self {
+        Self {
+            conjunctive_parts: value
+                .iter()
+                .map(|disjunctive_part| disjunctive_part.to_vec())
+                .collect(),
+        }
+    }
+}
+
+/// Macros to provide array implementations for matchers' slice implementations
+///
+/// Rust can auto-coerce array to slices. But with generic arguments, this
+/// array-to-slice-auto-coercion does not kick in. So one would have to convert manually. To avoid
+/// this for the common cases, this macro implements coercing `From`s. for a given array length
+///
+/// # Arguments
+///
+/// * `$n` - The array lengths to implement coercing `From`s for.
+macro_rules! matcher_array_impls {
+    ($n:expr) => {
+        impl<'a> From<[Component<'a>; $n]> for ComponentMatcher<'a> {
+            fn from(value: [Component<'a>; $n]) -> Self {
+                let coerced_value: &[Component<'a>] = &value;
+                Self::from(coerced_value)
+            }
+        }
+
+        impl<'a> From<[&[Component<'a>]; $n]> for ComponentMatcher<'a> {
+            fn from(value: [&[Component<'a>]; $n]) -> Self {
+                let coerced_value: &[&[Component<'a>]] = &value;
+                Self::from(coerced_value)
+            }
+        }
+    };
+}
+matcher_array_impls!(1);
+matcher_array_impls!(2);
+matcher_array_impls!(3);
+
 #[derive(Clone)]
 pub struct AvailableComponents {
     /// The available components' versions by their name
@@ -246,8 +330,10 @@ pub trait TestContextVersioning {
     fn get_available_components(&self) -> AvailableComponents;
 
     /// Returns whether the context's server has the given component in at least the given version
-    fn supports(&self, component: Component) -> bool {
-        self.get_available_components().supports(component)
+    fn supports<'a, T: Into<ComponentMatcher<'a>>>(&self, into_matcher: T) -> bool {
+        into_matcher
+            .into()
+            .matches(&self.get_available_components())
     }
 }
 

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -113,6 +113,69 @@ fn ctx_supports_major_match_minor_match_patch_bigger() {
     assert!(!mock.supports(("foo", (42, 4711, 24))));
 }
 
+/// Tries to assure that `support` correctly handles a disjunctive match
+#[test]
+fn ctx_supports_disjunctive() {
+    // The context to check with
+    let mock = MockTestContext::new("bar_version: 42.4711.23");
+
+    // Check for support when `bar` is `42.0.0` (matches)
+    assert!(mock.supports([
+        ("foo", (23, 23, 23)),
+        ("bar", (42, 0, 0)),
+        ("baz", (42, 42, 42)),
+    ]));
+
+    // Check for support when `bar` is `43.0.0` (too high)
+    assert!(!mock.supports([
+        ("foo", (23, 23, 23)),
+        ("bar", (43, 0, 0)),
+        ("baz", (42, 42, 42)),
+    ]));
+
+    // Check for support when `bar` is missing
+    assert!(!mock.supports([("foo", (23, 23, 23)), ("baz", (42, 42, 42)),]));
+}
+
+/// Tries to assure that `support` correctly handles a conjunctive match
+#[test]
+fn ctx_supports_conjunctive() {
+    // The context to check with
+    let input = r#"
+foo_version: 42.0.0
+bar_version: 4711.0.0
+baz_version: 23.0.0
+"#;
+    let mock = MockTestContext::new(input);
+
+    // Check for successful support
+    assert!(mock.supports([
+        &[
+            ("foo", (43, 0, 0)),  // does not match (too high)
+            ("bar", (151, 0, 0))  // matches
+        ][..],
+        &[("baz", (23, 0, 0))], // matches
+    ]));
+
+    // Check for failing support (first disjunctive fails)
+    assert!(!mock.supports([
+        &[
+            ("foo", (43, 0, 0)),   // does not match (too high)
+            ("bar", (4712, 0, 0))  // does not match (too high)
+        ][..],
+        &[("baz", (23, 0, 0))], // matches
+    ]));
+
+    // Check for failing support (second disjunctive fails)
+    assert!(!mock.supports([
+        &[
+            ("foo", (43, 0, 0)),  // does not match (too high)
+            ("bar", (151, 0, 0))  // matches
+        ][..],
+        &[("baz", (151, 0, 0))][..], // does not match (too high)
+    ]));
+}
+
 /// Tries to assure that the current server allows to parse the versions
 #[test]
 fn ctx_live_test_server() {


### PR DESCRIPTION
This allows to use list of components to `OR` them and write version
guards like

```
let ctx = run_test_if_version_supported!(&[&REDIS_8_8, &VALKEY_9_0]);
```

to run the test only on `Redis v8.8 || Valkey v9.0` and skip otherwise.

And it allows to use list of lists of components to `OR` the inner lists
and `AND` the outer lists to write version guards like

```
let ctx = run_test_if_version_supported!(&[&[&REDIS_8_8, &VALKEY_9_0][..], &[&REJSON_MODULE_8_8]]);
```

to match `(Redis v8.8 || Valkey v9.0) && REJSON module v8.8`.
