### PR TITLE
tests/version: Drop Redis binary version parsing (Version refactor 8/10)

### DIFF
--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -269,57 +269,6 @@ impl<'a> From<&'a AvailableComponents> for Vec<Component<'a>> {
     }
 }
 
-/// Get the Redis server version by running `redis-server --version`.
-/// Returns `None` if the binary is not available.
-pub fn get_redis_binary_version() -> Option<Version> {
-    use std::process::Command;
-
-    let binary = std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-
-    let output = match Command::new(&binary).arg("--version").output() {
-        Ok(output) => output,
-        Err(_) => {
-            eprintln!("Failed to execute redis-server --version");
-            return None;
-        }
-    };
-
-    let full_string =
-        String::from_utf8(output.stdout).expect("Invalid UTF-8 in redis-server version output");
-
-    let version_str = full_string
-        .split_whitespace()
-        .find(|s| s.starts_with("v="))
-        .and_then(|s| s.strip_prefix("v="))
-        .expect("Could not find version in redis-server output");
-
-    let versions: Vec<u32> = version_str
-        .split('.')
-        .take(3)
-        .map(|v| v.parse::<u32>().expect("Failed to parse version number"))
-        .collect();
-
-    assert_eq!(versions.len(), 3, "Expected version format x.y.z");
-    Some((versions[0], versions[1], versions[2]))
-}
-
-/// Returns `true` if the server binary is Valkey (as opposed to Redis).
-///
-/// Inspects the `redis-server --version` output rather than a running server,
-/// so it can gate a test before any server is started. Returns `false` if the
-/// binary cannot be located.
-pub fn is_valkey_binary() -> bool {
-    use std::process::Command;
-
-    let binary = std::env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-    match Command::new(&binary).arg("--version").output() {
-        Ok(output) => String::from_utf8_lossy(&output.stdout)
-            .to_lowercase()
-            .contains("valkey"),
-        Err(_) => false,
-    }
-}
-
 /// Server version extraction and matching
 pub trait TestContextVersioning {
     /// Gets the components for the first server in the context
@@ -373,55 +322,6 @@ macro_rules! run_test_if_version_supported {
         $crate::skip_if_context_does_not_support!(ctx, $component);
 
         ctx
-    }};
-}
-
-/// Macro to run tests only if the version of the Redis binary meets the minimum requirement.
-/// If the binary is not available or the version is insufficient, the test is skipped with a message.
-///
-/// # Example
-/// ```rust,no_run
-/// #[test]
-/// fn test_redis_8_6_feature() {
-///     run_test_if_redis_binary_version_supported!(REDIS_VERSION_CE_8_6);
-///     // Only now create the expensive test context
-///     let ctx = TestContext::new_with_cert_auth(tls_files);
-///     // ...
-/// }
-/// ```
-#[macro_export]
-macro_rules! run_test_if_redis_binary_version_supported {
-    ($minimum_required_version:expr) => {{
-        match $crate::support::get_redis_binary_version() {
-            None => {
-                eprintln!(
-                    "Skipping the test because the Redis binary was not found."
-                );
-                return;
-            }
-            Some(redis_version) => {
-                if redis_version < $minimum_required_version.1 {
-                    eprintln!(
-                        "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
-                        redis_version, $minimum_required_version
-                    );
-                    return;
-                }
-            }
-        }
-    }};
-}
-
-/// Macro to run a test only if the server binary is Valkey, skipping it otherwise.
-///
-/// Inspects the binary (not a running server), so it never starts a server.
-#[macro_export]
-macro_rules! run_test_if_engine_is_valkey {
-    () => {{
-        if !$crate::support::is_valkey_binary() {
-            eprintln!("Skipping the test because the server binary is not Valkey.");
-            return;
-        }
     }};
 }
 

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "cluster")]
+#[macro_use]
 mod support;
 
 #[cfg(test)]
@@ -10,7 +11,6 @@ mod cluster {
     };
 
     use crate::support::*;
-    use crate::{run_test_if_engine_is_valkey, run_test_if_redis_binary_version_supported};
     use assert_matches::assert_matches;
     use redis::{
         Commands, ConnectionLike, ErrorKind, RedisError, ServerErrorKind, Value,
@@ -52,8 +52,7 @@ mod cluster {
 
     #[test]
     fn test_cluster_numbered_database() {
-        run_test_if_engine_is_valkey!();
-        run_test_if_redis_binary_version_supported!(VALKEY_VERSION_CE_9_0);
+        run_test_if_version_supported!(VALKEY_VERSION_CE_9_0);
 
         let cluster = TestClusterContext::new_with_config_and_builder(
             RedisClusterConfiguration {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "cluster-async")]
+#[macro_use]
 mod support;
 
 #[cfg(test)]
@@ -37,7 +38,6 @@ mod cluster_async {
     use tokio::{join, sync::mpsc::UnboundedReceiver};
 
     use crate::support::*;
-    use crate::{run_test_if_engine_is_valkey, run_test_if_redis_binary_version_supported};
 
     fn broken_pipe_error() -> RedisError {
         RedisError::from(std::io::Error::new(
@@ -72,8 +72,7 @@ mod cluster_async {
 
     #[async_test]
     async fn test_async_cluster_numbered_database() {
-        run_test_if_engine_is_valkey!();
-        run_test_if_redis_binary_version_supported!(VALKEY_VERSION_CE_9_0);
+        run_test_if_version_supported!(VALKEY_VERSION_CE_9_0);
 
         let cluster = TestClusterContext::new_with_config_and_builder(
             RedisClusterConfiguration {
@@ -2479,8 +2478,6 @@ mod cluster_async {
 
     mod pubsub {
         use super::*;
-
-        use crate::skip_if_context_does_not_support;
 
         async fn subscribe_to_channels(
             pubsub_conn: &mut ClusterConnection,

--- a/redis/tests/test_tls_cert_auth.rs
+++ b/redis/tests/test_tls_cert_auth.rs
@@ -93,8 +93,7 @@ fn test_tls_certificate_authentication_with_matching_acl_user() {
     // This test verifies that Redis 8.6+ can automatically authenticate a client
     // based on the Common Name (CN) field in the client's TLS certificate.
 
-    // Check Redis binary version before creating the test context.
-    run_test_if_redis_binary_version_supported!(REDIS_VERSION_CE_8_6);
+    run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
 
     // Generate a random username for the test.
     let test_username = generate_random_username();
@@ -171,9 +170,7 @@ fn test_tls_certificate_authentication_with_matching_acl_user() {
 fn test_tls_certificate_authentication_no_matching_user() {
     // This test verifies that when a client certificate's CN doesn't match
     // any existing ACL user, Redis falls back to the "default" user.
-
-    // Check Redis binary version before creating the test context.
-    run_test_if_redis_binary_version_supported!(REDIS_VERSION_CE_8_6);
+    run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
 
     // Generate a random username (that won't have a corresponding ACL user).
     let test_username = generate_random_username();


### PR DESCRIPTION
While running the Redis binary with `--version` is cheaper than starting
up a full instance, this version parsing does not work reliably on
Valkey and straight-out fails on Dragonfly.

Instead of running with `--version` we start a plain simple
`TestContext` (no TLS, no nothing) and check the versions through that.
That's not much slower (and is only necessary in 2 tests).
But foremostly, it allows to kill a brittle part for good. And brings all
version parsing together in one place.
