### PR TITLE
perf: enable TCP_NODELAY by default

### DIFF
--- a/redis/src/io/tcp.rs
+++ b/redis/src/io/tcp.rs
@@ -35,6 +35,14 @@ impl TcpSettings {
     }
 
     /// Sets the value of the `TCP_NODELAY` option on this socket.
+    ///
+    /// Enabled (`true`) by default, disabling Nagle's algorithm, since Redis
+    /// traffic is strictly request-response: coalescing small writes only adds
+    /// latency (most visibly on multiplexed connections under concurrency,
+    /// where Nagle serializes writes to one per ACK round-trip). Set to `false`
+    /// to re-enable Nagle's algorithm, e.g. on packets-per-second-limited
+    /// cloud instances or metered/WAN links where fewer, larger packets are
+    /// preferable to lower latency.
     pub fn set_nodelay(self, nodelay: bool) -> Self {
         Self { nodelay, ..self }
     }
@@ -77,11 +85,16 @@ impl TcpSettings {
     }
 }
 
-#[allow(clippy::derivable_impls)]
 impl Default for TcpSettings {
     fn default() -> Self {
         Self {
-            nodelay: false,
+            // Enabled by default: RESP is strictly request-response and every
+            // write path in this crate already batches commands into a single
+            // buffer, so Nagle's algorithm only ever adds latency here — under
+            // multiplexed concurrency it serializes writes to one per ACK
+            // round-trip. Use `set_nodelay(false)` to re-enable Nagle (e.g. on
+            // packets-per-second-limited or metered links).
+            nodelay: true,
             #[cfg(not(target_family = "wasm"))]
             keepalive: None,
             linger_time: None,

--- a/version2.md
+++ b/version2.md
@@ -12,7 +12,7 @@ redis = "2"
 
 ### TCP_NODELAY is now enabled by default (Breaking Change)
 
-`TcpSettings::default()` now sets `nodelay: true`, disabling Nagle's algorithm on every TCP connection the crate creates (sync and async, plaintext and TLS). Previously Nagle was left enabled, which serialized writes on a multiplexed connection to one per ACK round-trip under concurrency — measured at 39–68% lower throughput and roughly double the p50 latency on a real network (see [#2195](https://github.com/redis-rs/redis-rs/issues/2195) for the full evidence). Sequential request-response traffic is unaffected, and Redis clients in other ecosystems already ship with TCP_NODELAY enabled.
+By default, Nagle's algorithm is now disabled on every TCP connection the crate creates (sync and async, plaintext and TLS). Previously it was left enabled, which serialized writes on a multiplexed connection to one per ACK round-trip under concurrency — measured at 39–68% lower throughput and roughly double the p50 latency on a real network (see [#2195](https://github.com/redis-rs/redis-rs/issues/2195) for the full evidence). Sequential request-response traffic is unaffected, and Redis clients in other ecosystems already ship with TCP_NODELAY enabled.
 
 No API changed, but the wire behavior did: the client now emits more, smaller packets at moderate concurrency. Deployments close to packets-per-second limits (small cloud instances) or on metered/WAN links may prefer the old behavior.
 

--- a/version2.md
+++ b/version2.md
@@ -10,6 +10,21 @@ redis = "2"
 
 ## Breaking Changes
 
+### TCP_NODELAY is now enabled by default (Breaking Change)
+
+`TcpSettings::default()` now sets `nodelay: true`, disabling Nagle's algorithm on every TCP connection the crate creates (sync and async, plaintext and TLS). Previously Nagle was left enabled, which serialized writes on a multiplexed connection to one per ACK round-trip under concurrency — measured at 39–68% lower throughput and roughly double the p50 latency on a real network (see [#2195](https://github.com/redis-rs/redis-rs/issues/2195) for the full evidence). Sequential request-response traffic is unaffected, and Redis clients in other ecosystems already ship with TCP_NODELAY enabled.
+
+No API changed, but the wire behavior did: the client now emits more, smaller packets at moderate concurrency. Deployments close to packets-per-second limits (small cloud instances) or on metered/WAN links may prefer the old behavior.
+
+**Migration:** nothing to do for most users — expect lower latency and higher multiplexed throughput. To keep Nagle's algorithm:
+
+```rust
+use redis::{IntoConnectionInfo, io::tcp::TcpSettings};
+
+let info = "redis://127.0.0.1/".into_connection_info()?
+    .set_tcp_settings(TcpSettings::default().set_nodelay(false));
+```
+
 ### `cmd_iter` yields `CmdRef` instead of `&Cmd` (Breaking Change)
 
 **Most users can upgrade to 2.0.0 with no code changes.** The flattening is an internal representation change; the pipeline builder API (`cmd`, `arg`, `add_command`, `ignore`, `query`, `query_async`, `exec`, …) is unchanged. The only adjustments are needed if you iterate a pipeline's commands or call `with_capacity` directly.


### PR DESCRIPTION
## What

One-line behavioral change: `TcpSettings::default()` now sets `nodelay: true` (TCP_NODELAY on, Nagle's algorithm off) for every connection the crate creates, plus documentation on the field explaining the default and the opt-out.

Full evidence and methodology in #2195. Highlights, measured on two identical bare-metal x86 hosts over a dedicated 1 GbE link (LAN RTT ≈ 0.13–0.38 ms):

- **+39–68% throughput** at 2–32 concurrent tasks on one multiplexed async connection (3 repetitions, stable), plaintext and mTLS alike
- **p50 −27…−46%**, all tail percentiles improve (p9999 under the default spiked to 4.6 ms; ≤930 µs with nodelay)
- 300-second mTLS run: per-second throughput distributions **never overlap** — the best Nagle second is below the worst nodelay second
- Kernel evidence: `ss -ti` shows application bytes held back (`notsent > 0`) in **88.8%** of 20 Hz samples under the default vs 15.4% with nodelay
- Wire evidence: **99.9986%** of outbound data segments depart only immediately after an inbound packet under the default (22 free departures in 1.58 M segments over 5 minutes) — Nagle's ACK-clocking on the wire
- Sequential request-response traffic is unaffected (no unACKed data at write time), which is why single-command benchmarks and loopback testing never surface this

## Why the crate never benefits from Nagle

Every write path already batches: the sync connection serializes each command/pipeline into one buffer and writes it once; the multiplexed sink drains its request channel and only flushes when the channel momentarily empties. There is no many-tiny-writes pattern for Nagle to fix — it only ever adds latency here.

Jedis, Lettuce, go-redis, and StackExchange.Redis all ship with TCP_NODELAY on.

## Trade-offs / opt-out

With nodelay the client emits more, smaller packets at moderate concurrency (~2.3× segments in the 300 s capture). Deployments near packets-per-second caps (small cloud instances) or on metered/WAN links can keep Nagle with a one-line opt-out, now documented on `set_nodelay`:

```rust
TcpSettings::default().set_nodelay(false)
```

This is a behavioral (not API) change; suggest a release-note callout.

## Verification

- `make lint` clean; unit tests and connection smoke tests pass (the change is protocol-invisible — only the socket option differs)
- Reproduction probe (per-second timeline, latency percentiles, plaintext or mTLS): [`redis/examples/nagle_probe.rs` on the fork](https://github.com/fcostaoliveira/redis-rs/blob/main/redis/examples/nagle_probe.rs)

Closes #2195
