### PR TITLE
perf(pipeline): skip result-filter rebuild when nothing is ignored

### DIFF
--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -358,6 +358,12 @@ macro_rules! implement_pipeline_commands {
             }
 
             fn filter_ignored_results(&self, resp: Vec<Value>) -> Vec<Value> {
+                // Common case: nothing was `.ignore()`d, so every result is kept.
+                // Return the response as-is instead of rebuilding the whole
+                // `Vec<Value>` (which would reallocate and move every element).
+                if self.ignored_commands.is_empty() {
+                    return resp;
+                }
                 resp.into_iter()
                     .enumerate()
                     .filter_map(|(index, result)| {


### PR DESCRIPTION
## Change

`Pipeline::filter_ignored_results` rebuilt the entire `Vec<Value>` (reallocating and moving every element) even when no command in the pipeline was `.ignore()`d — the common case. This returns the response as-is when `ignored_commands` is empty:

```rust
fn filter_ignored_results(&self, resp: Vec<Value>) -> Vec<Value> {
    if self.ignored_commands.is_empty() {
        return resp;
    }
    // …unchanged filtering path…
}
```

It's a pure identity in that case — filtering with an empty ignore set keeps every element in order — so behaviour is unchanged; only one full-response allocation + element move per pipeline query is avoided. Both the sync and async pipeline query paths (`compose_response`) benefit.

## Why

Profiling a pipelined `GET` workload showed `compose_response`/`filter_ignored_results` as a meaningful share of client CPU once parsing was cheap, and the filter rebuild is wasted work whenever nothing is ignored.

## Benchmarks

Pipelined `GET`, quiet Cascade Lake box:

| bench | before | after | Δ |
|---|---|---|---|
| `get_pipeline/sync_tls/16` | 1.575 Melem/s | 1.610 | +2.2% |
| `get_pipeline/async_tls/16` | 1.732 Melem/s | 1.782 | +2.9% |
| `get_pipeline/sync_tls/256` | 823 Kelem/s | 852 | +3.5% |
| `get_pipeline/async_tls/256` | 1.382 Melem/s | 1.431 | +3.6% |

## Correctness

Existing pipeline tests — including the `.ignore()`, server-error, and transaction cases — pass unchanged; fmt + clippy clean. Independent of the parser fast-path PRs (#2184/#2185); touches only `pipeline.rs`.
