### PR TITLE
tests/version: Require ownership to check version support (Version refactor 5b/10)

### DIFF
--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -72,8 +72,8 @@ pub trait TestContextVersioning {
     fn get_version(&self) -> Version;
 
     /// Returns whether the context's server has at least the given Redis version
-    fn supports(&self, version: &Version) -> bool {
-        self.get_version() >= *version
+    fn supports(&self, version: Version) -> bool {
+        self.get_version() >= version
     }
 }
 
@@ -118,7 +118,7 @@ macro_rules! run_test_if_version_supported {
 /// ```rust,no_run
 /// #[test]
 /// fn test_redis_8_6_feature() {
-///     run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+///     run_test_if_redis_binary_version_supported!(REDIS_VERSION_CE_8_6);
 ///     // Only now create the expensive test context
 ///     let ctx = TestContext::new_with_cert_auth(tls_files);
 ///     // ...
@@ -135,7 +135,7 @@ macro_rules! run_test_if_redis_binary_version_supported {
                 return;
             }
             Some(redis_version) => {
-                if redis_version < *$minimum_required_version {
+                if redis_version < $minimum_required_version {
                     eprintln!(
                         "Skipping the test because the current version of Redis {:?} doesn't match the minimum required version {:?}.",
                         redis_version, $minimum_required_version

--- a/redis/tests/test_acl.rs
+++ b/redis/tests/test_acl.rs
@@ -158,7 +158,7 @@ fn test_acl_log() {
 #[test]
 fn test_acl_dryrun() {
     // Skip the test <7.2, as the error message at the end was different before 7.2
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_7_2);
 
     let mut con = ctx.connection();
 
@@ -187,7 +187,7 @@ fn test_acl_dryrun() {
 #[test]
 fn test_acl_info() {
     // Skip the test <7.2, as `sanitize-payload` was not available before 7.2
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_7_2);
     let mut conn = ctx.connection();
     let username = "tenant";
     let password = "securepassword123";
@@ -265,7 +265,7 @@ fn test_acl_info() {
 #[test]
 fn test_acl_sample_info() {
     // Skip the test <7.2, as `sanitize-payload` was not available before 7.2
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_7_2);
     let mut conn = ctx.connection();
     let sample_rule = vec![
         Rule::On,

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -370,7 +370,7 @@ mod basic {
     #[test]
     fn test_hash_expiration() {
         // Hash expiration is only supported in Redis 7.4.0 and later.
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_7_4);
 
         let mut con = ctx.connection();
         redis::cmd("HMSET")
@@ -484,7 +484,7 @@ mod basic {
     /// 5. Attempting to delete a field from a non-existing hash results in a NIL response.
     #[test]
     fn test_hget_del() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -561,7 +561,7 @@ mod basic {
     /// 6. Attempting to retrieve a field from a non-existing hash returns in a NIL response.
     #[test]
     fn test_hget_ex() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -680,7 +680,7 @@ mod basic {
     /// as well as removing an existing expiration using the PERSIST option.
     #[test]
     fn test_hget_ex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -775,7 +775,7 @@ mod basic {
     ///        and verifies that their values have been modified and the fields are set to expire.
     #[test]
     fn test_hset_ex() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
 
         let generated_hash_key = generate_random_testing_hash_key(&mut con);
@@ -961,7 +961,7 @@ mod basic {
     /// as well as keeping an existing expiration using the KEEPTTL option.
     #[test]
     fn test_hsetex_field_expiration_options() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -1023,7 +1023,7 @@ mod basic {
 
     #[test]
     fn test_hsetex_can_update_the_expiration_of_a_field_that_has_already_been_set_to_expire() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
         // Create a hash with multiple fields and values that will be used for testing
         assert_eq!(con.hset_multiple(HASH_KEY, &HASH_FIELDS_AND_VALUES), Ok(()));
@@ -2207,7 +2207,7 @@ mod basic {
 
     #[test]
     fn test_bit_operations() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
         let mut con = ctx.connection();
 
         fn perform_bitwise_operation<F>(str1: &str, str2: &str, op: F) -> String
@@ -2731,7 +2731,7 @@ mod basic {
     /// The test validates the IFEQ value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_value_equals() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_ifeq_key";
@@ -2790,7 +2790,7 @@ mod basic {
     /// The test validates the IFNE value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_value_not_equals() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_ifne_key";
@@ -2855,7 +2855,7 @@ mod basic {
     /// The test validates the DIGEST command
     #[test]
     fn test_digest_command() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_digest_key";
@@ -2899,7 +2899,7 @@ mod basic {
     /// The test validates the IFDEQ value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_digest_equals() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_ifdeq_key";
@@ -2962,7 +2962,7 @@ mod basic {
     /// The test validates the IFDNE value comparison option for the SET command
     #[test]
     fn test_set_value_comparison_digest_not_equals() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_ifdne_key";
@@ -3030,7 +3030,7 @@ mod basic {
 
     #[test]
     fn test_del_ex() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key = "test_del_ex_key";
@@ -3159,7 +3159,7 @@ mod basic {
     /// Test the MSETEX command with the NX existence option
     #[test]
     fn test_mset_ex_nx() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key1 = "mset_ex_nx_key1";
@@ -3205,7 +3205,7 @@ mod basic {
     /// Test the MSETEX command with the XX existence option
     #[test]
     fn test_mset_ex_xx() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let key1 = "mset_ex_xx_key1";
@@ -3259,7 +3259,7 @@ mod basic {
     /// Test the MSETEX command with all supported expiration options
     #[test]
     fn test_mset_ex_expiration_options() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
         let mut con = ctx.connection();
 
         let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
@@ -3368,7 +3368,7 @@ mod basic {
     #[test]
     fn test_expire_time() {
         // EXPIRETIME/PEXPIRETIME is available from Redis version 7.4.0
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_4);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_7_4);
 
         let mut con = ctx.connection();
 
@@ -3525,7 +3525,7 @@ mod basic {
         );
 
         // BZMPOP is available from Redis version 7.0.0
-        if ctx.supports(&REDIS_VERSION_CE_7_0) {
+        if ctx.supports(REDIS_VERSION_CE_7_0) {
             let min = con.bzmpop_min(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
             let max = con.bzmpop_max(0.0, vec!["a", "b", "c", "d"].as_slice(), 1);
 
@@ -3612,7 +3612,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_basic_operations() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
 
         let key = "test_points";
@@ -3696,7 +3696,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_similarity_search() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
 
         let key = "test_points_for_similarity_search";
@@ -3877,7 +3877,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_auxiliary_commands() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
 
         let key = "test_points_for_auxiliary_commands";
@@ -4108,7 +4108,7 @@ mod basic {
     #[test]
     #[cfg(feature = "vector-sets")]
     fn test_vector_sets_edge_cases() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_0);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_0);
         let mut con = ctx.connection();
 
         let non_existent_key = "non_existent_key";
@@ -4498,7 +4498,7 @@ mod basic {
     #[test]
     fn test_connection_info_lib_name() {
         // Setting the lib_name etc is only supported in Redis 7.2.0 and later.
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_7_2);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_7_2);
 
         // Build a `ConnectionInfo` that sets lib_name etc
         let redis = redis_settings().set_lib_name("redis-rs-test-basic-lib-name", "42.4711");

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -774,7 +774,7 @@ async fn test_cache_async_cluster_slot_change(migrate: bool) {
     // When not `migrate`, this test relies on Redis commit 8945067 which was included beginning
     // with Redis 7.2
     if !migrate {
-        run_test_if_version_supported!(&REDIS_VERSION_CE_7_2);
+        run_test_if_version_supported!(REDIS_VERSION_CE_7_2);
     }
 
     struct NodeData {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2531,7 +2531,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
+            let supports_redis_7 = ctx.supports(REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2550,7 +2550,7 @@ mod cluster_async {
                 ctx.async_connection_with_config(config.clone()),
                 ctx.async_connection_with_config(config)
             );
-            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
+            let supports_redis_7 = ctx.supports(REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2562,7 +2562,7 @@ mod cluster_async {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder.use_protocol(ProtocolVersion::RESP3)
             });
-            skip_if_context_does_not_support!(ctx, &REDIS_VERSION_CE_7_0);
+            skip_if_context_does_not_support!(ctx, REDIS_VERSION_CE_7_0);
 
             let mut pubsub_conn = ctx.async_connection().await;
             let _: () = pubsub_conn.ssubscribe("foo").await.unwrap();
@@ -2587,7 +2587,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
+            let supports_redis_7 = ctx.supports(REDIS_VERSION_CE_7_0);
 
             let _: () = pubsub_conn.subscribe("regular-phonewave").await.unwrap();
             let push = get_push(&mut rx).await;
@@ -2676,7 +2676,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
+            let supports_redis_7 = ctx.supports(REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 
@@ -2702,7 +2702,7 @@ mod cluster_async {
             });
 
             let mut pubsub_conn = ctx.async_connection().await;
-            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
+            let supports_redis_7 = ctx.supports(REDIS_VERSION_CE_7_0);
 
             let _: () = pubsub_conn
                 .subscribe(&[
@@ -2830,7 +2830,7 @@ mod cluster_async {
 
             let (mut publish_conn, mut pubsub_conn) =
                 join!(ctx.async_connection(), ctx.async_connection());
-            let supports_redis_7 = ctx.supports(&REDIS_VERSION_CE_7_0);
+            let supports_redis_7 = ctx.supports(REDIS_VERSION_CE_7_0);
 
             subscribe_to_channels(&mut pubsub_conn, &mut rx, supports_redis_7).await;
 

--- a/redis/tests/test_hotkeys.rs
+++ b/redis/tests/test_hotkeys.rs
@@ -69,7 +69,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_state_machine_behavior(#[case] protocol: ProtocolVersion) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
         println!("Starting test_hotkeys_state_machine_behavior - Protocol: {protocol:?}");
@@ -145,7 +145,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2, Metric::All)]
     #[case(ProtocolVersion::RESP3, Metric::All)]
     fn test_hotkeys_with_metric(#[case] protocol: ProtocolVersion, #[case] metric: Metric) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
         println!("Starting test_hotkeys_with_metric - Metric: {metric}, Protocol: {protocol:?}");
@@ -171,7 +171,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_options_with_duration_and_count(#[case] protocol: ProtocolVersion) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
         println!("Starting test_hotkeys_options_with_duration_and_count - Protocol: {protocol:?}");
@@ -203,7 +203,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_options_with_sample_ratio(#[case] protocol: ProtocolVersion) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
         println!("Starting test_hotkeys_options_with_sample_ratio - Protocol: {protocol:?}");
@@ -223,7 +223,7 @@ mod hotkeys {
     #[case(ProtocolVersion::RESP2)]
     #[case(ProtocolVersion::RESP3)]
     fn test_hotkeys_start_with_slots_on_standalone_errors(#[case] protocol: ProtocolVersion) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = setup_connection_with_protocol(&ctx, protocol);
 
         println!(
@@ -329,7 +329,7 @@ mod hotkeys_cluster {
         let port = port_of(info.addr());
         let mut direct = direct_connection(info.clone(), protocol);
 
-        skip_if_context_does_not_support!(cluster_ctx, &REDIS_VERSION_CE_8_6, None);
+        skip_if_context_does_not_support!(cluster_ctx, REDIS_VERSION_CE_8_6, None);
 
         let (range_start, range_end) = first_owned_slot_range(&mut direct, port);
         let (hot_key, target_slot) = find_key_in_range(&mut direct, range_start, range_end);
@@ -634,7 +634,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
 
         println!("Starting test_hotkeys_state_machine_behavior_async - Protocol: {protocol:?}");
 
@@ -712,7 +712,7 @@ mod async_hotkeys {
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
         #[values(Metric::Cpu, Metric::Net, Metric::All)] metric: Metric,
     ) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
 
         println!(
             "Starting test_hotkeys_with_metric_async - Metric: {metric}, Protocol: {protocol:?}"
@@ -748,7 +748,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
 
         println!(
             "Starting test_hotkeys_options_with_duration_and_count_async - Protocol: {protocol:?}"
@@ -792,7 +792,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
 
         println!("Starting test_hotkeys_options_with_sample_ratio_async - Protocol: {protocol:?}");
 
@@ -824,7 +824,7 @@ mod async_hotkeys {
         #[case] runtime: RuntimeType,
         #[values(ProtocolVersion::RESP2, ProtocolVersion::RESP3)] protocol: ProtocolVersion,
     ) {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
 
         println!(
             "Starting test_hotkeys_start_with_slots_on_standalone_errors_async - \

--- a/redis/tests/test_module_json.rs
+++ b/redis/tests/test_module_json.rs
@@ -349,7 +349,7 @@ fn test_module_json_num_incr_by() {
 
     assert_eq!(set_initial, Ok(true));
 
-    if ctx.protocol.supports_resp3() && ctx.supports(&REDIS_VERSION_CE_7_0) {
+    if ctx.protocol.supports_resp3() && ctx.supports(REDIS_VERSION_CE_7_0) {
         // cannot increment a string
         let json_numincrby_a: RedisResult<Vec<Value>> = con.json_num_incr_by(TEST_KEY, "$.a", 2);
         assert_eq!(json_numincrby_a, Ok(vec![Nil]));
@@ -501,7 +501,7 @@ fn test_module_json_type() {
     let json_type_b: RedisResult<Value> = con.json_type(TEST_KEY, "$..a");
     let json_type_c: RedisResult<Value> = con.json_type(TEST_KEY, "$..dummy");
 
-    if ctx.protocol.supports_resp3() && ctx.supports(&REDIS_VERSION_CE_7_0) {
+    if ctx.protocol.supports_resp3() && ctx.supports(REDIS_VERSION_CE_7_0) {
         // In RESP3 current RedisJSON always gives response in an array.
         assert_eq!(
             json_type_a,

--- a/redis/tests/test_streams.rs
+++ b/redis/tests/test_streams.rs
@@ -794,7 +794,7 @@ fn test_xclaim_last_id() {
 
 #[test]
 fn test_xreadgroup_with_claim_option() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
     let mut con = ctx.connection();
 
     let stream_name = "test_stream";
@@ -895,7 +895,7 @@ fn test_xreadgroup_with_claim_option() {
 
 #[test]
 fn test_xreadgroup_claim_with_idle_and_incoming_messages() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
     let mut con = ctx.connection();
 
     let stream_name = "test_stream_claim_with_idle_and_incoming_messages";
@@ -1026,7 +1026,7 @@ fn test_xreadgroup_claim_with_idle_and_incoming_messages() {
 
 #[test]
 fn test_xreadgroup_claim_multiple_streams() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_4);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_4);
     let mut con = ctx.connection();
 
     let stream1 = "test_stream_claim_multi_1";
@@ -1121,7 +1121,7 @@ fn test_xdel() {
 
 #[test]
 fn test_xadd_options_deletion_policy_keepref() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1206,7 +1206,7 @@ fn test_xadd_options_deletion_policy_keepref() {
 
 #[test]
 fn test_xadd_options_deletion_policy_delref() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1291,7 +1291,7 @@ fn test_xadd_options_deletion_policy_delref() {
 
 #[test]
 fn test_xadd_options_deletion_policy_acked() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1379,7 +1379,7 @@ fn test_xadd_options_deletion_policy_acked() {
 
 #[test]
 fn test_xtrim_options_deletion_policy_keepref() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1450,7 +1450,7 @@ fn test_xtrim_options_deletion_policy_keepref() {
 
 #[test]
 fn test_xtrim_options_deletion_policy_delref() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1521,7 +1521,7 @@ fn test_xtrim_options_deletion_policy_delref() {
 
 #[test]
 fn test_xtrim_options_deletion_policy_acked() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1592,7 +1592,7 @@ fn test_xtrim_options_deletion_policy_acked() {
 
 #[test]
 fn test_xdel_ex() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -1792,7 +1792,7 @@ fn test_xdel_ex() {
 
 #[test]
 fn test_xack_del() {
-    let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_2);
+    let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_2);
     let mut con = ctx.connection();
     let _: () = con.flushdb().unwrap();
 
@@ -2290,7 +2290,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_full_entries() {
         .unwrap();
     assert_eq!(reply.claimed, claimed_entries);
 
-    if ctx.supports(&REDIS_VERSION_CE_7_0) {
+    if ctx.supports(REDIS_VERSION_CE_7_0) {
         assert_eq!(
             reply.deleted_ids,
             vec![claim.id.clone(), claim_1.id.clone()]
@@ -2344,7 +2344,7 @@ fn test_xautoclaim_invalid_pel_entries_claiming_just_ids() {
     std::mem::take(&mut claimed_entries[0].map);
     std::mem::take(&mut claimed_entries[1].map);
 
-    if ctx.supports(&REDIS_VERSION_CE_7_0) {
+    if ctx.supports(REDIS_VERSION_CE_7_0) {
         assert_eq!(reply.claimed, claimed_entries);
         assert_eq!(
             reply.deleted_ids,
@@ -2394,7 +2394,7 @@ mod idempotency_tests {
     #[test]
     fn test_xadd_idempotency_manual_mode() {
         // Test IDMP (manual mode) - prevents messages with the same PID and IID from being added to the stream.
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_idmp_stream";
@@ -2475,7 +2475,7 @@ mod idempotency_tests {
     #[test]
     fn test_xadd_idempotency_automatic_mode() {
         // Test IDMPAUTO (automatic mode) - prevents messages with the same PID and content from being added to the stream.
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_idmpauto_stream";
@@ -2544,7 +2544,7 @@ mod idempotency_tests {
     #[test]
     fn test_xadd_idempotency_with_other_options() {
         // Test that idempotency works correctly with other XADD options
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_idmp_combined_options_stream";
@@ -2695,7 +2695,7 @@ mod idempotency_tests {
 
     #[test]
     fn test_xcfgset() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_xcfgset_stream";
@@ -2784,7 +2784,7 @@ mod idempotency_tests {
 
     #[test]
     fn test_xcfgset_with_idempotent_messages() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_xcfgset_with_idempotent_messages_stream";
@@ -2889,7 +2889,7 @@ mod idempotency_tests {
 
     #[test]
     fn test_xcfgset_idempotency_behavior() {
-        let ctx = run_test_if_version_supported!(&REDIS_VERSION_CE_8_6);
+        let ctx = run_test_if_version_supported!(REDIS_VERSION_CE_8_6);
         let mut con = ctx.connection();
 
         const STREAM_NAME: &str = "test_xcfgset_behavior_stream";

--- a/redis/tests/test_support.rs
+++ b/redis/tests/test_support.rs
@@ -35,7 +35,7 @@ fn support_exact_match() {
     let mock = MockTestContext::new((42, 4711, 23));
 
     // Check for support
-    assert!(mock.supports(&(42, 4711, 23)));
+    assert!(mock.supports((42, 4711, 23)));
 }
 
 /// Tries to assure that `support` correctly handles a smaller major number
@@ -45,7 +45,7 @@ fn support_major_smaller() {
     let mock = MockTestContext::new((42, 4711, 23));
 
     // Check for support
-    assert!(mock.supports(&(41, 4712, 24)));
+    assert!(mock.supports((41, 4712, 24)));
 }
 
 /// Tries to assure that `support` correctly handles a bigger major number
@@ -55,7 +55,7 @@ fn support_major_bigger() {
     let mock = MockTestContext::new((42, 4711, 23));
 
     // Check for support
-    assert!(!mock.supports(&(43, 4710, 22)));
+    assert!(!mock.supports((43, 4710, 22)));
 }
 
 /// Tries to assure that `support` correctly handles a matching major but bigger minor number
@@ -65,7 +65,7 @@ fn support_major_match_minor_smaller() {
     let mock = MockTestContext::new((42, 4711, 23));
 
     // Check for support
-    assert!(mock.supports(&(42, 4710, 24)));
+    assert!(mock.supports((42, 4710, 24)));
 }
 
 /// Tries to assure that `support` correctly handles a matching major but smaller minor number
@@ -75,7 +75,7 @@ fn support_major_match_minor_bigger() {
     let mock = MockTestContext::new((42, 4711, 23));
 
     // Check for support
-    assert!(!mock.supports(&(42, 4712, 22)));
+    assert!(!mock.supports((42, 4712, 22)));
 }
 
 /// Tries to assure that `support` correctly handles a matching major and minor but bigger patch number
@@ -85,7 +85,7 @@ fn support_major_match_minor_match_patch_smaller() {
     let mock = MockTestContext::new((42, 4711, 23));
 
     // Check for support
-    assert!(mock.supports(&(42, 4711, 22)));
+    assert!(mock.supports((42, 4711, 22)));
 }
 
 /// Tries to assure that `support` correctly handles a matching major and minor but smaller patch number
@@ -95,5 +95,5 @@ fn support_major_match_minor_match_patch_bigger() {
     let mock = MockTestContext::new((42, 4711, 23));
 
     // Check for support
-    assert!(!mock.supports(&(42, 4711, 24)));
+    assert!(!mock.supports((42, 4711, 24)));
 }

--- a/redis/tests/test_tls_cert_auth.rs
+++ b/redis/tests/test_tls_cert_auth.rs
@@ -94,7 +94,7 @@ fn test_tls_certificate_authentication_with_matching_acl_user() {
     // based on the Common Name (CN) field in the client's TLS certificate.
 
     // Check Redis binary version before creating the test context.
-    run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+    run_test_if_redis_binary_version_supported!(REDIS_VERSION_CE_8_6);
 
     // Generate a random username for the test.
     let test_username = generate_random_username();
@@ -173,7 +173,7 @@ fn test_tls_certificate_authentication_no_matching_user() {
     // any existing ACL user, Redis falls back to the "default" user.
 
     // Check Redis binary version before creating the test context.
-    run_test_if_redis_binary_version_supported!(&REDIS_VERSION_CE_8_6);
+    run_test_if_redis_binary_version_supported!(REDIS_VERSION_CE_8_6);
 
     // Generate a random username (that won't have a corresponding ACL user).
     let test_username = generate_random_username();


### PR DESCRIPTION
Ownership is not necessary to check version support. But callers of `supports` can automatically get ownership and it frees `supports` calls from the ampersand. This makes the call a bit easier to read as it turns.