### PR TITLE
tests: Use server binary from env to detect major version

### DIFF
--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -173,7 +173,7 @@ impl RedisServer {
         spawner: F,
     ) -> RedisServer {
         let bin = env::var("REDISRS_SERVER_BIN").unwrap_or_else(|_| "redis-server".to_string());
-        let mut redis_cmd = process::Command::new(bin);
+        let mut redis_cmd = process::Command::new(&bin);
 
         if let Some(config_path) = config_file {
             redis_cmd.arg(config_path);
@@ -220,7 +220,7 @@ impl RedisServer {
             .expect("failed to create tempdir");
         let log_file = Self::log_file(&tempdir);
         redis_cmd.arg("--logfile").arg(log_file.clone());
-        if get_major_version() > 6 {
+        if get_major_version(&bin) > 6 {
             redis_cmd.arg("--enable-debug-command").arg("yes");
         }
         match addr {
@@ -337,9 +337,9 @@ impl RedisServer {
     }
 }
 
-fn get_major_version() -> u8 {
+fn get_major_version(server_binary: &str) -> u8 {
     let full_string = String::from_utf8(
-        process::Command::new("redis-server")
+        process::Command::new(server_binary)
             .arg("-v")
             .output()
             .unwrap()


### PR DESCRIPTION
While we try to respect the `REDIS_SERVER_BIN` environment variable to start the server, the command used to detect the major version was still hard wired to `redis-server`.

We switch it to the environment variable to get more reliable results when running tests locally.