### PR TITLE
Add support for the `COUNT` aggregator for sorted sets

### DIFF
--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -1106,7 +1106,8 @@ implement_commands! {
     }
 
     /// Intersect multiple sorted sets and store the resulting sorted set in
-    /// a new key using SUM as aggregation function.
+    /// a new key, optionally applying an `AGGREGATE` modifier.
+    /// If no `AGGREGATE` modifier is provided, `SUM` is used.
     /// [Redis Docs](https://redis.io/commands/ZINTERSTORE)
     fn zinterstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
@@ -1118,6 +1119,34 @@ implement_commands! {
     fn zinterstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
         cmd("ZINTERSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// Intersect multiple sorted sets and return the resulting members,
+    /// applying an optional `AGGREGATE` modifier (SUM by default).
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<String>) {
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg(options).take()
+    }
+
+    /// [`Commands::zinter`], but with the ability to specify a weight for each
+    /// sorted set by pairing each key with its corresponding weight.
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter_with_weights<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<String>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// [`Commands::zinter`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter_withscores<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg(options).arg("WITHSCORES").take()
+    }
+
+    /// [`Commands::zinter_with_weights`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZINTER)
+    fn zinter_with_weights_withscores<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZINTER").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).arg("WITHSCORES").take()
     }
 
     /// Count the number of members in a sorted set between a given lexicographical range.
@@ -1350,19 +1379,48 @@ implement_commands! {
         cmd("ZMSCORE").arg(key).arg(members).take()
     }
 
-    /// Unions multiple sorted sets and store the resulting sorted set in
-    /// a new key using SUM as aggregation function.
+    /// Union multiple sorted sets and store the resulting sorted set in
+    /// a new key, optionally applying an `AGGREGATE` modifier.
+    /// If no `AGGREGATE` modifier is provided, `SUM` is used.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore<D: ToSingleRedisArg, K: ToRedisArgs>(dstkey: D, keys: K, options: SortedSetOperationOptions) -> (usize) {
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg(options).take()
     }
 
-    /// Unions multiple sorted sets and store the resulting sorted set in
+    /// Union multiple sorted sets and store the resulting sorted set in
     /// a new key, applying per-key `WEIGHTS` and an optional `AGGREGATE` modifier.
     /// [Redis Docs](https://redis.io/commands/ZUNIONSTORE)
     fn zunionstore_with_weights<D: ToSingleRedisArg, K: ToRedisArgs, W: ToRedisArgs>(dstkey: D, keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (usize) {
         let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
         cmd("ZUNIONSTORE").arg(dstkey).arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// Union multiple sorted sets and return the resulting members,
+    /// applying an optional `AGGREGATE` modifier (SUM by default).
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<String>) {
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg(options).take()
+    }
+
+    /// [`Commands::zunion`], but with the ability to specify a weight for each
+    /// sorted set by pairing each key with its corresponding weight.
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion_with_weights<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<String>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).take()
+    }
+
+    /// [`Commands::zunion`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion_withscores<K: ToRedisArgs>(keys: K, options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg(options).arg("WITHSCORES").take()
+    }
+
+    /// [`Commands::zunion_with_weights`], but additionally returns the score of each member.
+    /// [Redis Docs](https://redis.io/commands/ZUNION)
+    fn zunion_with_weights_withscores<K: ToRedisArgs, W: ToRedisArgs>(keys: &'a [(K, W)], options: SortedSetOperationOptions) -> (Vec<(String, f64)>) {
+        let (keys, weights): (Vec<&K>, Vec<&W>) = keys.iter().map(|(k, w)| (k, w)).unzip();
+        cmd("ZUNION").arg(keys.num_of_args()).arg(keys).arg("WEIGHTS").arg(weights).arg(options).arg("WITHSCORES").take()
     }
 
     // vector set commands
@@ -3864,8 +3922,9 @@ impl ToRedisArgs for SortedSetAddOptions {
     }
 }
 
