### PR TITLE
perf(cmd): encode expiry options via itoa instead of format!/to_string

### DIFF
--- a/redis/benches/bench_basic.rs
+++ b/redis/benches/bench_basic.rs
@@ -214,6 +214,22 @@ fn bench_encode_integer(b: &mut Bencher) {
     });
 }
 
+fn bench_encode_set_ex(b: &mut Bencher) {
+    // `SET key val EX <secs>` — exercises the `SetExpiry` option encoder.
+    b.iter(|| {
+        let mut pipe = redis::pipe();
+
+        for _ in 0..1_000 {
+            pipe.cmd("SET")
+                .arg("session:abc123")
+                .arg("some-value")
+                .arg(redis::SetExpiry::EX(3600))
+                .ignore();
+        }
+        pipe.get_packed_pipeline()
+    });
+}
+
 fn bench_encode_pipeline(b: &mut Bencher) {
     b.iter(|| {
         let mut pipe = redis::pipe();
@@ -248,7 +264,8 @@ fn bench_encode(c: &mut Criterion) {
         .bench_function("pipeline", bench_encode_pipeline)
         .bench_function("pipeline_nested", bench_encode_pipeline_nested)
         .bench_function("integer", bench_encode_integer)
-        .bench_function("small", bench_encode_small);
+        .bench_function("small", bench_encode_small)
+        .bench_function("set_ex", bench_encode_set_ex);
     group.finish();
 }
 

--- a/redis/src/commands/mod.rs
+++ b/redis/src/commands/mod.rs
@@ -3805,22 +3805,23 @@ impl ToRedisArgs for Expiry {
     where
         W: ?Sized + RedisWrite,
     {
+        let mut buf = ::itoa::Buffer::new();
         match self {
             Expiry::EX(sec) => {
                 out.write_arg(b"EX");
-                out.write_arg(sec.to_string().as_bytes());
+                out.write_arg(buf.format(*sec).as_bytes());
             }
             Expiry::PX(ms) => {
                 out.write_arg(b"PX");
-                out.write_arg(ms.to_string().as_bytes());
+                out.write_arg(buf.format(*ms).as_bytes());
             }
             Expiry::EXAT(timestamp_sec) => {
                 out.write_arg(b"EXAT");
-                out.write_arg(timestamp_sec.to_string().as_bytes());
+                out.write_arg(buf.format(*timestamp_sec).as_bytes());
             }
             Expiry::PXAT(timestamp_ms) => {
                 out.write_arg(b"PXAT");
-                out.write_arg(timestamp_ms.to_string().as_bytes());
+                out.write_arg(buf.format(*timestamp_ms).as_bytes());
             }
             Expiry::PERSIST => {
                 out.write_arg(b"PERSIST");

--- a/redis/src/types.rs
+++ b/redis/src/types.rs
@@ -52,22 +52,23 @@ impl ToRedisArgs for SetExpiry {
     where
         W: ?Sized + RedisWrite,
     {
+        let mut buf = ::itoa::Buffer::new();
         match self {
             SetExpiry::EX(secs) => {
                 out.write_arg(b"EX");
-                out.write_arg(format!("{secs}").as_bytes());
+                out.write_arg(buf.format(*secs).as_bytes());
             }
             SetExpiry::PX(millis) => {
                 out.write_arg(b"PX");
-                out.write_arg(format!("{millis}").as_bytes());
+                out.write_arg(buf.format(*millis).as_bytes());
             }
             SetExpiry::EXAT(unix_time) => {
                 out.write_arg(b"EXAT");
-                out.write_arg(format!("{unix_time}").as_bytes());
+                out.write_arg(buf.format(*unix_time).as_bytes());
             }
             SetExpiry::PXAT(unix_time) => {
                 out.write_arg(b"PXAT");
-                out.write_arg(format!("{unix_time}").as_bytes());
+                out.write_arg(buf.format(*unix_time).as_bytes());
             }
             SetExpiry::KEEPTTL => {
                 out.write_arg(b"KEEPTTL");


### PR DESCRIPTION
## What

`SetExpiry` (`SET … EX/PX/EXAT/PXAT`) and `Expiry` (`GETEX …`) serialized their `u64` arguments with `format!("{n}")` / `n.to_string()`, each of which heap-allocates a `String`. This switches both to a stack `itoa::Buffer` — the same primitive already used for every other integer argument in the crate (`itoa_based_to_redis_impl!` in `types.rs`, and `write_command` in `cmd.rs`).

The encoded bytes are identical: both emit the base-10 ASCII digits of the `u64`, with no signs, padding, grouping, or locale involvement. All fields of both enums are `u64`.

## Why

Expiry options are on a hot encode path for expiry-heavy workloads (`SET`-with-TTL, `GETEX`). This removes one heap allocation per expiry argument, matching how the rest of the crate encodes integers.

## Benchmark

Added `encode/set_ex` to `benches/bench_basic.rs` (`SET key val EX 3600` × 1000, packed). This is a pure client-side encode microbenchmark (no server / no network), run locally:

| | time (1000 commands) |
|---|---|
| before (`format!`) | 334 µs |
| after (`itoa`) | **276 µs** (−17%) |

## Correctness

Output is byte-identical, so behavior is unchanged. Verified against a live server:

- `test_getex`, `test_set_options_*` (4), and the expiry tests (`test_*expir*`, `test_mset_ex_*`) — all pass.
- `make lint` clean.
