### PR TITLE
feat(cluster): add node address map for TLS hostname remapping

### DIFF
--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -4,7 +4,9 @@ use tempfile::TempDir;
 
 use crate::{
     server::{Module, RedisServer},
-    utils::{TlsFilePaths, build_keys_and_certs_for_tls_ext, get_random_available_port},
+    utils::{
+        TlsFilePaths, build_keys_and_certs_for_tls_with_hostname, get_random_available_port,
+    },
 };
 
 /// Configuration for creating a Redis Cluster.
@@ -22,6 +24,8 @@ pub struct RedisClusterConfiguration {
     /// value greater than `1` requires a server that supports numbered databases
     /// in cluster mode (Valkey 9.0+); older servers fail to start with this flag.
     pub cluster_databases: Option<u16>,
+    /// Custom DNS hostname for TLS certificate SAN (used when `certs_with_ip_alts` is false).
+    pub dns_hostname: Option<String>,
 }
 
 impl RedisClusterConfiguration {
@@ -45,6 +49,7 @@ impl Default for RedisClusterConfiguration {
             ports: vec![],
             certs_with_ip_alts: true,
             cluster_databases: None,
+            dns_hostname: None,
         }
     }
 }
@@ -140,6 +145,7 @@ impl RedisCluster {
             ports,
             certs_with_ip_alts,
             cluster_databases,
+            dns_hostname,
         } = configuration;
 
         let optional_ports = if ports.is_empty() {
@@ -162,7 +168,11 @@ impl RedisCluster {
                 .prefix("redis")
                 .tempdir()
                 .expect("failed to create tempdir");
-            let files = build_keys_and_certs_for_tls_ext(&tempdir, certs_with_ip_alts);
+            let files = build_keys_and_certs_for_tls_with_hostname(
+                &tempdir,
+                certs_with_ip_alts,
+                dns_hostname.as_deref(),
+            );
             folders.push(tempdir);
             tls_paths = Some(files);
             is_tls = true;

--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -4,9 +4,7 @@ use tempfile::TempDir;
 
 use crate::{
     server::{Module, RedisServer},
-    utils::{
-        TlsFilePaths, build_keys_and_certs_for_tls_with_hostname, get_random_available_port,
-    },
+    utils::{TlsFilePaths, build_keys_and_certs_for_tls_with_hostname, get_random_available_port},
 };
 
 /// Configuration for creating a Redis Cluster.

--- a/redis-test/src/utils.rs
+++ b/redis-test/src/utils.rs
@@ -97,7 +97,7 @@ pub fn build_keys_and_certs_for_tls_with_hostname(
             [alt_names]\n\
             IP.1 = 127.0.0.1\n\
             "
-            .to_string()
+        .to_string()
     } else {
         format!(
             "\

--- a/redis-test/src/utils.rs
+++ b/redis-test/src/utils.rs
@@ -24,6 +24,14 @@ pub fn build_keys_and_certs_for_tls(tempdir: &TempDir) -> TlsFilePaths {
 }
 
 pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -> TlsFilePaths {
+    build_keys_and_certs_for_tls_with_hostname(tempdir, with_ip_alts, None)
+}
+
+pub fn build_keys_and_certs_for_tls_with_hostname(
+    tempdir: &TempDir,
+    with_ip_alts: bool,
+    dns_hostname: Option<&str>,
+) -> TlsFilePaths {
     // Based on shell script in redis's server tests
     // https://github.com/redis/redis/blob/8c291b97b95f2e011977b522acf77ead23e26f55/utils/gen-test-certs.sh
     let ca_crt = tempdir.path().join("ca.crt");
@@ -79,6 +87,8 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
         "`openssl req` failed to create CA cert: {status}"
     );
 
+    let hostname = dns_hostname.unwrap_or("localhost.example.com");
+
     // Build x509v3 extensions file
     let ext = if with_ip_alts {
         "\
@@ -87,15 +97,17 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
             [alt_names]\n\
             IP.1 = 127.0.0.1\n\
             "
+            .to_string()
     } else {
-        "\
+        format!(
+            "\
             [req]\n\
             distinguished_name = req_distinguished_name\n\
             x509_extensions = v3_req\n\
             prompt = no\n\
             \n\
             [req_distinguished_name]\n\
-            CN = localhost.example.com\n\
+            CN = {hostname}\n\
             \n\
             [v3_req]\n\
             basicConstraints = CA:FALSE\n\
@@ -103,8 +115,9 @@ pub fn build_keys_and_certs_for_tls_ext(tempdir: &TempDir, with_ip_alts: bool) -
             subjectAltName = @alt_names\n\
             \n\
             [alt_names]\n\
-            DNS.1 = localhost.example.com\n\
+            DNS.1 = {hostname}\n\
             "
+        )
     };
     fs::write(&ext_file, ext).expect("failed to create x509v3 extensions file");
 

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -6,6 +6,7 @@ use crate::auth::StreamingCredentialsProvider;
 use crate::caching::{CacheConfig, CacheManager};
 use crate::client::DEFAULT_CONNECTION_TIMEOUT;
 use crate::cluster_handling::read_routing::{RandomReplicaStrategy, ReadRoutingStrategyFactory};
+use crate::cluster_handling::NodeAddress;
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::errors::{ErrorKind, RedisError};
 #[cfg(feature = "cluster-async")]
@@ -15,6 +16,7 @@ use crate::types::{ProtocolVersion, RedisResult};
 use crate::{TlsMode, cluster};
 use arcstr::ArcStr;
 use rand::RngExt;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -71,6 +73,7 @@ struct BuilderParams {
     connection_concurrency_limit: Option<usize>,
     #[cfg(feature = "cluster-async")]
     write_backpressure_boundary: Option<usize>,
+    node_address_map: Option<HashMap<NodeAddress, NodeAddress>>,
 }
 
 #[derive(Clone)]
@@ -159,6 +162,7 @@ pub(crate) struct ClusterParams {
     pub(crate) connection_concurrency_limit: Option<usize>,
     #[cfg(feature = "cluster-async")]
     pub(crate) write_backpressure_boundary: Option<usize>,
+    pub(crate) node_address_map: Option<HashMap<NodeAddress, NodeAddress>>,
 }
 
 impl ClusterParams {
@@ -225,6 +229,7 @@ impl ClusterParams {
             connection_concurrency_limit: value.connection_concurrency_limit,
             #[cfg(feature = "cluster-async")]
             write_backpressure_boundary: value.write_backpressure_boundary,
+            node_address_map: value.node_address_map,
         })
     }
 
@@ -634,6 +639,25 @@ impl ClusterClientBuilder {
     /// Set the behavior of the underlying TCP connections.
     pub fn tcp_settings(mut self, tcp_settings: TcpSettings) -> ClusterClientBuilder {
         self.builder_params.tcp_settings = tcp_settings;
+        self
+    }
+
+    /// Sets a node address map for remapping cluster node addresses.
+    ///
+    /// In TLS-enabled clusters, nodes may advertise IP addresses via `CLUSTER SLOTS`,
+    /// but TLS certificates are issued for domain names. This causes TLS verification
+    /// to fail because the certificate's Subject Alternative Names don't include
+    /// the IP address.
+    ///
+    /// The node address map lets you provide a mapping from the IP-based addresses
+    /// returned by `CLUSTER SLOTS` to the hostnames that match the TLS certificates.
+    /// The mapping is applied at connection time only — the internal slot map retains
+    /// the original addresses so that `MOVED`/`ASK` redirects continue to work.
+    pub fn node_address_map(
+        mut self,
+        map: HashMap<NodeAddress, NodeAddress>,
+    ) -> ClusterClientBuilder {
+        self.builder_params.node_address_map = Some(map);
         self
     }
 

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -5,8 +5,8 @@ use crate::auth::StreamingCredentialsProvider;
 #[cfg(all(feature = "cache-aio", feature = "cluster-async"))]
 use crate::caching::{CacheConfig, CacheManager};
 use crate::client::DEFAULT_CONNECTION_TIMEOUT;
-use crate::cluster_handling::read_routing::{RandomReplicaStrategy, ReadRoutingStrategyFactory};
 use crate::cluster_handling::NodeAddress;
+use crate::cluster_handling::read_routing::{RandomReplicaStrategy, ReadRoutingStrategyFactory};
 use crate::connection::{ConnectionAddr, ConnectionInfo, IntoConnectionInfo};
 use crate::errors::{ErrorKind, RedisError};
 #[cfg(feature = "cluster-async")]

--- a/redis/src/cluster_handling/mod.rs
+++ b/redis/src/cluster_handling/mod.rs
@@ -159,10 +159,18 @@ pub(crate) fn get_connection_info(
     node: &NodeAddress,
     cluster_params: &ClusterParams,
 ) -> ConnectionInfo {
+    let mapped = cluster_params
+        .node_address_map
+        .as_ref()
+        .and_then(|map| map.get(node));
+    let (host, port) = match mapped {
+        Some(addr) => (addr.host().to_string(), addr.port()),
+        None => (node.host().to_string(), node.port()),
+    };
     ConnectionInfo {
         addr: get_connection_addr(
-            node.host().to_string(),
-            node.port(),
+            host,
+            port,
             cluster_params.tls,
             cluster_params.tls_params.clone(),
         ),

--- a/redis/src/cluster_handling/mod.rs
+++ b/redis/src/cluster_handling/mod.rs
@@ -219,4 +219,66 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn get_connection_info_uses_node_address_map() {
+        let node = NodeAddress::new("10.0.0.1", 8501);
+        let mapped = NodeAddress::new("node1.westeurope.redis.azure.net", 8501);
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(node.clone(), mapped.clone());
+
+        let params = ClusterParams {
+            node_address_map: Some(map),
+            ..Default::default()
+        };
+
+        let info = get_connection_info(&node, &params);
+        match info.addr {
+            ConnectionAddr::Tcp(host, port) => {
+                assert_eq!(host, "node1.westeurope.redis.azure.net");
+                assert_eq!(port, 8501);
+            }
+            _ => panic!("expected Tcp connection addr"),
+        }
+    }
+
+    #[test]
+    fn get_connection_info_falls_back_without_mapping() {
+        let node = NodeAddress::new("10.0.0.1", 8501);
+        let other = NodeAddress::new("10.0.0.2", 8501);
+        let mapped = NodeAddress::new("node2.westeurope.redis.azure.net", 8501);
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(other, mapped);
+
+        let params = ClusterParams {
+            node_address_map: Some(map),
+            ..Default::default()
+        };
+
+        let info = get_connection_info(&node, &params);
+        match info.addr {
+            ConnectionAddr::Tcp(host, port) => {
+                assert_eq!(host, "10.0.0.1");
+                assert_eq!(port, 8501);
+            }
+            _ => panic!("expected Tcp connection addr"),
+        }
+    }
+
+    #[test]
+    fn get_connection_info_without_map() {
+        let node = NodeAddress::new("10.0.0.1", 6379);
+        let params = ClusterParams::default();
+
+        let info = get_connection_info(&node, &params);
+        match info.addr {
+            ConnectionAddr::Tcp(host, port) => {
+                assert_eq!(host, "10.0.0.1");
+                assert_eq!(port, 6379);
+            }
+            _ => panic!("expected Tcp connection addr"),
+        }
+    }
 }

--- a/redis/tests/support/mod.rs
+++ b/redis/tests/support/mod.rs
@@ -474,7 +474,7 @@ where
 }
 
 #[cfg(feature = "tls-rustls")]
-fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
+pub fn load_certs_from_file(tls_file_paths: &TlsFilePaths) -> TlsCertificates {
     let ca_file = File::open(&tls_file_paths.ca_crt).expect("Cannot open CA cert file");
     let mut root_cert_vec = Vec::new();
     BufReader::new(ca_file)

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -1231,4 +1231,97 @@ mod cluster {
             }
         }
     }
+
+    #[test]
+    fn test_cluster_node_address_map_remaps_connections() {
+        let cluster = TestClusterContext::new();
+
+        let mut address_map = std::collections::HashMap::new();
+        for server in cluster.cluster.iter_servers() {
+            if let Some((host, port)) = server.host_and_port() {
+                let original = redis::cluster::NodeAddress::new(host, port);
+                let mapped = redis::cluster::NodeAddress::new("localhost", port);
+                address_map.insert(original, mapped);
+            }
+        }
+
+        let initial_nodes: Vec<redis::ConnectionInfo> = cluster
+            .cluster
+            .iter_servers()
+            .map(|s| s.connection_info())
+            .collect();
+
+        let client = redis::cluster::ClusterClient::builder(initial_nodes)
+            .use_protocol(use_protocol())
+            .node_address_map(address_map)
+            .build()
+            .unwrap();
+
+        let mut con = client.get_connection().unwrap();
+
+        redis::cmd("SET")
+            .arg("{x}key1")
+            .arg(b"foo")
+            .exec(&mut con)
+            .unwrap();
+        redis::cmd("SET")
+            .arg(&["{x}key2", "bar"])
+            .exec(&mut con)
+            .unwrap();
+
+        assert_eq!(
+            redis::cmd("MGET")
+                .arg(&["{x}key1", "{x}key2"])
+                .query(&mut con),
+            Ok(("foo".to_string(), b"bar".to_vec()))
+        );
+    }
+
+    #[cfg(feature = "tls-rustls")]
+    #[test]
+    fn test_cluster_node_address_map_fixes_tls_hostname_mismatch() {
+        use redis_test::cluster::ClusterType;
+
+        if ClusterType::get_intended() != ClusterType::TcpTls {
+            return;
+        }
+
+        // Certs issued for "localhost" only (no IP SAN), so connecting via
+        // 127.0.0.1 will fail TLS verification without node_address_map.
+        let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
+            tls_insecure: false,
+            certs_with_ip_alts: false,
+            dns_hostname: Some("localhost".to_string()),
+            ..Default::default()
+        });
+
+        assert!(cluster.client.get_connection().is_err());
+
+        let mut address_map = std::collections::HashMap::new();
+        for server in cluster.cluster.iter_servers() {
+            if let Some((host, port)) = server.host_and_port() {
+                address_map.insert(
+                    redis::cluster::NodeAddress::new(host, port),
+                    redis::cluster::NodeAddress::new("localhost", port),
+                );
+            }
+        }
+
+        let initial_nodes: Vec<redis::ConnectionInfo> = cluster
+            .cluster
+            .iter_servers()
+            .map(|s| s.connection_info())
+            .collect();
+
+        let mut builder = redis::cluster::ClusterClient::builder(initial_nodes)
+            .use_protocol(use_protocol())
+            .node_address_map(address_map);
+
+        if let Some(tls_file_paths) = &cluster.cluster.tls_paths {
+            builder = builder.certs(load_certs_from_file(tls_file_paths));
+        }
+
+        let client = builder.build().unwrap();
+        smoke_test_connection(client.get_connection().unwrap());
+    }
 }

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -1295,7 +1295,19 @@ mod cluster {
             ..Default::default()
         });
 