-/// Aggregation function used by the `ZINTERSTORE` and `ZUNIONSTORE` commands to
-/// combine the scores of members that appear in more than one input sorted set.
+/// Aggregation function used by the `ZINTERSTORE`, `ZUNIONSTORE`, `ZINTER` and
+/// `ZUNION` commands to combine the scores of members that appear in more than
+/// one input sorted set.
 #[derive(Clone, Copy)]
 #[non_exhaustive]
 pub enum Aggregate {
@@ -3875,6 +3934,12 @@ pub enum Aggregate {
     Min,
     /// Use the maximum score of matching members.
     Max,
+    /// Ignore the input scores and instead sum the per-set weights of the sets
+    /// that contain each member (with default weights of `1`, this is the
+    /// number of input sets that contain the member).
+    ///
+    /// Requires Redis 8.8 or later.
+    Count,
 }
 
 impl ToRedisArgs for Aggregate {
@@ -3886,28 +3951,56 @@ impl ToRedisArgs for Aggregate {
             Aggregate::Sum => b"SUM",
             Aggregate::Min => b"MIN",
             Aggregate::Max => b"MAX",
+            Aggregate::Count => b"COUNT",
         };
         out.write_arg(s);
     }
 }
 
 /// Options for the [ZINTERSTORE](https://redis.io/commands/zinterstore) and
-/// [ZUNIONSTORE](https://redis.io/commands/zunionstore) commands.
+/// [ZUNIONSTORE](https://redis.io/commands/zunionstore) commands and their respective non-store variants
+/// [`ZINTER`](https://redis.io/commands/zinter) and [`ZUNION`](https://redis.io/commands/zunion).
 ///
-/// Controls the optional `AGGREGATE` modifier. For weighted variants use
-/// [`Commands::zinterstore_with_weights`] / [`Commands::zunionstore_with_weights`].
+/// Controls the optional `AGGREGATE` modifier. For weighted operations, use
+/// [`Commands::zinterstore_with_weights`] / [`Commands::zunionstore_with_weights`] or
+/// [`Commands::zinter_with_weights`] / [`Commands::zunion_with_weights`].
+/// The non-store commands also provide
+/// [`Commands::zinter_withscores`] / [`Commands::zunion_withscores`] to return member scores and
+/// [`Commands::zinter_with_weights_withscores`] / [`Commands::zunion_with_weights_withscores`] to return scores for weighted operations.
 ///
 /// # Example
 /// ```rust,no_run
 /// use redis::{Commands, RedisResult, SortedSetOperationOptions, Aggregate};
-/// fn intersect(con: &mut redis::Connection) -> RedisResult<usize> {
+/// fn intersect_and_store(con: &mut redis::Connection) -> RedisResult<usize> {
 ///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default())
 /// }
-/// fn intersect_min(con: &mut redis::Connection) -> RedisResult<usize> {
+/// fn intersect(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter(&["zset1", "zset2"], SortedSetOperationOptions::default())
+/// }
+/// fn intersect_min_and_store(con: &mut redis::Connection) -> RedisResult<usize> {
 ///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
 /// }
-/// fn intersect_weighted(con: &mut redis::Connection) -> RedisResult<usize> {
+/// fn intersect_min(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter(&["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_weighted_and_store(con: &mut redis::Connection) -> RedisResult<usize> {
 ///     con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_weighted(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_min_with_scores(con: &mut redis::Connection) -> RedisResult<Vec<(String, f64)>> {
