### PR TITLE
Versioning improvements

### DIFF
--- a/redis/tests/support/version.rs
+++ b/redis/tests/support/version.rs
@@ -82,35 +82,22 @@ impl<'a> From<&[&[Component<'a>]]> for ComponentMatcher<'a> {
     }
 }
 
-/// Macros to provide array implementations for matchers' slice implementations
+/// Coercing array implementations for matchers' slice implementations
 ///
-/// Rust can auto-coerce array to slices. But with generic arguments, this
+/// Rust can auto-coerce arrays to slices. But with generic arguments, this
 /// array-to-slice-auto-coercion does not kick in. So one would have to convert manually. To avoid
-/// this for the common cases, this macro implements coercing `From`s. for a given array length
-///
-/// # Arguments
-///
-/// * `$n` - The array lengths to implement coercing `From`s for.
-macro_rules! matcher_array_impls {
-    ($n:expr) => {
-        impl<'a> From<[Component<'a>; $n]> for ComponentMatcher<'a> {
-            fn from(value: [Component<'a>; $n]) -> Self {
-                let coerced_value: &[Component<'a>] = &value;
-                Self::from(coerced_value)
-            }
-        }
-
-        impl<'a> From<[&[Component<'a>]; $n]> for ComponentMatcher<'a> {
-            fn from(value: [&[Component<'a>]; $n]) -> Self {
-                let coerced_value: &[&[Component<'a>]] = &value;
-                Self::from(coerced_value)
-            }
-        }
-    };
+/// this, these const-generic `From`s coerce arrays of any length to the corresponding slice matcher.
+impl<'a, const N: usize> From<[Component<'a>; N]> for ComponentMatcher<'a> {
+    fn from(value: [Component<'a>; N]) -> Self {
+        Self::from(value.as_slice())
+    }
 }
-matcher_array_impls!(1);
-matcher_array_impls!(2);
-matcher_array_impls!(3);
+
+impl<'a, const N: usize> From<[&[Component<'a>]; N]> for ComponentMatcher<'a> {
+    fn from(value: [&[Component<'a>]; N]) -> Self {
+        Self::from(value.as_slice())
+    }
+}
 
 #[derive(Clone)]
 pub struct AvailableComponents {


### PR DESCRIPTION
# Versioning improvements

## Summary

This pull request replaces the `matcher_array_impls!` `macro_rules!` with **const-generic `From` impls**.
This makes array matchers of any length work (previously only lengths 1, 2, and 3 were implemented).
Which solves the following problem:
Coercing `From<[Component; N]>` / `From<[&[Component]; N]>` impls were generated by a macro invoked for `N = 1, 2, 3`.
A 4-element matcher would have failed to compile until `matcher_array_impls!(4);` was added and so on.

## What is changed?
### `redis/tests/support/version.rs`

- **Const generics replace the array macro:** 
`matcher_array_impls!` and its three invocations are gone; `From<[Component; N]>` and `From<[&[Component]; N]>` are now single const-generic impls that delegate to the slice `From` via `as_slice()`.
Behavior is identical for existing call sites and arrays of any length now work.

## Compatibility

There are **no changes to the `redis` client library or its public API** - the work is confined to the test support module (`redis/tests/support/version.rs`).