### PR TITLE
[V2] Flatten Pipeline storage to reduce allocations and fragmentation

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -223,6 +223,10 @@ name = "test_tls_cert_auth"
 required-features = ["acl", "tls-rustls", "tokio-rustls-comp", "cluster"]
 
 [[bench]]
+name = "bench_pipeline_build"
+harness = false
+
+[[bench]]
 name = "bench_basic"
 harness = false
 required-features = ["tokio-comp"]

--- a/redis/benches/bench_pipeline_build.rs
+++ b/redis/benches/bench_pipeline_build.rs
@@ -1,0 +1,172 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+const N: usize = 1_000;
+
+// Builds an empty pipeline with capacity pre-reserved for the expected command, argument, and
+// argument-byte counts. This is the ONE spot that differs between the old and new layouts: the
+// new layout reserves each buffer via `reserve_for_*`, while the old layout only had
+// `with_capacity(command_count)`. Keeping the bench function names identical lets criterion
+// compare them directly.
+fn preallocated_pipe(commands: usize, args: usize, data: usize) -> redis::Pipeline {
+    let mut pipe = redis::pipe();
+    pipe.reserve_for_commands(commands)
+        .reserve_for_args(args)
+        .reserve_for_data(data);
+    pipe
+}
+
+// Create and populate a pipeline with N simple commands.
+fn bench_build_pipeline(c: &mut Criterion) {
+    c.bench_function("build_pipeline", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(&pipe);
+        });
+    });
+}
+
+// Create and populate a pipeline with N multi-arg commands.
+fn bench_build_pipeline_nested(c: &mut Criterion) {
+    c.bench_function("build_pipeline_nested", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            for _ in 0..N / 5 {
+                pipe.cmd("MSET")
+                    .arg(&[
+                        ("foo1", &b"bar"[..]),
+                        ("foo2", &b"123"[..]),
+                        ("foo3", &b"1231279712"[..]),
+                        ("foo4", &b"test"[..]),
+                    ])
+                    .ignore();
+            }
+            black_box(&pipe);
+        });
+    });
+}
+
+// Write the packed command bytes for a pre-built pipeline.
+fn bench_packed_pipeline(c: &mut Criterion) {
+    let mut pipe = redis::pipe();
+    for _ in 0..N {
+        pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+    }
+    c.bench_function("packed_pipeline", |b| {
+        b.iter(|| black_box(pipe.get_packed_pipeline()));
+    });
+}
+
+// End-to-end: create, populate, and write the packed command in one go. This is the realistic
+// per-request cost, and verifies the net change is positive across both phases.
+fn bench_build_and_pack(c: &mut Criterion) {
+    c.bench_function("build_and_pack", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+// Create and populate a pipeline whose buffers were pre-allocated up front. Compared against the
+// default `build_pipeline`, this isolates the benefit of reserving capacity; compared across the
+// old/new layouts, it pits the old `with_capacity` against the new `reserve_for_*`.
+fn bench_build_pipeline_preallocated(c: &mut Criterion) {
+    c.bench_function("build_pipeline_preallocated", |b| {
+        b.iter(|| {
+            let mut pipe = preallocated_pipe(N, N * 3, N * 16);
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(&pipe);
+        });
+    });
+}
+
+// End-to-end with pre-allocated buffers: create, populate, and write the packed command.
+fn bench_build_and_pack_preallocated(c: &mut Criterion) {
+    c.bench_function("build_and_pack_preallocated", |b| {
+        b.iter(|| {
+            let mut pipe = preallocated_pipe(N, N * 3, N * 16);
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+// Write the packed command bytes for a pre-built atomic (MULTI/EXEC) pipeline.
+fn bench_packed_pipeline_atomic(c: &mut Criterion) {
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+    for _ in 0..N {
+        pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+    }
+    c.bench_function("packed_pipeline_atomic", |b| {
+        b.iter(|| black_box(pipe.get_packed_pipeline()));
+    });
+}
+
+// End-to-end for an atomic pipeline: create, populate, and write the packed command in one go.
+fn bench_build_and_pack_atomic(c: &mut Criterion) {
+    c.bench_function("build_and_pack_atomic", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            pipe.atomic();
+            for _ in 0..N {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+// A small atomic pipeline — the realistic transaction size, where the fixed cost of the
+// MULTI/EXEC wrapper is a meaningful fraction of the work.
+const N_SMALL: usize = 5;
+
+fn bench_packed_pipeline_atomic_small(c: &mut Criterion) {
+    let mut pipe = redis::pipe();
+    pipe.atomic();
+    for _ in 0..N_SMALL {
+        pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+    }
+    c.bench_function("packed_pipeline_atomic_small", |b| {
+        b.iter(|| black_box(pipe.get_packed_pipeline()));
+    });
+}
+
+fn bench_build_and_pack_atomic_small(c: &mut Criterion) {
+    c.bench_function("build_and_pack_atomic_small", |b| {
+        b.iter(|| {
+            let mut pipe = redis::pipe();
+            pipe.atomic();
+            for _ in 0..N_SMALL {
+                pipe.cmd("SET").arg("some_key").arg(42i64).ignore();
+            }
+            black_box(pipe.get_packed_pipeline())
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_build_pipeline,
+    bench_build_pipeline_nested,
+    bench_build_pipeline_preallocated,
+    bench_packed_pipeline,
+    bench_build_and_pack,
+    bench_build_and_pack_preallocated,
+    bench_packed_pipeline_atomic,
+    bench_build_and_pack_atomic,
+    bench_packed_pipeline_atomic_small,
+    bench_build_and_pack_atomic_small
+);
+criterion_main!(benches);

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -741,7 +741,7 @@ impl MultiplexedConnection {
         };
         #[cfg(feature = "cache-aio")]
         if let Some(cache_manager) = &self.cache_manager {
-            match cache_manager.get_cached_cmd(cmd) {
+            match cache_manager.get_cached_cmd(crate::cmd::CmdRef::from_cmd(cmd)) {
                 PrepareCacheResult::Cached(value) => return Ok(value),
                 PrepareCacheResult::NotCached(cacheable_command) => {
                     let mut pipeline = crate::Pipeline::new();
@@ -753,7 +753,7 @@ impl MultiplexedConnection {
                             pipeline.get_packed_pipeline(),
                             Some(PipelineResponseExpectation {
                                 skipped_response_count: 0,
-                                expected_response_count: pipeline.commands.len(),
+                                expected_response_count: pipeline.len(),
                                 is_transaction: false,
                                 seen_responses: 0,
                             }),

--- a/redis/src/caching/cache_manager.rs
+++ b/redis/src/caching/cache_manager.rs
@@ -1,7 +1,7 @@
 use super::cmd::{CacheableCommand, CacheablePipeline, MultipleCachedCommandPart};
 use super::sharded_lru::*;
 use super::{CacheConfig, CacheMode, CacheStatistics};
-use crate::cmd::{Cmd, cmd_len};
+use crate::cmd::CmdRef;
 use crate::{FromRedisValue, Pipeline, PushKind, Value};
 use std::cmp::min;
 use std::ops::Add;
@@ -84,7 +84,7 @@ impl CacheManager {
         }
     }
 
-    pub(crate) fn get_cached_cmd<'a>(&self, cmd: &'a Cmd) -> PrepareCacheResult<'a> {
+    pub(crate) fn get_cached_cmd<'a>(&self, cmd: CmdRef<'a>) -> PrepareCacheResult<'a> {
         match self.cache_config.mode {
             CacheMode::All => self.get_cached_cmd_inner(cmd),
             CacheMode::OptIn => {
@@ -101,7 +101,7 @@ impl CacheManager {
         }
     }
 
-    fn calculate_expiration_time(&self, cmd: &Cmd) -> Instant {
+    fn calculate_expiration_time(&self, cmd: CmdRef<'_>) -> Instant {
         let client_side_ttl = cmd
             .get_cache_config()
             .as_ref()
@@ -126,7 +126,7 @@ impl CacheManager {
         }
     }
 
-    fn extract_simple_arguments<'a>(&self, cmd: &'a Cmd) -> Vec<&'a [u8]> {
+    fn extract_simple_arguments<'a>(&self, cmd: CmdRef<'a>) -> Vec<&'a [u8]> {
         cmd.args_iter()
             .skip(1) // Skip the command name
             .filter_map(|arg| match arg {
@@ -138,7 +138,7 @@ impl CacheManager {
 
     fn process_multi_key_arguments<'a>(
         &self,
-        cmd: &'a Cmd,
+        cmd: CmdRef<'a>,
         is_json_command: bool,
         single_command_name: &[u8],
         commands: &mut Vec<(usize, MultipleCachedCommandPart<'a>)>,
@@ -177,7 +177,7 @@ impl CacheManager {
 
     fn handle_multi_key_command<'a>(
         &self,
-        cmd: &'a Cmd,
+        cmd: CmdRef<'a>,
         command_name_str: &'a str,
         single_command_name: &[u8],
         client_side_expire: Instant,
@@ -212,7 +212,7 @@ impl CacheManager {
 
     fn handle_single_key_command<'a>(
         &self,
-        cmd: &'a Cmd,
+        cmd: CmdRef<'a>,
         client_side_expire: Instant,
     ) -> PrepareCacheResult<'a> {
         let redis_key = match cmd.arg_idx(1) {
@@ -220,7 +220,7 @@ impl CacheManager {
             None => return PrepareCacheResult::NotCacheable,
         };
 
-        let cmd_key = cmd.data.as_slice();
+        let cmd_key = cmd.data();
 
         if let Some(value) = self.get(redis_key, cmd_key) {
             return PrepareCacheResult::Cached(value);
@@ -241,8 +241,8 @@ impl CacheManager {
     /// If there isn't enough information in cache but Cmd is cacheable then packs enough information
     /// into CacheableCommand and returns PrepareCacheResult::NotCached.
     /// If Cmd doesn't support client side caching then it returns PrepareCacheResult::NotCacheable.
-    fn get_cached_cmd_inner<'a>(&self, cmd: &'a Cmd) -> PrepareCacheResult<'a> {
-        if cmd_len(cmd) < 2 {
+    fn get_cached_cmd_inner<'a>(&self, cmd: CmdRef<'a>) -> PrepareCacheResult<'a> {
+        if cmd.encoded_len() < 2 {
             return PrepareCacheResult::NotCacheable;
         }
 
@@ -279,10 +279,10 @@ impl CacheManager {
         let transaction_mode = requested_pipeline.transaction_mode;
         let mut packed_pipeline = Pipeline::new();
 
-        for (idx, cmd) in requested_pipeline.commands.iter().enumerate() {
-            if requested_pipeline.ignored_commands.contains(&idx) {
+        for cmd in requested_pipeline.cmd_iter() {
+            if cmd.is_ignored() {
                 commands.push(PrepareCacheResult::Ignored);
-                packed_pipeline.add_command(cmd.clone());
+                packed_pipeline.add_command_ref(cmd);
                 continue;
             }
             let cacheable_command = self.get_cached_cmd(cmd);
@@ -293,7 +293,7 @@ impl CacheManager {
                 }
                 PrepareCacheResult::NotCacheable => {
                     // It must be added to packed_pipeline manually, since it's not packed via pack_command.
-                    packed_pipeline.add_command(cmd.clone());
+                    packed_pipeline.add_command_ref(cmd);
                 }
                 // PrepareCacheResult::Ignored shouldn't return by get_cached_cmd
                 _ => panic!("Unexpected result is given from get_cached_cmd"),
@@ -303,9 +303,9 @@ impl CacheManager {
 
         let pipeline_response_counts = if transaction_mode {
             packed_pipeline.atomic();
-            (packed_pipeline.commands.len() + 1, 1)
+            (packed_pipeline.len() + 1, 1)
         } else {
-            (0, packed_pipeline.commands.len())
+            (0, packed_pipeline.len())
         };
         let cp = CacheablePipeline {
             commands,

--- a/redis/src/caching/cmd.rs
+++ b/redis/src/caching/cmd.rs
@@ -1,4 +1,4 @@
-use crate::{Cmd, ErrorKind, Pipeline, RedisError, RedisResult, Value};
+use crate::{Cmd, ErrorKind, Pipeline, RedisError, RedisResult, Value, cmd::CmdRef};
 use std::{iter::zip, time::Instant};
 
 use super::{CacheManager, CacheMode, PrepareCacheResult};
@@ -49,7 +49,7 @@ impl CacheablePipeline<'_> {
 pub(crate) struct SingleCachedCommand<'a> {
     pub(crate) redis_key: &'a [u8],
     pub(crate) cmd_key: &'a [u8],
-    pub(crate) cmd: &'a Cmd,
+    pub(crate) cmd: CmdRef<'a>,
     pub(crate) client_side_expire: Instant,
 }
 
@@ -144,7 +144,7 @@ impl CacheableCommand<'_> {
         match self {
             CacheableCommand::Single(scc) => {
                 pipeline.add_command(Cmd::pttl(scc.redis_key));
-                pipeline.add_command(scc.cmd.clone());
+                pipeline.add_command_ref(scc.cmd);
             }
             CacheableCommand::Multiple {
                 command_name,

--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -708,7 +708,7 @@ where
                         if !matches!(res, Value::ServerError(_))
                             && let Some(tracker) = &self.subscription_tracker
                             && let Some((action, args)) =
-                                SubscriptionTracker::to_request(cmd.as_ref())
+                                SubscriptionTracker::to_request(cmd.as_ref().args_iter())
                         {
                             let mut tracker = tracker.lock().unwrap();
                             tracker.update_with_request(action, args);
@@ -752,7 +752,7 @@ where
                                 if matches!(res[index], Value::ServerError(_)) {
                                     None
                                 } else {
-                                    SubscriptionTracker::to_request(cmd)
+                                    SubscriptionTracker::to_request(cmd.args_iter())
                                 }
                             })
                             .peekable();

--- a/redis/src/cluster_handling/async_connection/routing.rs
+++ b/redis/src/cluster_handling/async_connection/routing.rs
@@ -1,8 +1,8 @@
 use crate::{
-    Cmd, RedisResult,
+    RedisResult,
     cluster_handling::NodeAddress,
     cluster_routing::{
-        MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Route, RoutingInfo,
+        MultipleNodeRoutingInfo, Redirect, ResponsePolicy, Routable, Route, RoutingInfo,
         SingleNodeRoutingInfo, SlotAddr,
     },
     errors::ServerErrorKind,
@@ -97,7 +97,7 @@ impl<C> From<SingleNodeRoutingInfo> for InternalSingleNodeRouting<C> {
 }
 
 pub(super) fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Option<Route>> {
-    fn route_for_command(cmd: &Cmd) -> Option<Route> {
+    fn route_for_command(cmd: &impl Routable) -> Option<Route> {
         match RoutingInfo::for_routable(cmd) {
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random)) => None,
             Some(RoutingInfo::SingleNode(SingleNodeRoutingInfo::SpecificNode(route))) => {
@@ -114,26 +114,28 @@ pub(super) fn route_for_pipeline(pipeline: &crate::Pipeline) -> RedisResult<Opti
 
     // Find first specific slot and send to it. There's no need to check If later commands
     // should be routed to a different slot, since the server will return an error indicating this.
-    pipeline.cmd_iter().map(route_for_command).try_fold(
-        None,
-        |chosen_route, next_cmd_route| match (chosen_route, next_cmd_route) {
-            (None, _) => Ok(next_cmd_route),
-            (_, None) => Ok(chosen_route),
-            (Some(chosen_route), Some(next_cmd_route)) => {
-                if chosen_route.slot() != next_cmd_route.slot() {
-                    Err((
-                        ServerErrorKind::CrossSlot.into(),
-                        "Received crossed slots in pipeline",
-                    )
-                        .into())
-                } else if chosen_route.slot_addr() != SlotAddr::Master {
-                    Ok(Some(next_cmd_route))
-                } else {
-                    Ok(Some(chosen_route))
+    pipeline
+        .cmd_iter()
+        .map(|cmd| route_for_command(&cmd))
+        .try_fold(None, |chosen_route, next_cmd_route| {
+            match (chosen_route, next_cmd_route) {
+                (None, _) => Ok(next_cmd_route),
+                (_, None) => Ok(chosen_route),
+                (Some(chosen_route), Some(next_cmd_route)) => {
+                    if chosen_route.slot() != next_cmd_route.slot() {
+                        Err((
+                            ServerErrorKind::CrossSlot.into(),
+                            "Received crossed slots in pipeline",
+                        )
+                            .into())
+                    } else if chosen_route.slot_addr() != SlotAddr::Master {
+                        Ok(Some(next_cmd_route))
+                    } else {
+                        Ok(Some(chosen_route))
+                    }
                 }
             }
-        },
-    )
+        })
 }
 
 #[cfg(test)]

--- a/redis/src/cluster_handling/routing.rs
+++ b/redis/src/cluster_handling/routing.rs
@@ -2,7 +2,7 @@ use rand::RngExt;
 
 use super::NodeAddress;
 use crate::cluster_handling::slot_map::SLOT_SIZE;
-use crate::cmd::{Arg, Cmd};
+use crate::cmd::{Arg, Cmd, CmdRef};
 use crate::commands::is_readonly_cmd;
 use crate::types::Value;
 use crate::{ErrorKind, RedisError, RedisResult};
@@ -891,6 +891,19 @@ pub(crate) trait Routable {
 impl Routable for Cmd {
     fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
         self.arg_idx(idx)
+    }
+
+    fn position(&self, candidate: &[u8]) -> Option<usize> {
+        self.args_iter().position(|a| match a {
+            Arg::Simple(d) => d.eq_ignore_ascii_case(candidate),
+            _ => false,
+        })
+    }
+}
+
+impl Routable for CmdRef<'_> {
+    fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
+        CmdRef::arg_idx(self, idx)
     }
 
     fn position(&self, candidate: &[u8]) -> Option<usize> {

--- a/redis/src/cluster_handling/sync_connection/mod.rs
+++ b/redis/src/cluster_handling/sync_connection/mod.rs
@@ -398,7 +398,8 @@ where
     }
 
     pub(crate) fn execute_pipeline(&mut self, pipe: &ClusterPipeline) -> RedisResult<Vec<Value>> {
-        self.send_recv_and_retry_cmds(pipe.commands())
+        let cmds: Vec<Cmd> = pipe.cmd_iter().map(|cmd| cmd.to_cmd()).collect();
+        self.send_recv_and_retry_cmds(&cmds)
     }
 
     /// Returns the connection status.

--- a/redis/src/cluster_handling/sync_connection/pipeline.rs
+++ b/redis/src/cluster_handling/sync_connection/pipeline.rs
@@ -1,8 +1,9 @@
 use super::ClusterConnection;
 use crate::RedisError;
-use crate::cmd::{Cmd, cmd};
+use crate::cmd::{Arg, Cmd, CmdRef};
 use crate::errors::ErrorKind;
-use crate::types::{FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value, from_redis_value};
+use crate::pipeline::CommandRecord;
+use crate::types::{FromRedisValue, RedisResult, ToRedisArgs, Value, from_redis_value};
 
 pub(crate) const UNROUTABLE_ERROR: (ErrorKind, &str) = (
     ErrorKind::Client,
@@ -44,8 +45,9 @@ fn is_illegal_cmd(cmd: &str) -> bool {
 /// Represents a Redis Cluster command pipeline.
 #[derive(Clone)]
 pub struct ClusterPipeline {
-    commands: Vec<Cmd>,
-    ignored_commands: HashSet<usize>,
+    data: Vec<u8>,
+    args: Vec<Arg<usize>>,
+    commands: Vec<CommandRecord>,
     ignore_errors: bool,
 }
 
@@ -73,21 +75,18 @@ pub struct ClusterPipeline {
 /// ```
 impl ClusterPipeline {
     /// Create an empty pipeline.
+    ///
+    /// To pre-allocate the internal buffers when you have a size estimate, chain the
+    /// [`reserve_for_commands`](Self::reserve_for_commands),
+    /// [`reserve_for_args`](Self::reserve_for_args), and
+    /// [`reserve_for_data`](Self::reserve_for_data) methods.
     pub fn new() -> ClusterPipeline {
-        Self::with_capacity(0)
-    }
-
-    /// Creates an empty pipeline with pre-allocated capacity.
-    pub fn with_capacity(capacity: usize) -> ClusterPipeline {
         ClusterPipeline {
-            commands: Vec::with_capacity(capacity),
-            ignored_commands: HashSet::new(),
+            data: Vec::new(),
+            args: Vec::new(),
+            commands: Vec::new(),
             ignore_errors: false,
         }
-    }
-
-    pub(crate) fn commands(&self) -> &Vec<Cmd> {
-        &self.commands
     }
 
     /// Executes the pipeline and fetches the return values:
@@ -105,7 +104,7 @@ impl ClusterPipeline {
     /// ```
     #[inline]
     pub fn query<T: FromRedisValue>(&self, con: &mut ClusterConnection) -> RedisResult<T> {
-        for cmd in &self.commands {
+        for cmd in self.cmd_iter() {
             let cmd_name = std::str::from_utf8(cmd.arg_idx(0).unwrap_or(b""))
                 .unwrap_or("")
                 .trim()

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -24,6 +24,158 @@ pub enum Arg<D> {
     Cursor,
 }
 
+/// A lightweight, borrowed view of a single command.
+///
+/// `CmdRef` is the item type yielded by [`Pipeline::cmd_iter`](crate::Pipeline::cmd_iter).
+/// It borrows directly into the pipeline's shared buffers, so iterating the commands of a
+/// pipeline performs no per-command allocation. It can also be created from a standalone
+/// [`Cmd`], which lets internal machinery treat both uniformly.
+///
+/// The type is intentionally opaque: it exposes a curated set of read-only accessors so that
+/// the underlying storage can evolve without breaking callers.
+#[derive(Clone, Copy, Debug)]
+pub struct CmdRef<'a> {
+    // The contiguous argument bytes belonging to this command.
+    data: &'a [u8],
+    // This command's args. `Arg::Simple` offsets are absolute into the buffer that `data` is a
+    // slice of; `data_start` records where `data` begins within it.
+    args: &'a [Arg<usize>],
+    data_start: usize,
+    cursor: Option<u64>,
+    no_response: bool,
+    ignored: bool,
+    #[cfg(feature = "cache-aio")]
+    cache: &'a Option<CommandCacheConfig>,
+}
+
+impl<'a> CmdRef<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        data: &'a [u8],
+        args: &'a [Arg<usize>],
+        data_start: usize,
+        cursor: Option<u64>,
+        no_response: bool,
+        ignored: bool,
+        #[cfg(feature = "cache-aio")] cache: &'a Option<CommandCacheConfig>,
+    ) -> Self {
+        CmdRef {
+            data,
+            args,
+            data_start,
+            cursor,
+            no_response,
+            ignored,
+            #[cfg(feature = "cache-aio")]
+            cache,
+        }
+    }
+
+    /// Creates a view borrowing from a standalone [`Cmd`].
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn from_cmd(cmd: &'a Cmd) -> Self {
+        CmdRef {
+            data: &cmd.data,
+            args: &cmd.args,
+            data_start: 0,
+            cursor: cmd.cursor,
+            no_response: cmd.no_response,
+            ignored: false,
+            #[cfg(feature = "cache-aio")]
+            cache: &cmd.cache,
+        }
+    }
+
+    /// Returns an iterator over the arguments in this command (including the command name itself).
+    pub fn args_iter(&self) -> impl Clone + ExactSizeIterator<Item = Arg<&'a [u8]>> + use<'a> {
+        let data = self.data;
+        let base = self.data_start;
+        let args = self.args;
+        let mut prev = 0;
+        args.iter().map(move |arg| match *arg {
+            Arg::Simple(end) => {
+                let arg = Arg::Simple(&data[prev..end - base]);
+                prev = end - base;
+                arg
+            }
+            Arg::Cursor => Arg::Cursor,
+        })
+    }
+
+    /// Returns a reference to the data for the argument at `idx`.
+    pub fn arg_idx(&self, idx: usize) -> Option<&'a [u8]> {
+        match self.args_iter().nth(idx)? {
+            Arg::Simple(bytes) => Some(bytes),
+            Arg::Cursor => None,
+        }
+    }
+
+    /// Returns this command's contiguous argument bytes.
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    /// Returns the command's cursor value, if it is in scan mode.
+    pub fn cursor(&self) -> Option<u64> {
+        self.cursor
+    }
+
+    /// Check whether the command's result will be waited for.
+    pub fn is_no_response(&self) -> bool {
+        self.no_response
+    }
+
+    /// Returns `true` if this command's result is ignored within the pipeline.
+    pub fn is_ignored(&self) -> bool {
+        self.ignored
+    }
+
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn get_cache_config(&self) -> &'a Option<CommandCacheConfig> {
+        self.cache
+    }
+
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn encoded_len(&self) -> usize {
+        args_len(self.args_iter(), self.cursor.unwrap_or(0))
+    }
+
+    /// Returns the packed command as a byte vector.
+    pub fn get_packed_command(&self) -> Vec<u8> {
+        let mut cmd = Vec::new();
+        if self.args.is_empty() {
+            return cmd;
+        }
+        self.write_packed_command(&mut cmd);
+        cmd
+    }
+
+    /// Writes the packed command to `dst`, appending to it.
+    pub fn write_packed_command(&self, dst: &mut Vec<u8>) {
+        write_command_to_vec(dst, self.args_iter(), self.cursor.unwrap_or(0))
+    }
+
+    /// Reconstructs an owned [`Cmd`] from this view.
+    pub fn to_cmd(self) -> Cmd {
+        let mut cmd = Cmd::with_capacity(self.args.len(), self.data.len());
+        cmd.data.extend_from_slice(self.data);
+        let base = self.data_start;
+        for arg in self.args {
+            match *arg {
+                Arg::Simple(end) => cmd.args.push(Arg::Simple(end - base)),
+                Arg::Cursor => cmd.args.push(Arg::Cursor),
+            }
+        }
+        cmd.cursor = self.cursor;
+        cmd.no_response = self.no_response;
+        #[cfg(feature = "cache-aio")]
+        {
+            cmd.cache = self.cache.clone();
+        }
+        cmd
+    }
+}
+
 /// CommandCacheConfig is used to define caching behaviour of individual commands.
 /// # Example
 /// ```rust
@@ -295,7 +447,7 @@ fn bulklen(len: usize) -> usize {
     1 + countdigits(len) + 2 + len + 2
 }
 
-fn args_len<'a, I>(args: I, cursor: u64) -> usize
+pub(crate) fn args_len<'a, I>(args: I, cursor: u64) -> usize
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + ExactSizeIterator,
 {
@@ -309,6 +461,7 @@ where
     totlen
 }
 
+#[cfg(test)]
 pub(crate) fn cmd_len(cmd: &Cmd) -> usize {
     args_len(cmd.args_iter(), cmd.cursor.unwrap_or(0))
 }
@@ -333,7 +486,11 @@ where
     write_command(cmd, args, cursor).unwrap()
 }
 
-fn write_command<'a, I>(cmd: &mut (impl ?Sized + Write), args: I, cursor: u64) -> io::Result<()>
+pub(crate) fn write_command<'a, I>(
+    cmd: &mut (impl ?Sized + Write),
+    args: I,
+    cursor: u64,
+) -> io::Result<()>
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + Clone + ExactSizeIterator,
 {
@@ -624,14 +781,14 @@ impl Cmd {
         write_command_to_vec(dst, self.args_iter(), self.cursor.unwrap_or(0))
     }
 
-    pub(crate) fn write_packed_command_preallocated(&self, cmd: &mut Vec<u8>) {
-        write_command(cmd, self.args_iter(), self.cursor.unwrap_or(0)).unwrap()
-    }
-
     /// Returns true if the command is in scan mode.
     #[inline]
     pub fn in_scan_mode(&self) -> bool {
         self.cursor.is_some()
+    }
+
+    pub(crate) fn cursor_value(&self) -> Option<u64> {
+        self.cursor
     }
 
     /// Sends the command as query to the connection and converts the
@@ -773,7 +930,7 @@ impl Cmd {
     }
 
     // Get a reference to the argument at `idx`
-    #[cfg(any(feature = "cluster", feature = "cache-aio"))]
+    #[cfg(feature = "cluster")]
     pub(crate) fn arg_idx(&self, idx: usize) -> Option<&[u8]> {
         if idx >= self.args.len() {
             return None;

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -2484,8 +2484,7 @@ mod tests {
             .0;
 
             let actual_packed_cmds = pipeline
-                .commands
-                .iter()
+                .cmd_iter()
                 .map(|c| c.get_packed_command())
                 .collect::<Vec<_>>();
 

--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -2,17 +2,36 @@
 
 #[cfg(feature = "cache-aio")]
 use crate::cmd::CommandCacheConfig;
-use crate::cmd::{Cmd, cmd, cmd_len};
+use crate::cmd::{Arg, Cmd, CmdRef, args_len, write_command};
 use crate::connection::ConnectionLike;
 use crate::errors::ErrorKind;
-use crate::types::{FromRedisValue, HashSet, RedisResult, ToRedisArgs, Value, from_redis_value};
+use crate::types::{FromRedisValue, RedisResult, ToRedisArgs, Value, from_redis_value};
+
+/// Per-command metadata in a flattened pipeline.
+///
+/// The command's arguments are `args[args_start..next.args_start]` and its argument bytes are
+/// `data[data_start..next.data_start]`, where `next` is the following command's record (or the
+/// buffer ends for the last command). Keeping a small record per command — rather than the
+/// boundary in the hot `args` buffer — allows O(1) jumps between commands while keeping each
+/// `args` entry as small as a standalone `Cmd`'s.
+#[derive(Clone, Debug)]
+pub(crate) struct CommandRecord {
+    pub(crate) args_start: usize,
+    pub(crate) data_start: usize,
+    pub(crate) cursor: Option<u64>,
+    pub(crate) ignored: bool,
+    pub(crate) no_response: bool,
+    #[cfg(feature = "cache-aio")]
+    pub(crate) cache: Option<CommandCacheConfig>,
+}
 
 /// Represents a redis command pipeline.
 #[derive(Clone, Debug)]
 pub struct Pipeline {
-    pub(crate) commands: Vec<Cmd>,
+    pub(crate) data: Vec<u8>,
+    pub(crate) args: Vec<Arg<usize>>,
+    pub(crate) commands: Vec<CommandRecord>,
     pub(crate) transaction_mode: bool,
-    pub(crate) ignored_commands: HashSet<usize>,
     pub(crate) ignore_errors: bool,
 }
 
@@ -40,16 +59,17 @@ pub struct Pipeline {
 impl Pipeline {
     /// Creates an empty pipeline.  For consistency with the `cmd`
     /// api a `pipe` function is provided as alias.
+    ///
+    /// To pre-allocate the internal buffers when you have a size estimate, chain the
+    /// [`reserve_for_commands`](Self::reserve_for_commands),
+    /// [`reserve_for_args`](Self::reserve_for_args), and
+    /// [`reserve_for_data`](Self::reserve_for_data) methods.
     pub fn new() -> Pipeline {
-        Self::with_capacity(0)
-    }
-
-    /// Creates an empty pipeline with pre-allocated capacity.
-    pub fn with_capacity(capacity: usize) -> Pipeline {
         Pipeline {
-            commands: Vec::with_capacity(capacity),
+            data: Vec::new(),
+            args: Vec::new(),
+            commands: Vec::new(),
             transaction_mode: false,
-            ignored_commands: HashSet::new(),
             ignore_errors: false,
         }
     }
@@ -130,7 +150,22 @@ impl Pipeline {
 
     /// Returns the encoded pipeline commands.
     pub fn get_packed_pipeline(&self) -> Vec<u8> {
-        encode_pipeline(&self.commands, self.transaction_mode)
+        encode_pipeline(self, self.transaction_mode)
+    }
+
+    /// Returns the `(args, data_start, cursor)` for the command at `idx`, used by the encoder to
+    /// walk the flat buffers directly.
+    fn command_parts(&self, idx: usize) -> (&[Arg<usize>], usize, u64) {
+        let record = &self.commands[idx];
+        let args_end = self
+            .commands
+            .get(idx + 1)
+            .map_or(self.args.len(), |r| r.args_start);
+        (
+            &self.args[record.args_start..args_end],
+            record.data_start,
+            record.cursor.unwrap_or(0),
+        )
     }
 
     /// Returns the number of commands currently queued by the usr in the pipeline.
@@ -183,17 +218,9 @@ impl Pipeline {
         }
 
         let response = if self.transaction_mode {
-            con.req_packed_commands(
-                &encode_pipeline(&self.commands, true),
-                self.commands.len() + 1,
-                1,
-            )?
+            con.req_packed_commands(&encode_pipeline(self, true), self.len() + 1, 1)?
         } else {
-            con.req_packed_commands(
-                &encode_pipeline(&self.commands, false),
-                0,
-                self.commands.len(),
-            )?
+            con.req_packed_commands(&encode_pipeline(self, false), 0, self.len())?
         };
 
         self.complete_request(response)
@@ -207,11 +234,9 @@ impl Pipeline {
         con: &mut impl crate::aio::ConnectionLike,
     ) -> RedisResult<T> {
         let response = if self.transaction_mode {
-            con.req_packed_commands(self, self.commands.len() + 1, 1)
-                .await?
+            con.req_packed_commands(self, self.len() + 1, 1).await?
         } else {
-            con.req_packed_commands(self, 0, self.commands.len())
-                .await?
+            con.req_packed_commands(self, 0, self.len()).await?
         };
 
         self.complete_request(response)
@@ -258,31 +283,59 @@ impl Pipeline {
     }
 }
 
-fn encode_pipeline(cmds: &[Cmd], atomic: bool) -> Vec<u8> {
+fn encode_pipeline(pipe: &Pipeline, atomic: bool) -> Vec<u8> {
     let mut rv = vec![];
-    write_pipeline(&mut rv, cmds, atomic);
+    write_pipeline(&mut rv, pipe, atomic);
     rv
 }
 
-fn write_pipeline(rv: &mut Vec<u8>, cmds: &[Cmd], atomic: bool) {
-    let cmds_len = cmds.iter().map(cmd_len).sum();
+// Pre-encoded RESP frames for the transaction wrapper. These are constant, so there's no need
+// to build (and allocate) `Cmd`s just to encode them.
+const PACKED_MULTI: &[u8] = b"*1\r\n$5\r\nMULTI\r\n";
+const PACKED_EXEC: &[u8] = b"*1\r\n$4\r\nEXEC\r\n";
+
+/// Builds an iterator over a single command's arguments, slicing directly into the pipeline's
+/// shared `data` buffer using absolute offsets. Unlike [`CmdRef::args_iter`], this needs no
+/// per-argument rebasing, which keeps the hot encode path tight.
+fn command_args_iter<'a>(
+    data: &'a [u8],
+    args: &'a [Arg<usize>],
+    data_start: usize,
+) -> impl Clone + ExactSizeIterator<Item = Arg<&'a [u8]>> {
+    let mut prev = data_start;
+    args.iter().map(move |arg| match *arg {
+        Arg::Simple(end) => {
+            let arg = Arg::Simple(&data[prev..end]);
+            prev = end;
+            arg
+        }
+        Arg::Cursor => Arg::Cursor,
+    })
+}
+
+fn write_pipeline(rv: &mut Vec<u8>, pipe: &Pipeline, atomic: bool) {
+    let cmds_len: usize = (0..pipe.commands.len())
+        .map(|idx| {
+            let (args, data_start, cursor) = pipe.command_parts(idx);
+            args_len(command_args_iter(&pipe.data, args, data_start), cursor)
+        })
+        .sum();
+
+    let write_commands = |rv: &mut Vec<u8>| {
+        for idx in 0..pipe.commands.len() {
+            let (args, data_start, cursor) = pipe.command_parts(idx);
+            write_command(rv, command_args_iter(&pipe.data, args, data_start), cursor).unwrap();
+        }
+    };
 
     if atomic {
-        let multi = cmd("MULTI");
-        let exec = cmd("EXEC");
-        rv.reserve(cmd_len(&multi) + cmd_len(&exec) + cmds_len);
-
-        multi.write_packed_command_preallocated(rv);
-        for cmd in cmds {
-            cmd.write_packed_command_preallocated(rv);
-        }
-        exec.write_packed_command_preallocated(rv);
+        rv.reserve(PACKED_MULTI.len() + PACKED_EXEC.len() + cmds_len);
+        rv.extend_from_slice(PACKED_MULTI);
+        write_commands(rv);
+        rv.extend_from_slice(PACKED_EXEC);
     } else {
         rv.reserve(cmds_len);
-
-        for cmd in cmds {
-            cmd.write_packed_command_preallocated(rv);
-        }
+        write_commands(rv);
     }
 }
 
@@ -290,10 +343,39 @@ fn write_pipeline(rv: &mut Vec<u8>, cmds: &[Cmd], atomic: bool) {
 macro_rules! implement_pipeline_commands {
     ($struct_name:ident) => {
         impl $struct_name {
-            /// Adds a command to the cluster pipeline.
+            /// Pushes a new, empty command record. Subsequent arguments written through
+            /// [`RedisWrite`](crate::RedisWrite) belong to it until the next command starts.
+            #[inline]
+            fn start_command(&mut self) {
+                self.commands.push($crate::pipeline::CommandRecord {
+                    args_start: self.args.len(),
+                    data_start: self.data.len(),
+                    cursor: None,
+                    ignored: false,
+                    no_response: false,
+                    #[cfg(feature = "cache-aio")]
+                    cache: None,
+                });
+            }
+
+            /// Adds a command to the pipeline.
             #[inline]
             pub fn add_command(&mut self, cmd: Cmd) -> &mut Self {
-                self.commands.push(cmd);
+                self.start_command();
+                for arg in cmd.args_iter() {
+                    match arg {
+                        Arg::Simple(bytes) => $crate::types::RedisWrite::write_arg(self, bytes),
+                        Arg::Cursor => self.args.push(Arg::Cursor),
+                    }
+                }
+                if let Some(record) = self.commands.last_mut() {
+                    record.cursor = cmd.cursor_value();
+                    record.no_response = cmd.is_no_response();
+                    #[cfg(feature = "cache-aio")]
+                    {
+                        record.cache = cmd.get_cache_config().clone();
+                    }
+                }
                 self
             }
 
@@ -301,12 +383,62 @@ macro_rules! implement_pipeline_commands {
             /// available to add more arguments to that command.
             #[inline]
             pub fn cmd(&mut self, name: &str) -> &mut Self {
-                self.add_command(cmd(name))
+                self.start_command();
+                $crate::types::RedisWrite::write_arg(self, name.as_bytes());
+                self
             }
 
             /// Returns an iterator over all the commands currently in this pipeline
-            pub fn cmd_iter(&self) -> impl Iterator<Item = &Cmd> {
-                self.commands.iter()
+            pub fn cmd_iter(&self) -> impl Iterator<Item = CmdRef<'_>> {
+                (0..self.commands.len()).map(move |idx| self.command_ref(idx))
+            }
+
+            /// Reserves capacity for at least `additional` more commands.
+            ///
+            /// This is a hint for pre-allocation; the pipeline grows automatically as needed.
+            #[inline]
+            pub fn reserve_for_commands(&mut self, additional: usize) -> &mut Self {
+                self.commands.reserve(additional);
+                self
+            }
+
+            /// Reserves capacity for at least `additional` more arguments, counted across all
+            /// commands.
+            ///
+            /// This is a hint for pre-allocation; the pipeline grows automatically as needed.
+            #[inline]
+            pub fn reserve_for_args(&mut self, additional: usize) -> &mut Self {
+                self.args.reserve(additional);
+                self
+            }
+
+            /// Reserves capacity for at least `additional` more argument bytes, counted across all
+            /// commands.
+            ///
+            /// This is a hint for pre-allocation; the pipeline grows automatically as needed.
+            #[inline]
+            pub fn reserve_for_data(&mut self, additional: usize) -> &mut Self {
+                self.data.reserve(additional);
+                self
+            }
+
+            /// Builds a borrowed view of the command at `idx`.
+            #[inline]
+            fn command_ref(&self, idx: usize) -> CmdRef<'_> {
+                let record = &self.commands[idx];
+                let next = self.commands.get(idx + 1);
+                let args_end = next.map_or(self.args.len(), |r| r.args_start);
+                let data_end = next.map_or(self.data.len(), |r| r.data_start);
+                CmdRef::new(
+                    &self.data[record.data_start..data_end],
+                    &self.args[record.args_start..args_end],
+                    record.data_start,
+                    record.cursor,
+                    record.no_response,
+                    record.ignored,
+                    #[cfg(feature = "cache-aio")]
+                    &record.cache,
+                )
             }
 
             /// Instructs the pipeline to ignore the return value of this command.
@@ -318,10 +450,9 @@ macro_rules! implement_pipeline_commands {
             /// so that the user could retrace which command failed.
             #[inline]
             pub fn ignore(&mut self) -> &mut Self {
-                match self.commands.len() {
-                    0 => true,
-                    x => self.ignored_commands.insert(x - 1),
-                };
+                if let Some(record) = self.commands.last_mut() {
+                    record.ignored = true;
+                }
                 self
             }
 
@@ -331,10 +462,8 @@ macro_rules! implement_pipeline_commands {
             /// Note that this function fails the task if executed on an empty pipeline.
             #[inline]
             pub fn arg<T: ToRedisArgs>(&mut self, arg: T) -> &mut Self {
-                {
-                    let cmd = self.get_last_command();
-                    cmd.arg(arg);
-                }
+                assert!(!self.commands.is_empty(), "No command on stack");
+                arg.write_redis_args(self);
                 self
             }
 
@@ -344,24 +473,20 @@ macro_rules! implement_pipeline_commands {
             /// amount of memory released/reallocated.
             #[inline]
             pub fn clear(&mut self) {
+                self.data.clear();
+                self.args.clear();
                 self.commands.clear();
-                self.ignored_commands.clear();
-            }
-
-            #[inline]
-            fn get_last_command(&mut self) -> &mut Cmd {
-                let idx = match self.commands.len() {
-                    0 => panic!("No command on stack"),
-                    x => x - 1,
-                };
-                &mut self.commands[idx]
             }
 
             fn filter_ignored_results(&self, resp: Vec<Value>) -> Vec<Value> {
                 resp.into_iter()
                     .enumerate()
                     .filter_map(|(index, result)| {
-                        (!self.ignored_commands.contains(&index)).then(|| result)
+                        let ignored = self
+                            .commands
+                            .get(index)
+                            .is_some_and(|record| record.ignored);
+                        (!ignored).then_some(result)
                     })
                     .collect()
             }
@@ -392,6 +517,51 @@ macro_rules! implement_pipeline_commands {
             }
         }
 
+        impl $crate::types::RedisWrite for $struct_name {
+            fn write_arg(&mut self, arg: &[u8]) {
+                self.data.extend_from_slice(arg);
+                self.args.push(Arg::Simple(self.data.len()));
+            }
+
+            fn write_arg_fmt(&mut self, arg: impl std::fmt::Display) {
+                use std::io::Write as _;
+                write!(self.data, "{arg}").unwrap();
+                self.args.push(Arg::Simple(self.data.len()));
+            }
+
+            fn writer_for_next_arg(&mut self) -> impl std::io::Write + '_ {
+                struct PipelineArgGuard<'a>(&'a mut $struct_name);
+                impl Drop for PipelineArgGuard<'_> {
+                    fn drop(&mut self) {
+                        self.0.args.push(Arg::Simple(self.0.data.len()));
+                    }
+                }
+                impl std::io::Write for PipelineArgGuard<'_> {
+                    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                        self.0.data.extend_from_slice(buf);
+                        Ok(buf.len())
+                    }
+
+                    fn flush(&mut self) -> std::io::Result<()> {
+                        Ok(())
+                    }
+                }
+
+                PipelineArgGuard(self)
+            }
+
+            fn reserve_space_for_args(&mut self, additional: impl IntoIterator<Item = usize>) {
+                let mut capacity = 0;
+                let mut args = 0;
+                for add in additional {
+                    capacity += add;
+                    args += 1;
+                }
+                self.data.reserve(capacity);
+                self.args.reserve(args);
+            }
+        }
+
         impl Default for $struct_name {
             fn default() -> Self {
                 Self::new()
@@ -408,14 +578,39 @@ impl Pipeline {
     #[cfg(feature = "cache-aio")]
     #[cfg_attr(docsrs, doc(cfg(feature = "cache-aio")))]
     pub fn set_cache_config(&mut self, command_cache_config: CommandCacheConfig) -> &mut Self {
-        let cmd = self.get_last_command();
-        cmd.set_cache_config(command_cache_config);
+        if let Some(record) = self.commands.last_mut() {
+            record.cache = Some(command_cache_config);
+        }
+        self
+    }
+
+    /// Appends a command from a borrowed [`CmdRef`] without allocating an intermediate [`Cmd`].
+    ///
+    /// This is the borrowing counterpart of [`add_command`](Self::add_command), used by the
+    /// caching layer to repack commands it inspected as `CmdRef`s.
+    #[cfg(feature = "cache-aio")]
+    pub(crate) fn add_command_ref(&mut self, cmd: CmdRef<'_>) -> &mut Self {
+        self.start_command();
+        for arg in cmd.args_iter() {
+            match arg {
+                Arg::Simple(bytes) => crate::types::RedisWrite::write_arg(self, bytes),
+                Arg::Cursor => self.args.push(Arg::Cursor),
+            }
+        }
+        if let Some(record) = self.commands.last_mut() {
+            record.cursor = cmd.cursor();
+            record.no_response = cmd.is_no_response();
+            record.cache = cmd.get_cache_config().clone();
+        }
         self
     }
 
     #[cfg(feature = "cluster-async")]
     pub(crate) fn into_cmd_iter(self) -> impl Iterator<Item = Cmd> {
-        self.commands.into_iter()
+        self.cmd_iter()
+            .map(|cmd| cmd.to_cmd())
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }
 

--- a/redis/src/subscription_tracker.rs
+++ b/redis/src/subscription_tracker.rs
@@ -3,7 +3,7 @@
 use core::str;
 use std::collections::HashSet;
 
-use crate::{Arg, Cmd, Pipeline};
+use crate::{Arg, Pipeline};
 
 #[derive(Default)]
 pub(crate) struct SubscriptionTracker {
@@ -36,10 +36,9 @@ impl SubscriptionAction {
 }
 
 impl SubscriptionTracker {
-    pub(crate) fn to_request(
-        cmd: &Cmd,
+    pub(crate) fn to_request<'a>(
+        mut args_iter: impl Iterator<Item = Arg<&'a [u8]>>,
     ) -> Option<(SubscriptionAction, impl Iterator<Item = Vec<u8>>)> {
-        let mut args_iter = cmd.args_iter();
         let first_arg = args_iter.next()?;
 
         let first_arg = match first_arg {
@@ -100,8 +99,8 @@ impl SubscriptionTracker {
     }
 
     #[cfg(test)]
-    fn update_with_cmd<'a>(&'a mut self, cmd: &'a Cmd) {
-        if let Some((action, args)) = Self::to_request(cmd) {
+    fn update_with_cmd<'a>(&'a mut self, cmd: &'a crate::Cmd) {
+        if let Some((action, args)) = Self::to_request(cmd.args_iter()) {
             self.update_with_request(action, args);
         }
     }

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -1,11 +1,11 @@
 use crate::errors::ParsingError;
 #[cfg(feature = "ahash")]
-pub(crate) use ahash::{AHashMap as HashMap, AHashSet as HashSet};
+pub(crate) use ahash::AHashMap as HashMap;
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
 use std::borrow::Cow;
 #[cfg(not(feature = "ahash"))]
-pub(crate) use std::collections::{HashMap, HashSet};
+pub(crate) use std::collections::HashMap;
 use std::default::Default;
 use std::ffi::CString;
 use std::fmt;

--- a/redis/tests/support/mock_cluster.rs
+++ b/redis/tests/support/mock_cluster.rs
@@ -230,7 +230,7 @@ impl aio::ConnectionLike for MockConnection {
         Box::pin(future::ready(
             pipeline
                 .cmd_iter()
-                .map(|cmd| self.execute_cmd(cmd))
+                .map(|cmd| self.execute_cmd(&cmd.to_cmd()))
                 .collect(),
         ))
     }

--- a/version2.md
+++ b/version2.md
@@ -1,0 +1,68 @@
+# Announcing redis-rs & redis-test 2.0.0
+
+With version 1.0.0 behind us, version 2.0.0 begins a new major series, with redis-test tracking it with the same version.
+
+This document highlights the breaking changes in version 2.0.0. For a complete list of changes, see CHANGELOG.md. We appreciate feedback and bug reports — please open an issue for anything you encounter during migration. In order to get the newest version, please specify in your Cargo.toml file
+
+```toml
+redis = "2"
+```
+
+## Breaking Changes
+
+### `cmd_iter` yields `CmdRef` instead of `&Cmd` (Breaking Change)
+
+**Most users can upgrade to 2.0.0 with no code changes.** The flattening is an internal representation change; the pipeline builder API (`cmd`, `arg`, `add_command`, `ignore`, `query`, `query_async`, `exec`, …) is unchanged. The only adjustments are needed if you iterate a pipeline's commands or call `with_capacity` directly.
+
+Because a pipeline no longer owns a `Vec<Cmd>`, there is no `&Cmd` to hand out. [`Pipeline::cmd_iter`] and [`ClusterPipeline::cmd_iter`] now yield `CmdRef<'_>`, a lightweight, `Copy` view that borrows directly into the pipeline's shared buffers — iterating a pipeline's commands performs no per-command allocation.
+
+`CmdRef` is intentionally opaque so that the underlying storage can keep evolving. It exposes the read-only accessors you previously reached for on `&Cmd`, including `args_iter()`, `arg_idx()`, `data()`, `cursor()`, `is_no_response()`, and `get_packed_command()`. If you genuinely need an owned `Cmd`, call `to_cmd()`.
+
+**Migration:** Update code that iterates a pipeline's commands. Most call sites only need to drop a borrow or call an accessor:
+
+```rust
+// Before:
+for cmd in pipe.cmd_iter() {
+    let name = cmd.arg_idx(0);
+    // cmd: &Cmd
+}
+
+// After:
+for cmd in pipe.cmd_iter() {
+    let name = cmd.arg_idx(0);
+    // cmd: CmdRef<'_> — same read accessors, Copy
+}
+```
+
+If you stored or passed the `&Cmd` onward and need an owned value:
+
+```rust
+// Before:
+let owned: Vec<Cmd> = pipe.cmd_iter().cloned().collect();
+
+// After:
+let owned: Vec<Cmd> = pipe.cmd_iter().map(|cmd| cmd.to_cmd()).collect();
+```
+
+### `Pipeline::with_capacity` is replaced by `reserve_for_*` methods (Breaking Change)
+
+[`Pipeline::with_capacity`] and [`ClusterPipeline::with_capacity`] have been removed. A flattened pipeline stores its commands across three buffers (commands, arguments, and argument bytes), and a single capacity number no longer maps cleanly onto them. Rather than force you to estimate all three up front, pre-allocation is now opt-in per buffer via chainable methods, so you reserve only the dimensions you actually have a number for:
+
+```rust
+pub fn reserve_for_commands(&mut self, additional: usize) -> &mut Self
+pub fn reserve_for_args(&mut self, additional: usize) -> &mut Self
+pub fn reserve_for_data(&mut self, additional: usize) -> &mut Self // argument bytes
+```
+
+**Migration:** Replace `with_capacity` with the reservations you can estimate:
+
+```rust
+// Before:
+let mut pipe = redis::Pipeline::with_capacity(16); // 16 commands
+
+// After: reserve whichever buffers you have an estimate for
+let mut pipe = redis::pipe();
+pipe.reserve_for_commands(16).reserve_for_args(48);
+```
+
+`Pipeline::new()` and `pipe()` are unchanged.


### PR DESCRIPTION
# Summary

Reworks the internal representation of Pipeline and ClusterPipeline. Previously a pipeline held a Vec<Cmd>, where every command carried two Vecs of its own — so building an N-command pipeline meant ~2N heap allocations and left the argument data scattered across memory. Both pipeline types now store all commands in a small number of shared, flat buffers:

- data: Vec<u8> — every command's argument bytes, concatenated
- args: Vec<Arg<usize>> — every argument, as offsets into data
- commands: Vec<CommandRecord> — a small per-command record (arg/data boundaries + cursor/ignored/no-response/cache) enabling O(1) jumps between commands

Building a pipeline now appends into these reused buffers instead of allocating per command, and a command's argument bytes live contiguously in memory.

This is targeted at a new major version (2.0.0), so the public-API breakage below is acceptable.

## What changed

- Flattened storage for Pipeline and ClusterPipeline; the shared builder logic lives in one macro.
- CmdRef<'a> — a new, opaque, Copy borrowed view of a single command, yielded by cmd_iter(). It borrows directly into the pipeline buffers (no per-command allocation) and exposes the read accessors previously available on &Cmd (args_iter, arg_idx, data, cursor, is_no_response, get_packed_command), plus to_cmd() to materialize an owned Cmd when needed.
- RedisWrite for the pipeline types, so arguments are written straight into the shared buffers.
- Dropped the ignored_commands: HashSet in favor of a per-command ignored flag on each record.
- Encoder writes directly off the flat buffers (no intermediate CmdRef/Cmd), and emits the transaction wrapper as constant MULTI/EXEC frames rather than constructing throwaway Cmds.
- Caching now inspects commands as CmdRef and repacks them via a new allocation-free add_command_ref, instead of cloning owned Cmds.
- with_capacity → reserve_for_* builder methods. with_capacity is removed; pre-allocation is now opt-in per buffer (reserve_for_commands, reserve_for_args, reserve_for_data), so callers reserve only the dimensions they can estimate.

## Breaking changes (see version2.md for migration)

- Pipeline::cmd_iter / ClusterPipeline::cmd_iter now yield CmdRef<'_> instead of &Cmd.
- Pipeline::with_capacity / ClusterPipeline::with_capacity are removed; use the reserve_for_* methods.
- Additive: the new CmdRef type and RedisWrite impls on the pipeline types.

All other pipeline builder methods (cmd, arg, add_command, ignore, query/query_async, exec, set_cache_config) keep their signatures, and Cmd is unchanged — most users upgrade with no code changes.

## Benchmarks

`cargo bench --bench bench_pipeline_build`, criterion medians, N=1000 commands (the `_small` atomic rows use 5 commands). **Before** = `Vec<Cmd>` layout; **After** = flattened layout. Measured on a laptop, so treat ±5% as noise.

| Benchmark | Before | After | Change |
|---|---|---|---|
| `build_pipeline` | 86.88 µs | 11.03 µs | −87% (7.9×) |
| `build_pipeline_nested` | 46.41 µs | 6.34 µs | −86% (7.3×) |
| `build_pipeline_preallocated` | 85.02 µs | 8.21 µs | −90% (10.4×) |
| `packed_pipeline` (encode only) | 21.27 µs | 20.55 µs | −3% (≈ parity) |
| `build_and_pack` (end-to-end) | 108.90 µs | 32.89 µs | −70% (3.3×) |
| `build_and_pack_preallocated` (end-to-end) | 107.16 µs | 29.46 µs | −73% (3.6×) |
| `packed_pipeline_atomic` (encode only) | 21.41 µs | 20.59 µs | −4% (≈ parity) |
| `build_and_pack_atomic` (end-to-end) | 108.43 µs | 33.15 µs | −69% (3.3×) |
| `packed_pipeline_atomic_small` (encode, 5 cmds) | 246 ns | 136 ns | −45% |
| `build_and_pack_atomic_small` (end-to-end, 5 cmds) | 766 ns | 473 ns | −38% |

**Pre-allocation: `with_capacity` vs `reserve_for_*`.** Comparing each layout's pre-allocated build against its own default build shows how much reserving capacity actually buys:

| | default build | pre-allocated build | benefit |
|---|---|---|---|
| Before — `with_capacity(N)` | 86.88 µs | 85.02 µs | ~2% |
| After — `reserve_for_*` | 11.03 µs | 8.21 µs | ~25% |

The old command-count `with_capacity` barely helped (~2%): the dominant cost was the two per-`Cmd` `Vec` allocations, which a command count can't pre-reserve. `reserve_for_*` pre-sizes the actual hot buffers (`data`/`args`), cutting another ~25% off an already-much-faster build.