+///     con.zinter_withscores(&["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// fn intersect_weighted_with_scores(con: &mut redis::Connection) -> RedisResult<Vec<(String, f64)>> {
+///     con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], SortedSetOperationOptions::default().aggregate(Aggregate::Min))
+/// }
+/// // Count the number of input sets each member appears in (Redis 8.8+):
+/// fn store_membership_counts(con: &mut redis::Connection) -> RedisResult<usize> {
+///     con.zinterstore("out", &["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Count))
+/// }
+/// fn membership_counts(con: &mut redis::Connection) -> RedisResult<Vec<String>> {
+///     con.zinter(&["zset1", "zset2"], SortedSetOperationOptions::default().aggregate(Aggregate::Count))
 /// }
 /// ```
 #[derive(Clone, Default)]
@@ -3916,8 +4009,7 @@ pub struct SortedSetOperationOptions {
 }
 
 impl SortedSetOperationOptions {
-    /// Sets the `AGGREGATE` modifier used to combine the scores of members that
-    /// appear in more than one input sorted set.
+    /// Sets the `AGGREGATE` modifier used when combining scores from the input sorted sets.
     pub fn aggregate(mut self, aggregate: Aggregate) -> Self {
         self.aggregate = Some(aggregate);
         self

--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -12,6 +12,7 @@ pub const REDIS_CE_8_0: Component = ("redis", (8, 0, 0));
 pub const REDIS_CE_8_2: Component = ("redis", (8, 1, 240));
 pub const REDIS_CE_8_4: Component = ("redis", (8, 3, 224));
 pub const REDIS_CE_8_6: Component = ("redis", (8, 6, 0));
+pub const REDIS_CE_8_8: Component = ("redis", (8, 8, 0));
 
 pub const REDIS_BLOOM_ANY: Component = ("redis:bf", (0, 0, 0));
 

--- a/redis/tests/test_basic.rs
+++ b/redis/tests/test_basic.rs
@@ -2332,146 +2332,438 @@ mod basic {
     }
 
     #[test]
-    fn test_zinterstore_options() {
+    fn test_zinterstore_zunionstore() {
         let ctx = TestContext::new();
         let mut con = ctx.connection();
 
+        // Shared members (one, two) have different scores in each set so that
+        // SUM, MIN and MAX each produce distinct, obvious results.
         con.zadd_multiple("zset1", &[(1, "one"), (2, "two"), (4, "four")])
             .unwrap();
-        con.zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
+        con.zadd_multiple("zset2", &[(5, "one"), (6, "two"), (3, "three")])
             .unwrap();
 
-        // zinterstore with SUM aggregation (default)
-        assert_eq!(
-            con.zinterstore(
-                "out",
-                &["zset1", "zset2"],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(2)
-        );
+        let sum = || SortedSetOperationOptions::default();
+        let min = || SortedSetOperationOptions::default().aggregate(Aggregate::Min);
+        let max = || SortedSetOperationOptions::default().aggregate(Aggregate::Max);
 
-        // zinterstore with weights
-        assert_eq!(
-            con.zinterstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(2)
-        );
-
+        // ZINTERSTORE (intersection = {one, two}).
+        // Without weights the aggregators combine the raw scores:
+        // SUM one = 1 + 5, two = 2 + 6; MIN/MAX keep the smaller/larger score.
+        assert_eq!(con.zinterstore("out", &["zset1", "zset2"], sum()), Ok(2));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
-            Ok(vec![("one".to_string(), 5.0), ("two".to_string(), 10.0)])
+            Ok(vec![("one".to_string(), 6.0), ("two".to_string(), 8.0)])
         );
-
-        // zinterstore_with_weights with MIN aggregation
-        assert_eq!(
-            con.zinterstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Min)
-            ),
-            Ok(2)
-        );
-
+        assert_eq!(con.zinterstore("out", &["zset1", "zset2"], min()), Ok(2));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
-            Ok(vec![("one".to_string(), 2.0), ("two".to_string(), 4.0),])
+            Ok(vec![("one".to_string(), 1.0), ("two".to_string(), 2.0)])
         );
-
-        // zinterstore_with_weights with MAX aggregation
-        assert_eq!(
-            con.zinterstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Max)
-            ),
-            Ok(2)
-        );
-
+        assert_eq!(con.zinterstore("out", &["zset1", "zset2"], max()), Ok(2));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
-            Ok(vec![("one".to_string(), 3.0), ("two".to_string(), 6.0),])
+            Ok(vec![("one".to_string(), 5.0), ("two".to_string(), 6.0)])
         );
