### PR TITLE
Add async address selection policy

### DIFF
--- a/redis/src/aio/connection.rs
+++ b/redis/src/aio/connection.rs
@@ -1,6 +1,7 @@
 use super::AsyncDNSResolver;
 use super::RedisRuntime;
 
+use crate::AsyncConnectionAddrSelection;
 use crate::connection::{ConnectionAddr, ConnectionInfo};
 #[cfg(feature = "aio")]
 use crate::types::RedisResult;
@@ -11,20 +12,20 @@ use crate::pipeline::Pipeline;
 use crate::{FromRedisValue, RedisError, ToRedisArgs};
 use futures_util::future::select_ok;
 use std::future::Future;
+use std::net::SocketAddr;
 
 pub(crate) async fn connect_simple<T: RedisRuntime>(
     connection_info: &ConnectionInfo,
     dns_resolver: &dyn AsyncDNSResolver,
+    connection_addr_selection: &AsyncConnectionAddrSelection,
 ) -> RedisResult<T> {
     Ok(match connection_info.addr {
         ConnectionAddr::Tcp(ref host, port) => {
             let socket_addrs = dns_resolver.resolve(host, port).await?;
-            select_ok(
-                socket_addrs
-                    .map(|addr| Box::pin(<T>::connect_tcp(addr, &connection_info.tcp_settings))),
-            )
+            connect_with_addr_selection(socket_addrs, connection_addr_selection, |addr| {
+                <T>::connect_tcp(addr, &connection_info.tcp_settings)
+            })
             .await?
-            .0
         }
 
         #[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
@@ -35,17 +36,16 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             ref tls_params,
         } => {
             let socket_addrs = dns_resolver.resolve(host, port).await?;
-            select_ok(socket_addrs.map(|socket_addr| {
-                Box::pin(<T>::connect_tcp_tls(
+            connect_with_addr_selection(socket_addrs, connection_addr_selection, |socket_addr| {
+                <T>::connect_tcp_tls(
                     host,
                     socket_addr,
                     insecure,
                     tls_params,
                     &connection_info.tcp_settings,
-                ))
-            }))
+                )
+            })
             .await?
-            .0
         }
 
         #[cfg(not(any(feature = "tls-native-tls", feature = "tls-rustls")))]
@@ -68,6 +68,49 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             ))
         }
     })
+}
+
+async fn connect_with_addr_selection<T, F, Fut>(
+    socket_addrs: impl Iterator<Item = SocketAddr>,
+    connection_addr_selection: &AsyncConnectionAddrSelection,
+    mut connect: F,
+) -> RedisResult<T>
+where
+    F: FnMut(SocketAddr) -> Fut,
+    Fut: Future<Output = RedisResult<T>>,
+{
+    match connection_addr_selection {
+        AsyncConnectionAddrSelection::Race => {
+            select_ok(socket_addrs.map(|addr| Box::pin(connect(addr))))
+                .await
+                .map(|(connection, _)| connection)
+        }
+        AsyncConnectionAddrSelection::Sequential => connect_sequential(socket_addrs, connect).await,
+    }
+}
+
+async fn connect_sequential<T, F, Fut>(
+    socket_addrs: impl Iterator<Item = SocketAddr>,
+    mut connect: F,
+) -> RedisResult<T>
+where
+    F: FnMut(SocketAddr) -> Fut,
+    Fut: Future<Output = RedisResult<T>>,
+{
+    let mut last_error = None;
+    for socket_addr in socket_addrs {
+        match connect(socket_addr).await {
+            Ok(connection) => return Ok(connection),
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        RedisError::from((
+            crate::errors::ErrorKind::InvalidClientConfig,
+            "No address found for host",
+        ))
+    }))
 }
 
 /// Executes a Redis transaction asynchronously by automatically watching keys and running