-        assert!(cluster.client.get_connection().is_err());
+        let err = match cluster.client.get_connection() {
+            Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),
+            Err(err) => err,
+        };
+        assert!(
+            err.is_io_error(),
+            "expected a TLS/IO error from hostname verification failure, got: {err:?}"
+        );
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("certificate") || err_string.contains("NotValidForName"),
+            "expected a certificate hostname verification error, got: {err_string}"
+        );
 
         let mut address_map = std::collections::HashMap::new();
         for server in cluster.cluster.iter_servers() {

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -513,6 +513,55 @@ mod cluster_async {
         smoke_test_connection(connection).await;
     }
 
+    #[cfg(feature = "tls-rustls")]
+    #[async_test]
+    async fn async_cluster_node_address_map_fixes_tls_hostname_mismatch() {
+        use redis_test::cluster::ClusterType;
+
+        if ClusterType::get_intended() != ClusterType::TcpTls {
+            return;
+        }
+
+        // Certs issued for "localhost" only (no IP SAN), so connecting via
+        // 127.0.0.1 will fail TLS verification without node_address_map.
+        let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
+            tls_insecure: false,
+            certs_with_ip_alts: false,
+            dns_hostname: Some("localhost".to_string()),
+            ..Default::default()
+        });
+
+        assert!(cluster.client.get_async_connection().await.is_err());
+
+        let mut address_map = HashMap::new();
+        for server in cluster.cluster.iter_servers() {
+            if let Some((host, port)) = server.host_and_port() {
+                address_map.insert(
+                    redis::cluster::NodeAddress::new(host, port),
+                    redis::cluster::NodeAddress::new("localhost", port),
+                );
+            }
+        }
+
+        let initial_nodes: Vec<redis::ConnectionInfo> = cluster
+            .cluster
+            .iter_servers()
+            .map(|s| s.connection_info())
+            .collect();
+
+        let mut builder = ClusterClient::builder(initial_nodes)
+            .use_protocol(use_protocol())
+            .node_address_map(address_map);
+
+        if let Some(tls_file_paths) = &cluster.cluster.tls_paths {
+            builder = builder.certs(load_certs_from_file(tls_file_paths));
+        }
+
+        let client = builder.build().unwrap();
+        let connection = client.get_async_connection().await.unwrap();
+        smoke_test_connection(connection).await;
+    }
+
     #[async_test]
     async fn test_async_cluster_basic_failover() {
         test_failover(

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -531,7 +531,19 @@ mod cluster_async {
             ..Default::default()
         });
 
-        assert!(cluster.client.get_async_connection().await.is_err());
+        let err = match cluster.client.get_async_connection().await {
+            Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),
+            Err(err) => err,
+        };
+        assert!(
+            err.is_io_error(),
+            "expected a TLS/IO error from hostname verification failure, got: {err:?}"
+        );
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("certificate") || err_string.contains("NotValidForName"),
+            "expected a certificate hostname verification error, got: {err_string}"
+        );
 
         let mut address_map = HashMap::new();
         for server in cluster.cluster.iter_servers() {


### PR DESCRIPTION
In TLS-enabled clusters, CLUSTER SLOTS returns IP addresses but TLS certificates are issued for domain names, causing verification to fail. This adds a node_address_map option to ClusterClientBuilder that lets users provide IP-to-hostname mappings applied at connection time.

Closes #1963