-    }
-
-    #[test]
-    fn test_zunionstore_options() {
-        let ctx = TestContext::new();
-        let mut con = ctx.connection();
-
-        con.zadd_multiple("zset1", &[(1, "one"), (2, "two")])
-            .unwrap();
-        con.zadd_multiple("zset2", &[(1, "one"), (2, "two"), (3, "three")])
-            .unwrap();
-
-        // zunionstore with SUM aggregation (default)
+        // Weights multiply each set's score before aggregating:
+        // one = (1 * 2), (5 * 3); two = (2 * 2), (6 * 3).
         assert_eq!(
-            con.zunionstore(
-                "out",
-                &["zset1", "zset2"],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(3)
+            con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(2)
         );
-
-        // zunionstore with weights
         assert_eq!(
-            con.zunionstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default()
-            ),
-            Ok(3)
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![("one".to_string(), 17.0), ("two".to_string(), 22.0)])
+        );
+        assert_eq!(
+            con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], min()),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![("one".to_string(), 2.0), ("two".to_string(), 4.0)])
+        );
+        assert_eq!(
+            con.zinterstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], max()),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![("one".to_string(), 15.0), ("two".to_string(), 18.0)])
         );
 
+        // ZUNIONSTORE (union = {one, two, three, four}).
+        // three (only in zset2) and four (only in zset1) pass through unchanged.
+        assert_eq!(con.zunionstore("out", &["zset1", "zset2"], sum()), Ok(4));
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
             Ok(vec![
-                ("one".to_string(), 5.0),
-                ("three".to_string(), 9.0),
-                ("two".to_string(), 10.0)
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 6.0),
+                ("two".to_string(), 8.0)
             ])
         );
-
-        // zunionstore_with_weights with MIN aggregation
+        assert_eq!(con.zunionstore("out", &["zset1", "zset2"], min()), Ok(4));
         assert_eq!(
-            con.zunionstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Min)
-            ),
-            Ok(3)
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![
+                ("one".to_string(), 1.0),
+                ("two".to_string(), 2.0),
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0)
+            ])
         );
-
+        assert_eq!(con.zunionstore("out", &["zset1", "zset2"], max()), Ok(4));
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 5.0),
+                ("two".to_string(), 6.0)
+            ])
+        );
+        // Weights (zset1 * 2, zset2 * 3): three = 3 * 3 = 9, four = 4 * 2 = 8.
+        assert_eq!(
+            con.zunionstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(4)
+        );
+        assert_eq!(
+            con.zrange_withscores("out", 0, -1),
+            Ok(vec![
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 17.0),
+                ("two".to_string(), 22.0)
+            ])
+        );
+        assert_eq!(
+            con.zunionstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], min()),
+            Ok(4)
+        );
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
             Ok(vec![
                 ("one".to_string(), 2.0),
                 ("two".to_string(), 4.0),
+                ("four".to_string(), 8.0),
                 ("three".to_string(), 9.0)
             ])
         );
-
-        // zunionstore_with_weights with MAX aggregation
         assert_eq!(
-            con.zunionstore_with_weights(
-                "out",
-                &[("zset1", 2), ("zset2", 3)],
-                SortedSetOperationOptions::default().aggregate(Aggregate::Max)
-            ),
-            Ok(3)
+            con.zunionstore_with_weights("out", &[("zset1", 2), ("zset2", 3)], max()),
+            Ok(4)
         );
