### PR TITLE
Make backpressure boundary configurable

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -44,7 +44,7 @@ futures-util = { version = "0.3.31", default-features = false, features = [
   "sink",
 ], optional = true }
 pin-project-lite = { version = "0.2", optional = true }
-tokio-util = { version = "0.7", optional = true }
+tokio-util = { version = "0.7.5", optional = true }
 async-lock = { version = "3", optional = true }
 tokio = { version = "1", features = [
   "sync",

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -890,8 +890,8 @@ mod tests {
         assert_eq!(config.write_backpressure_boundary, Some(16 * 1024 * 1024));
     }
 
-    #[test]
-    fn test_lazy_connection_manager_with_config() {
+    #[tokio::test]
+    async fn test_lazy_connection_manager_with_config() {
         // Test that lazy connection manager can be created with custom config
         let client = Client::open("redis://127.0.0.1/").unwrap();
         let config = ConnectionManagerConfig::new()
@@ -900,6 +900,18 @@ mod tests {
             .set_number_of_retries(3);
         let result = ConnectionManager::new_lazy_with_config(client, config);
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_lazy_connection_manager_wires_write_backpressure_boundary() {
+        let client = Client::open("redis://127.0.0.1/").unwrap();
+        let config =
+            ConnectionManagerConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        let manager = ConnectionManager::new_lazy_with_config(client, config).unwrap();
+        assert_eq!(
+            manager.0.connection_config.write_backpressure_boundary,
+            Some(16 * 1024 * 1024)
+        );
     }
 
     #[test]

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -878,6 +878,19 @@ mod tests {
     }
 
     #[test]
+    fn test_connection_manager_config_write_backpressure_boundary_default() {
+        let config = ConnectionManagerConfig::new();
+        assert_eq!(config.write_backpressure_boundary, None);
+    }
+
+    #[test]
+    fn test_connection_manager_config_write_backpressure_boundary_custom() {
+        let config =
+            ConnectionManagerConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        assert_eq!(config.write_backpressure_boundary, Some(16 * 1024 * 1024));
+    }
+
+    #[test]
     fn test_lazy_connection_manager_with_config() {
         // Test that lazy connection manager can be created with custom config
         let client = Client::open("redis://127.0.0.1/").unwrap();

--- a/redis/src/aio/connection_manager.rs
+++ b/redis/src/aio/connection_manager.rs
@@ -46,6 +46,8 @@ pub struct ConnectionManagerConfig {
     pub(crate) cache_config: Option<crate::caching::CacheConfig>,
     pipeline_buffer_size: Option<usize>,
     concurrency_limit: Option<usize>,
+    /// Flush threshold for the outbound write buffer; see [`AsyncConnectionConfig::set_write_backpressure_boundary`].
+    write_backpressure_boundary: Option<usize>,
     /// Optional credentials provider for dynamic authentication (e.g., token-based authentication)
     #[cfg(feature = "token-based-authentication")]
     credentials_provider: Option<std::sync::Arc<dyn crate::auth::StreamingCredentialsProvider>>,
@@ -66,6 +68,7 @@ impl std::fmt::Debug for ConnectionManagerConfig {
             cache_config,
             pipeline_buffer_size,
             concurrency_limit,
+            write_backpressure_boundary,
             #[cfg(feature = "token-based-authentication")]
             credentials_provider,
         } = &self;
@@ -79,6 +82,7 @@ impl std::fmt::Debug for ConnectionManagerConfig {
             .field("resubscribe_automatically", &resubscribe_automatically)
             .field("pipeline_buffer_size", &pipeline_buffer_size)
             .field("concurrency_limit", &concurrency_limit)
+            .field("write_backpressure_boundary", &write_backpressure_boundary)
             .field(
                 "push_sender",
                 if push_sender.is_some() {
@@ -273,6 +277,15 @@ impl ConnectionManagerConfig {
         self
     }
 
+    /// Sets the flush threshold (backpressure boundary) for the outbound write buffer.
+    ///
+    /// See [`AsyncConnectionConfig::set_write_backpressure_boundary`] for full semantics.
+    /// When left unset, the connection keeps `tokio_util`'s default boundary.
+    pub fn set_write_backpressure_boundary(mut self, boundary: usize) -> Self {
+        self.write_backpressure_boundary = Some(boundary);
+        self
+    }
+
     /// Sets a credentials provider for dynamic authentication.
     ///
     /// This is useful for token-based authentication where credentials need to be
@@ -319,6 +332,7 @@ impl Default for ConnectionManagerConfig {
             cache_config: None,
             pipeline_buffer_size: None,
             concurrency_limit: None,
+            write_backpressure_boundary: None,
             #[cfg(feature = "token-based-authentication")]
             credentials_provider: None,
         }
@@ -476,6 +490,7 @@ impl ConnectionManager {
             .set_response_timeout(config.response_timeout);
         connection_config.pipeline_buffer_size = config.pipeline_buffer_size;
         connection_config.concurrency_limit = config.concurrency_limit;
+        connection_config.write_backpressure_boundary = config.write_backpressure_boundary;
 
         #[cfg(feature = "cache-aio")]
         let cache_manager = config

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -600,6 +600,9 @@ impl MultiplexedConnection {
         C: Unpin + AsyncRead + AsyncWrite + Send + 'static,
     {
         let mut codec = ValueCodec::default().framed(stream);
+        if let Some(boundary) = config.write_backpressure_boundary {
+            codec.set_backpressure_boundary(boundary);
+        }
         if config.push_sender.is_some() {
             check_resp3!(
                 connection_info.protocol,

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -717,4 +717,18 @@ mod test {
         let config = AsyncConnectionConfig::new().set_concurrency_limit(128);
         assert_eq!(config.concurrency_limit, Some(128));
     }
+
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_async_connection_config_write_backpressure_boundary_default() {
+        let config = AsyncConnectionConfig::new();
+        assert_eq!(config.write_backpressure_boundary, None);
+    }
+
+    #[cfg(feature = "aio")]
+    #[test]
+    fn test_async_connection_config_write_backpressure_boundary_custom() {
+        let config = AsyncConnectionConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        assert_eq!(config.write_backpressure_boundary, Some(16 * 1024 * 1024));
+    }
 }

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -195,6 +195,8 @@ pub struct AsyncConnectionConfig {
     pub(crate) dns_resolver: Option<std::sync::Arc<dyn AsyncDNSResolver>>,
     pub(crate) pipeline_buffer_size: Option<usize>,
     pub(crate) concurrency_limit: Option<usize>,
+    /// Flush threshold for the outbound write buffer; see [`AsyncConnectionConfig::set_write_backpressure_boundary`].
+    pub(crate) write_backpressure_boundary: Option<usize>,
     /// Optional credentials provider for dynamic authentication (e.g., token-based authentication)
     #[cfg(feature = "token-based-authentication")]
     pub(crate) credentials_provider: Option<std::sync::Arc<dyn StreamingCredentialsProvider>>,
@@ -212,6 +214,7 @@ impl Default for AsyncConnectionConfig {
             dns_resolver: Default::default(),
             pipeline_buffer_size: None,
             concurrency_limit: None,
+            write_backpressure_boundary: None,
             #[cfg(feature = "token-based-authentication")]
             credentials_provider: None,
         }
@@ -348,6 +351,26 @@ impl AsyncConnectionConfig {
     /// By default there is no limit.
     pub fn set_concurrency_limit(mut self, limit: usize) -> Self {
         self.concurrency_limit = Some(limit);
+        self
+    }
+
+    /// Sets the flush threshold (backpressure boundary) for the outbound write buffer.
+    ///
+    /// The multiplexed connection encodes commands into an in-memory buffer before
+    /// writing them to the socket. This value controls how many bytes may accumulate
+    /// in that buffer before the connection flushes to the socket and applies
+    /// backpressure to newly queued commands.
+    ///
+    /// With a small threshold the buffer flushes frequently and, when commands are
+    /// produced faster than the socket drains, it repeatedly grows by reallocation. A
+    /// larger threshold lets the buffer reach a stable capacity and batch larger writes,
+    /// trading a higher peak memory bound (roughly this many bytes per connection) for
+    /// fewer reallocations and syscalls. The buffer still grows lazily, so idle
+    /// connections do not hold this much memory.
+    ///
+    /// When left unset, the connection keeps `tokio_util`'s default boundary (8 KiB).
+    pub fn set_write_backpressure_boundary(mut self, boundary: usize) -> Self {
+        self.write_backpressure_boundary = Some(boundary);
         self
     }
 

--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -1536,6 +1536,9 @@ where
     if let Some(limit) = params.connection_concurrency_limit {
         config = config.set_concurrency_limit(limit);
     }
+    if let Some(boundary) = params.write_backpressure_boundary {
+        config = config.set_write_backpressure_boundary(boundary);
+    }
     let mut conn = match C::connect_with_config(info, config).await {
         Ok(conn) => conn,
         Err(err) => {

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -69,6 +69,8 @@ struct BuilderParams {
     overall_response_timeout: OverallResponseTimeout,
     #[cfg(feature = "cluster-async")]
     connection_concurrency_limit: Option<usize>,
+    #[cfg(feature = "cluster-async")]
+    write_backpressure_boundary: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -155,6 +157,8 @@ pub(crate) struct ClusterParams {
     pub(crate) overall_response_timeout: Option<Duration>,
     #[cfg(feature = "cluster-async")]
     pub(crate) connection_concurrency_limit: Option<usize>,
+    #[cfg(feature = "cluster-async")]
+    pub(crate) write_backpressure_boundary: Option<usize>,
 }
 
 impl ClusterParams {
@@ -219,6 +223,8 @@ impl ClusterParams {
             },
             #[cfg(feature = "cluster-async")]
             connection_concurrency_limit: value.connection_concurrency_limit,
+            #[cfg(feature = "cluster-async")]
+            write_backpressure_boundary: value.write_backpressure_boundary,
         })
     }
 
@@ -671,6 +677,18 @@ impl ClusterClientBuilder {
         self
     }
 
+    /// Sets the flush threshold (backpressure boundary) for each node connection's outbound write buffer.
+    ///
+    /// See [`crate::AsyncConnectionConfig::set_write_backpressure_boundary`] for full semantics.
+    /// This value is applied identically to every node connection in the cluster.
+    ///
+    /// When left unset, connections keep `tokio_util`'s default boundary.
+    #[cfg(feature = "cluster-async")]
+    pub fn write_backpressure_boundary(mut self, boundary: usize) -> ClusterClientBuilder {
+        self.builder_params.write_backpressure_boundary = Some(boundary);
+        self
+    }
+
     /// Sets a credentials provider for dynamic authentication (e.g., token-based authentication)
     /// on all cluster node connections.
     ///
@@ -1071,6 +1089,26 @@ mod tests {
         assert_eq!(
             client.cluster_params.connection_concurrency_limit,
             Some(128)
+        );
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn write_backpressure_boundary_default() {
+        let client = ClusterClient::new(get_connection_data()).unwrap();
+        assert_eq!(client.cluster_params.write_backpressure_boundary, None);
+    }
+
+    #[cfg(feature = "cluster-async")]
+    #[test]
+    fn write_backpressure_boundary_custom() {
+        let client = ClusterClientBuilder::new(get_connection_data())
+            .write_backpressure_boundary(16 * 1024 * 1024)
+            .build()
+            .unwrap();
+        assert_eq!(
+            client.cluster_params.write_backpressure_boundary,
+            Some(16 * 1024 * 1024)
         );
     }
 

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -155,6 +155,21 @@ mod basic_async {
     }
 
     #[async_test]
+    async fn set_write_backpressure_boundary_does_not_break_connection() {
+        let ctx = TestContext::new();
+        let config =
+            redis::AsyncConnectionConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
+        let mut conn = ctx
+            .client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await
+            .unwrap();
+        let _: () = conn.set("key", "value").await.unwrap();
+        let result: String = conn.get("key").await.unwrap();
+        assert_eq!(result, "value");
+    }
+
+    #[async_test]
     async fn can_authenticate_with_username_and_password() {
         let ctx = TestContext::new();
         let mut con = ctx.async_connection().await.unwrap();


### PR DESCRIPTION
We're using redis with larger payloads (~16MB P99s)
We see significant churn from CPU profiles that we were able to attribute to the tokio framed reallocations on writes because it frequently flushes and grows to a bounded set.

I was hoping we could simply reconfigure the backpressure boundary but that lever is not exposed by redis-rs
This PR is an attempt to change that. Please let me know if this direction is acceptable or if the knob exposes too much of the internals of how the crate works.