@@ -167,6 +210,9 @@ mod tests {
     use crate::cluster_async;
 
     use super::super::*;
+    use super::connect_sequential;
+    use crate::{ErrorKind, RedisError};
+    use std::{future::ready, net::SocketAddr};
 
     #[test]
     fn test_is_sync() {
@@ -192,5 +238,57 @@ mod tests {
         assert_send::<ConnectionManager>();
         #[cfg(feature = "cluster-async")]
         assert_send::<cluster_async::ClusterConnection>();
+    }
+
+    #[test]
+    fn connect_sequential_uses_first_successful_address() {
+        futures::executor::block_on(async {
+            let first_addr: SocketAddr = "127.0.0.1:6379".parse().unwrap();
+            let second_addr: SocketAddr = "127.0.0.1:6380".parse().unwrap();
+            let mut attempts = 0;
+
+            let selected = connect_sequential([first_addr, second_addr].into_iter(), |addr| {
+                attempts += 1;
+                ready(if attempts == 1 {
+                    Err(RedisError::from((
+                        ErrorKind::Io,
+                        "synthetic connection failure",
+                    )))
+                } else {
+                    Ok(addr)
+                })
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(selected, second_addr);
+            assert_eq!(attempts, 2);
+        });
+    }
+
+    #[test]
+    fn connect_sequential_returns_last_connection_error() {
+        futures::executor::block_on(async {
+            let first_addr: SocketAddr = "127.0.0.1:6379".parse().unwrap();
+            let second_addr: SocketAddr = "127.0.0.1:6380".parse().unwrap();
+            let mut attempts = 0;
+
+            let result = connect_sequential([first_addr, second_addr].into_iter(), |_addr| {
+                attempts += 1;
+                let error_kind = if attempts == 1 {
+                    ErrorKind::Client
+                } else {
+                    ErrorKind::Io
+                };
+                ready(Err::<(), _>(RedisError::from((
+                    error_kind,
+                    "synthetic connection failure",
+                ))))
+            })
+            .await;
+
+            assert_eq!(result.unwrap_err().kind(), ErrorKind::Io);
+            assert_eq!(attempts, 2);
+        });
     }
 }

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -181,6 +181,19 @@ pub(crate) const DEFAULT_RESPONSE_TIMEOUT: Option<Duration> = Some(Duration::fro
 #[cfg(any(feature = "aio", feature = "cluster"))]
 pub(crate) const DEFAULT_CONNECTION_TIMEOUT: Option<Duration> = Some(Duration::from_secs(1));
 
+/// Controls how async TCP connection attempts use addresses returned by DNS resolution.
+#[cfg(feature = "aio")]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum AsyncConnectionAddrSelection {
+    /// Race connection attempts to all resolved socket addresses and use the first
+    /// successful connection.
+    #[default]
+    Race,
+    /// Try resolved socket addresses in iterator order until one connects.
+    Sequential,
+}
+
 /// Options for creation of async connection
 #[cfg(feature = "aio")]
 #[derive(Clone)]
@@ -193,6 +206,7 @@ pub struct AsyncConnectionConfig {
     #[cfg(feature = "cache-aio")]
     pub(crate) cache: Option<Cache>,
     pub(crate) dns_resolver: Option<std::sync::Arc<dyn AsyncDNSResolver>>,
+    pub(crate) connection_addr_selection: AsyncConnectionAddrSelection,
     pub(crate) pipeline_buffer_size: Option<usize>,
     pub(crate) concurrency_limit: Option<usize>,
     /// Optional credentials provider for dynamic authentication (e.g., token-based authentication)
@@ -210,6 +224,7 @@ impl Default for AsyncConnectionConfig {
             #[cfg(feature = "cache-aio")]
             cache: Default::default(),
             dns_resolver: Default::default(),
+            connection_addr_selection: Default::default(),
             pipeline_buffer_size: None,
             concurrency_limit: None,
             #[cfg(feature = "token-based-authentication")]
@@ -306,6 +321,18 @@ impl AsyncConnectionConfig {
         dns_resolver: std::sync::Arc<dyn AsyncDNSResolver>,
     ) -> Self {
         self.dns_resolver = Some(dns_resolver);
+        self
+    }
+
+    /// Set how async TCP connection attempts use addresses returned by DNS resolution.
+    ///
+    /// The default is [`AsyncConnectionAddrSelection::Race`], which preserves the
+    /// existing redis-rs behavior of racing all returned socket addresses.
+    pub fn set_connection_addr_selection(
+        mut self,
+        connection_addr_selection: AsyncConnectionAddrSelection,
+    ) -> Self {
+        self.connection_addr_selection = connection_addr_selection;
         self
     }
 
@@ -550,7 +577,9 @@ impl Client {
             .dns_resolver
             .as_deref()
             .unwrap_or(&DefaultAsyncDNSResolver);
-        let con = self.get_simple_async_connection::<T>(resolver).await?;
+        let con = self
+            .get_simple_async_connection::<T>(resolver, &config.connection_addr_selection)
+            .await?;
         crate::aio::MultiplexedConnection::new_with_config(
             &self.connection_info.redis,
             con,
@@ -566,14 +595,20 @@ impl Client {
         match Runtime::locate() {
             #[cfg(feature = "tokio-comp")]
             Runtime::Tokio => {
-                self.get_simple_async_connection::<crate::aio::tokio::Tokio>(dns_resolver)
-                    .await
+                self.get_simple_async_connection::<crate::aio::tokio::Tokio>(
+                    dns_resolver,
+                    &AsyncConnectionAddrSelection::Race,
+                )
+                .await
             }
 
             #[cfg(feature = "smol-comp")]
             Runtime::Smol => {
-                self.get_simple_async_connection::<crate::aio::smol::Smol>(dns_resolver)
-                    .await
+                self.get_simple_async_connection::<crate::aio::smol::Smol>(
+                    dns_resolver,
+                    &AsyncConnectionAddrSelection::Race,
+                )
+                .await
             }
         }
     }
@@ -581,15 +616,18 @@ impl Client {
     async fn get_simple_async_connection<T>(
         &self,
         dns_resolver: &dyn AsyncDNSResolver,
+        connection_addr_selection: &AsyncConnectionAddrSelection,
     ) -> RedisResult<Pin<Box<dyn crate::aio::AsyncStream + Send + Sync>>>
     where
         T: crate::aio::RedisRuntime,
     {
-        Ok(
-            crate::aio::connect_simple::<T>(&self.connection_info, dns_resolver)
-                .await?
-                .boxed(),
+        Ok(crate::aio::connect_simple::<T>(
+            &self.connection_info,
+            dns_resolver,
+            connection_addr_selection,
         )
+        .await?
+        .boxed())
     }
 
     #[cfg(feature = "connection-manager")]
@@ -693,5 +731,22 @@ mod test {
     fn test_async_connection_config_concurrency_limit_custom() {
         let config = AsyncConnectionConfig::new().set_concurrency_limit(128);
         assert_eq!(config.concurrency_limit, Some(128));
+    }
+
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_async_connection_config_addr_selection() {
+        let config = AsyncConnectionConfig::new();
+        assert_eq!(
+            config.connection_addr_selection,
+            AsyncConnectionAddrSelection::Race
+        );
+
+        let config = AsyncConnectionConfig::new()
+            .set_connection_addr_selection(AsyncConnectionAddrSelection::Sequential);
+        assert_eq!(
+            config.connection_addr_selection,
+            AsyncConnectionAddrSelection::Sequential
+        );
     }
 }

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -639,9 +639,9 @@ let primary = sentinel.get_async_connection().await.unwrap();
 )]
 
 // public api
-#[cfg(feature = "aio")]
-pub use crate::client::AsyncConnectionConfig;
 pub use crate::client::Client;
+#[cfg(feature = "aio")]
+pub use crate::client::{AsyncConnectionAddrSelection, AsyncConnectionConfig};
 #[cfg(feature = "cache-aio")]
 pub use crate::cmd::CommandCacheConfig;
 pub use crate::cmd::{Arg, Cmd, Iter, cmd, pack_command, pipe};


### PR DESCRIPTION
## Summary

Adds an async connection address selection policy so callers can choose whether redis-rs races all DNS results or connects to resolved addresses sequentially.

`AsyncConnectionAddrSelection::Race` remains the default and preserves existing behavior. `Sequential` tries resolved socket addresses in iterator order, which lets custom DNS resolvers control address distribution for `AsyncConnectionConfig` users.

The setting is wired through multiplexed async connections. The policy type lives next to `AsyncConnectionConfig` and is re-exported as `redis::AsyncConnectionAddrSelection`.

Refs #2161.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p redis --features tokio-comp --lib addr_selection`
- `cargo test -p redis --features tokio-comp --lib connect_sequential`
- `cargo clippy -p redis --features tokio-comp --lib -- -D warnings`
- `cargo check -p redis --features cluster`
- `cargo check -p redis --features tokio-comp,connection-manager`
- `cargo check -p redis --features tokio-rustls-comp`
- `cargo check -p redis --features tokio-native-tls-comp`
- `cargo check -p redis --no-default-features --features tokio-comp`
- `cargo check -p redis --no-default-features --features cluster-async,tokio-comp`
- `cargo check -p redis --no-default-features --features cluster-async,smol-comp`
- `cargo check -p redis --no-default-features --features smol-comp,connection-manager`
- `cargo doc -p redis --no-deps --features tokio-comp,connection-manager,cluster-async`