-
         assert_eq!(
             con.zrange_withscores("out", 0, -1),
             Ok(vec![
-                ("one".to_string(), 3.0),
-                ("two".to_string(), 6.0),
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 15.0),
+                ("two".to_string(), 18.0)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_zinterstore_zunionstore_count() {
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        let mut con = ctx.connection();
+
+        con.zadd_multiple("s1", &[(1, "foo"), (1, "bar")]).unwrap();
+        con.zadd_multiple("s2", &[(2, "foo"), (2, "bar")]).unwrap();
+        con.zadd_multiple("s3", &[(3, "foo")]).unwrap();
+
+        // With COUNT and no weights, the score is the number of input sets containing the element.
+        // For the intersection, only foo is present and it is in all 3 sets.
+        assert_eq!(
+            con.zinterstore(
+                "t1",
+                &["s1", "s2", "s3"],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(1)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("foo".to_string(), 3.0)])
+        );
+
+        // For the union, foo is in all 3 sets and bar in 2.
+        assert_eq!(
+            con.zunionstore(
+                "t1",
+                &["s1", "s2", "s3"],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("bar".to_string(), 2.0), ("foo".to_string(), 3.0)])
+        );
+
+        // With COUNT and weights, the score is the sum of the weights of the input sets
+        // containing the element, ignoring the original scores.
+        assert_eq!(
+            con.zinterstore_with_weights(
+                "t1",
+                &[("s1", 10), ("s2", 5), ("s3", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(1)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("foo".to_string(), 18.0)])
+        );
+
+        assert_eq!(
+            con.zunionstore_with_weights(
+                "t1",
+                &[("s1", 10), ("s2", 5), ("s3", 3)],
+                SortedSetOperationOptions::default().aggregate(Aggregate::Count)
+            ),
+            Ok(2)
+        );
+        assert_eq!(
+            con.zrange_withscores("t1", 0, -1),
+            Ok(vec![("bar".to_string(), 15.0), ("foo".to_string(), 18.0)])
+        );
+    }
+
+    #[test]
+    fn test_zinter_zunion() {
+        let ctx = TestContext::new();
+        let mut con = ctx.connection();
+
+        // Shared members (one, two) have different scores in each set so that
+        // SUM, MIN and MAX each produce distinct, obvious results.
+        con.zadd_multiple("zset1", &[(1, "one"), (2, "two"), (4, "four")])
+            .unwrap();
+        con.zadd_multiple("zset2", &[(5, "one"), (6, "two"), (3, "three")])
+            .unwrap();
+
+        let sum = || SortedSetOperationOptions::default();
+        let min = || SortedSetOperationOptions::default().aggregate(Aggregate::Min);
+        let max = || SortedSetOperationOptions::default().aggregate(Aggregate::Max);
+
+        // ZINTER (intersection = {one, two})
+        // The intersection is always {one, two} and one always scores below two so the order is stable across aggregators.
+        assert_eq!(
+            con.zinter(&["zset1", "zset2"], sum()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter(&["zset1", "zset2"], min()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter(&["zset1", "zset2"], max()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        assert_eq!(
+            con.zinter_with_weights(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec!["one".to_string(), "two".to_string()])
+        );
+        // With scores:
+        assert_eq!(
+            con.zinter_withscores(&["zset1", "zset2"], sum()),
+            Ok(vec![("one".to_string(), 6.0), ("two".to_string(), 8.0)])
+        );
+        assert_eq!(
+            con.zinter_withscores(&["zset1", "zset2"], min()),
+            Ok(vec![("one".to_string(), 1.0), ("two".to_string(), 2.0)])
+        );
+        assert_eq!(
+            con.zinter_withscores(&["zset1", "zset2"], max()),
+            Ok(vec![("one".to_string(), 5.0), ("two".to_string(), 6.0)])
+        );
+        // Weights multiply each set's score before aggregating:
+        // one = (1 * 2) + (5 * 3)
+        // two = (2 * 2) + (6 * 3)
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec![("one".to_string(), 17.0), ("two".to_string(), 22.0)])
+        );
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec![("one".to_string(), 2.0), ("two".to_string(), 4.0)])
+        );
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec![("one".to_string(), 15.0), ("two".to_string(), 18.0)])
+        );
+
+        // ZUNION (union = {one, two, three, four})
+        // Members only (ordered by resulting score, ties broken lexically).
+        assert_eq!(
+            con.zunion(&["zset1", "zset2"], sum()),
+            Ok(vec![
+                "three".to_string(),
+                "four".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion(&["zset1", "zset2"], min()),
+            Ok(vec![
+                "one".to_string(),
+                "two".to_string(),
+                "three".to_string(),
+                "four".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion(&["zset1", "zset2"], max()),
+            Ok(vec![
+                "three".to_string(),
+                "four".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec![
+                "four".to_string(),
+                "three".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec![
+                "one".to_string(),
+                "two".to_string(),
+                "four".to_string(),
+                "three".to_string()
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec![
+                "four".to_string(),
+                "three".to_string(),
+                "one".to_string(),
+                "two".to_string()
+            ])
+        );
+        // With scores:
+        assert_eq!(
+            con.zunion_withscores(&["zset1", "zset2"], sum()),
+            Ok(vec![
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 6.0),
+                ("two".to_string(), 8.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_withscores(&["zset1", "zset2"], min()),
+            Ok(vec![
+                ("one".to_string(), 1.0),
+                ("two".to_string(), 2.0),
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_withscores(&["zset1", "zset2"], max()),
+            Ok(vec![
+                ("three".to_string(), 3.0),
+                ("four".to_string(), 4.0),
+                ("one".to_string(), 5.0),
+                ("two".to_string(), 6.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], sum()),
+            Ok(vec![
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 17.0),
+                ("two".to_string(), 22.0)
+            ])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], min()),
+            Ok(vec![
+                ("one".to_string(), 2.0),
+                ("two".to_string(), 4.0),
+                ("four".to_string(), 8.0),
                 ("three".to_string(), 9.0)
             ])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("zset1", 2), ("zset2", 3)], max()),
+            Ok(vec![
+                ("four".to_string(), 8.0),
+                ("three".to_string(), 9.0),
+                ("one".to_string(), 15.0),
+                ("two".to_string(), 18.0)
+            ])
+        );
+    }
+
+    #[test]
+    fn test_zinter_zunion_count() {
+        let ctx = run_test_if_version_supported!(REDIS_CE_8_8);
+        let mut con = ctx.connection();
+
+        con.zadd_multiple("s1", &[(1, "foo"), (1, "bar")]).unwrap();
+        con.zadd_multiple("s2", &[(2, "foo"), (2, "bar")]).unwrap();
+        con.zadd_multiple("s3", &[(3, "foo")]).unwrap();
+
+        let count = || SortedSetOperationOptions::default().aggregate(Aggregate::Count);
+
+        // COUNT with no weights = number of input sets containing the element.
+        assert_eq!(
+            con.zinter(&["s1", "s2", "s3"], count()),
+            Ok(vec!["foo".to_string()])
+        );
+        assert_eq!(
+            con.zunion(&["s1", "s2", "s3"], count()),
+            Ok(vec!["bar".to_string(), "foo".to_string()])
+        );
+        // With scores.
+        assert_eq!(
+            con.zinter_withscores(&["s1", "s2", "s3"], count()),
+            Ok(vec![("foo".to_string(), 3.0)])
+        );
+        assert_eq!(
+            con.zunion_withscores(&["s1", "s2", "s3"], count()),
+            Ok(vec![("bar".to_string(), 2.0), ("foo".to_string(), 3.0)])
+        );
+
+        // COUNT with weights = sum of weights of the sets containing the element.
+        assert_eq!(
+            con.zinter_with_weights(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec!["foo".to_string()])
+        );
+        assert_eq!(
+            con.zunion_with_weights(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec!["bar".to_string(), "foo".to_string()])
+        );
+        // With scores.
+        assert_eq!(
+            con.zinter_with_weights_withscores(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec![("foo".to_string(), 18.0)])
+        );
+        assert_eq!(
+            con.zunion_with_weights_withscores(&[("s1", 10), ("s2", 5), ("s3", 3)], count()),
+            Ok(vec![("bar".to_string(), 15.0), ("foo".to_string(), 18.0)])
         );
     }
 


### PR DESCRIPTION
# Add support for the `COUNT` aggregator to sorted set intersection/union commands

## Summary

Introduce the missing `ZINTER` / `ZUNION` commands.

Add support for the `COUNT` aggregator (new in **Redis 8.8**) to the existing set operation commands (**`ZINTERSTORE` / `ZUNIONSTORE`**)

## Background - what is the COUNT aggregator?

`ZUNIONSTORE` / `ZINTERSTORE` / `ZUNION` / `ZINTER` combine sorted sets and compute each output element's score by aggregating its per-input scores.

Until version 8.8 the aggregator was one of:

| Aggregator | Output score for an element |
|------------|-----------------------------|
| `SUM` (default) | `Σ (score × weight)` over the input sets containing it |
| `MIN` | `min(score × weight)` |
| `MAX` | `max(score × weight)` |

These all operate on the **stored scores**.
A common need is to score an element purely by **how many input sets contain it** (e.g. "for each player, the number of leaderboards they appear on"), ignoring the stored scores entirely.

Redis 8.8 adds `COUNT` for exactly this. It ignores the input scores and sums the **weights** instead (default weight `1`):

| Mode | Output score for an element |
|------|-----------------------------|
| `COUNT` without `WEIGHTS` | number of input sets that contain it |
| `COUNT` with `WEIGHTS` | sum of the weights of the input sets that contain it |

For an **intersection**, the element is by definition in every input set, so the no-weights score equals the number of input keys.

### Example
Input:
```
s1 = { foo: 1, bar: 1 }
s2 = { foo: 2, bar: 2 }
s3 = { foo: 3 }
```
Command and resulting sorted set:
```
ZUNIONSTORE t1 3 s1 s2 s3 AGGREGATE COUNT
  -> bar: 2, foo: 3                      (membership count)

ZINTERSTORE t1 3 s1 s2 s3 AGGREGATE COUNT
  -> foo: 3                              (foo is the only common element)

ZUNIONSTORE t1 3 s1 s2 s3 WEIGHTS 10 5 3 AGGREGATE COUNT
  -> bar: 15, foo: 18                    (Σ weights of containing sets)

ZINTERSTORE t1 3 s1 s2 s3 WEIGHTS 10 5 3 AGGREGATE COUNT
  -> foo: 18
```

Before this command-level support, the only way to get this was the documented workaround: 
Copy each set with all scores rewritten to `1`, then `ZUNIONSTORE` with `SUM`. `COUNT` removes that entirely.

## Testing

| Test | Gating | Covers |
|------|--------|--------|
| `test_zinterstore_zunionstore` | none | `sum`, `min` and `max` aggregators, weighted and uweighted variants |
| `test_zinterstore_zunionstore_count` | 8.8 | the new `COUNT `aggregator for `zinterstore` /`zunionstore` |
| `test_zinter_zunion` | none | `sum`, `min` and `max` aggregators, weighted and unweighted variants, members only and `WITHSCORES` |
| `test_zinter_zunion_count` | 8.8 | the new `COUNT` aggregator for `zinter` / `zunion` |

## Relevant documentation:
ZINTER - https://redis.io/docs/latest/commands/zinter/
ZUNION - https://redis.io/docs/latest/commands/zunion/
ZINTERSTORE - https://redis.io/docs/latest/commands/zinterstore/
ZUNIONSTORE - https://redis.io/docs/latest/commands/zunionstore/