### PR TITLE
fix(cluster): clamp retry backoff upper bound after min-wait floor

### DIFF
--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -98,8 +98,16 @@ impl Default for RetryParams {
 }
 
 /// Exclusive upper bound (ms) for [`RetryParams::wait_time_for_retry`] jitter; see [`ClusterClientBuilder::retry_wait_formula`].
+///
+/// The result is always strictly greater than `min_wait` so the half-open jitter range is never empty
+/// (e.g. when `max_retry_wait == min_retry_wait`, or when the clamp would otherwise equal `min_wait`).
 fn cluster_retry_wait_upper_ms(base_wait: u64, min_wait: u64, max_wait: u64) -> u64 {
-    base_wait.max(min_wait + 1).min(max_wait)
+    let capped = base_wait.max(min_wait + 1).min(max_wait);
+    if capped <= min_wait {
+        min_wait.saturating_add(1)
+    } else {
+        capped
+    }
 }
 
 impl RetryParams {
@@ -1067,9 +1075,34 @@ mod tests {
     }
 
     #[test]
-    fn cluster_retry_wait_upper_caps_max_when_min_plus_one_exceeds_max() {
-        // When min_retry_wait + 1 > max_retry_wait, applying `.min(max).max(min+1)` can exceed
-        // `max_retry_wait`; the backoff upper bound must be capped at `max_retry_wait` after the floor.
-        assert_eq!(super::cluster_retry_wait_upper_ms(10, 100, 50), 50);
+    fn cluster_retry_clamp_order_caps_at_max_after_floor() {
+        // Documented chain is `max(base, min+1).min(max)`; the old `.min(max).max(min+1)` overshoots `max` here.
+        let base = 10u64;
+        let min_w = 100u64;
+        let max_w = 50u64;
+        assert_eq!(base.max(min_w + 1).min(max_w), 50);
+        assert_eq!(base.min(max_w).max(min_w + 1), 101);
+        // Exclusive upper must exceed `min_wait` for `random_range`, so we lift when the clamp hits `min_wait`.
+        assert_eq!(
+            super::cluster_retry_wait_upper_ms(base, min_w, max_w),
+            min_w + 1
+        );
+    }
+
+    #[test]
+    fn cluster_retry_wait_upper_strictly_above_min_when_min_equals_max() {
+        assert_eq!(super::cluster_retry_wait_upper_ms(10, 100, 100), 101);
+    }
+
+    #[test]
+    fn cluster_retry_wait_time_does_not_panic_when_min_equals_max() {
+        let p = super::RetryParams {
+            number_of_retries: 16,
+            max_wait_time: 100,
+            min_wait_time: 100,
+            exponent_base: 2,
+            factor: 10,
+        };
+        let _ = p.wait_time_for_retry(0);
     }
 }

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -97,12 +97,15 @@ impl Default for RetryParams {
     }
 }
 
+/// Exclusive upper bound (ms) for [`RetryParams::wait_time_for_retry`] jitter; see [`ClusterClientBuilder::retry_wait_formula`].
+fn cluster_retry_wait_upper_ms(base_wait: u64, min_wait: u64, max_wait: u64) -> u64 {
+    base_wait.max(min_wait + 1).min(max_wait)
+}
+
 impl RetryParams {
     pub(crate) fn wait_time_for_retry(&self, retry: u32) -> Duration {
         let base_wait = self.exponent_base.pow(retry) * self.factor;
-        let clamped_wait = base_wait
-            .min(self.max_wait_time)
-            .max(self.min_wait_time + 1);
+        let clamped_wait = cluster_retry_wait_upper_ms(base_wait, self.min_wait_time, self.max_wait_time);
         let jittered_wait = rand::rng().random_range(self.min_wait_time..clamped_wait);
         Duration::from_millis(jittered_wait)
     }
@@ -1060,5 +1063,12 @@ mod tests {
             client.cluster_params.connection_concurrency_limit,
             Some(128)
         );
+    }
+
+    #[test]
+    fn cluster_retry_wait_upper_caps_max_when_min_plus_one_exceeds_max() {
+        // When min_retry_wait + 1 > max_retry_wait, applying `.min(max).max(min+1)` can exceed
+        // `max_retry_wait`; the backoff upper bound must be capped at `max_retry_wait` after the floor.
+        assert_eq!(super::cluster_retry_wait_upper_ms(10, 100, 50), 50);
     }
 }

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -105,7 +105,8 @@ fn cluster_retry_wait_upper_ms(base_wait: u64, min_wait: u64, max_wait: u64) -> 
 impl RetryParams {
     pub(crate) fn wait_time_for_retry(&self, retry: u32) -> Duration {
         let base_wait = self.exponent_base.pow(retry) * self.factor;
-        let clamped_wait = cluster_retry_wait_upper_ms(base_wait, self.min_wait_time, self.max_wait_time);
+        let clamped_wait =
+            cluster_retry_wait_upper_ms(base_wait, self.min_wait_time, self.max_wait_time);
         let jittered_wait = rand::rng().random_range(self.min_wait_time..clamped_wait);
         Duration::from_millis(jittered_wait)
     }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -2410,8 +2410,10 @@ mod cluster_async {
         } = MockEnv::with_client_builder(
             ClusterClient::builder(vec![&*format!("redis://{name}")])
                 .retries(5)
-                .max_retry_wait(2)
-                .min_retry_wait(2),
+                // Backoff must exceed the outer timeout; 1 ms was too tight (timeout could win
+                // before the first mock request on slow CI).
+                .max_retry_wait(64)
+                .min_retry_wait(64),
             name,
             move |received_cmd: &[u8], _| {
                 respond_startup(name, received_cmd)?;
@@ -2432,14 +2434,13 @@ mod cluster_async {
         runtime.block_on(async move {
             let err = cmd
                 .exec_async(&mut connection)
-                .timeout(futures_time::time::Duration::from_millis(1))
+                // Fires after the first TRYAGAIN returns but before min_retry_wait elapses.
+                .timeout(futures_time::time::Duration::from_millis(32))
                 .await
                 .unwrap_err();
             assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
 
-            // we sleep here, to allow the cluster connection time to retry. We expect it won't, but without this
-            // sleep the test will complete before the the runtime gave the connection time to retry, which would've made the
-            // test pass regardless of whether the connection tries retrying or not.
+            // Give the driver a chance to run a spurious retry if the drop path regressed.
             sleep(Duration::from_millis(10).into()).await;
         });
 


### PR DESCRIPTION
Cluster retry jitter used .min(max_wait).max(min_wait + 1), which can exceed max_retry_wait when min_retry_wait + 1 > max_retry_wait, contradicting retry_wait_formula.

Extract cluster_retry_wait_upper_ms with .max(min_wait + 1).min(max_wait) and add a regression test.

Based on https://github.com/redis-rs/redis-rs/pull/2018, which seems to be abandoned.