### PR TITLE
perf(cmd): encode into the Vec buffer instead of via io::Write

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -8,7 +8,7 @@ use futures_util::{
 use std::pin::Pin;
 #[cfg(feature = "cache-aio")]
 use std::time::Duration;
-use std::{fmt, io, io::Write};
+use std::{fmt, io::Write};
 
 use crate::pipeline::Pipeline;
 use crate::types::{FromRedisValue, RedisResult, RedisWrite, ToRedisArgs, from_redis_value};
@@ -330,19 +330,23 @@ where
 
     cmd.reserve(totlen);
 
-    write_command(cmd, args, cursor).unwrap()
+    write_command(cmd, args, cursor)
 }
 
-fn write_command<'a, I>(cmd: &mut (impl ?Sized + Write), args: I, cursor: u64) -> io::Result<()>
+// Both encoding entry points target an in-memory, pre-reserved `Vec<u8>`, so
+// write directly with `extend_from_slice` rather than through the generic
+// `io::Write` machinery (which wraps every one of the ~5 writes per argument in
+// a `Result` and a `write_all` loop). The buffer is sized by `args_len` first,
+// so these extends never reallocate on the hot path.
+fn write_command<'a, I>(cmd: &mut Vec<u8>, args: I, cursor: u64)
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + Clone + ExactSizeIterator,
 {
     let mut buf = ::itoa::Buffer::new();
 
-    cmd.write_all(b"*")?;
-    let s = buf.format(args.len());
-    cmd.write_all(s.as_bytes())?;
-    cmd.write_all(b"\r\n")?;
+    cmd.extend_from_slice(b"*");
+    cmd.extend_from_slice(buf.format(args.len()).as_bytes());
+    cmd.extend_from_slice(b"\r\n");
 
     let mut cursor_bytes = itoa::Buffer::new();
     for item in args {
@@ -351,15 +355,13 @@ where
             Arg::Simple(val) => val,
         };
 
-        cmd.write_all(b"$")?;
-        let s = buf.format(bytes.len());
-        cmd.write_all(s.as_bytes())?;
-        cmd.write_all(b"\r\n")?;
+        cmd.extend_from_slice(b"$");
+        cmd.extend_from_slice(buf.format(bytes.len()).as_bytes());
+        cmd.extend_from_slice(b"\r\n");
 
-        cmd.write_all(bytes)?;
-        cmd.write_all(b"\r\n")?;
+        cmd.extend_from_slice(bytes);
+        cmd.extend_from_slice(b"\r\n");
     }
-    Ok(())
 }
 
 impl RedisWrite for Cmd {
@@ -625,7 +627,7 @@ impl Cmd {
     }
 
     pub(crate) fn write_packed_command_preallocated(&self, cmd: &mut Vec<u8>) {
-        write_command(cmd, self.args_iter(), self.cursor.unwrap_or(0)).unwrap()
+        write_command(cmd, self.args_iter(), self.cursor.unwrap_or(0))
     }
 
     /// Returns true if the command is in scan mode.

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -333,11 +333,6 @@ where
     write_command(cmd, args, cursor)
 }
 
-// Both encoding entry points target an in-memory, pre-reserved `Vec<u8>`, so
-// write directly with `extend_from_slice` rather than through the generic
-// `io::Write` machinery (which wraps every one of the ~5 writes per argument in
-// a `Result` and a `write_all` loop). The buffer is sized by `args_len` first,
-// so these extends never reallocate on the hot path.
 fn write_command<'a, I>(cmd: &mut Vec<u8>, args: I, cursor: u64)
 where
     I: IntoIterator<Item = Arg<&'a [u8]>> + Clone + ExactSizeIterator,


### PR DESCRIPTION
## Change

`write_command` is only ever called with a pre-reserved `Vec<u8>` (both call sites). It went through the generic `io::Write` trait — a `Result`-wrapped `write_all` for each of ~5 pieces per argument. This writes directly with `extend_from_slice` instead.

Output is byte-identical: `Vec<u8>`'s `write_all` *is* `extend_from_slice`; the buffer is already sized by `args_len` before writing, so no reallocation happens on the hot path.

## Benchmarks

Quiet Cascade Lake box, `bench_basic`:

| bench | before | after | Δ |
|---|---|---|---|
| `encode/small` | 252 ns | 219 ns | **−13%** |
| `encode/integer` / `encode/pipeline` | — | — | flat |

End-to-end, a pipelined `GET` over the multiplexed connection is **~+2–3%** (each query re-encodes its commands, so `encode_pipeline`/`write_command` are a real share of the client CPU).

## Correctness

Byte-identical output; `make lint` clean and `make test` green (975+ tests across the tcp/tls/unix × RESP2/RESP3 matrices). Independent change — `cmd.rs` only.
