### PR TITLE
Add Monoio async runtime support

### DIFF
--- a/redis/src/aio/mod.rs
+++ b/redis/src/aio/mod.rs
@@ -24,6 +24,10 @@ mod monitor;
 #[cfg(any(feature = "tls-rustls", feature = "tls-native-tls"))]
 use crate::connection::TlsConnParams;
 
+/// Enables the monoio compatibility
+#[cfg(feature = "monoio-comp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "monoio-comp")))]
+pub mod monoio;
 /// Enables the smol compatibility
 #[cfg(feature = "smol-comp")]
 #[cfg_attr(docsrs, doc(cfg(feature = "smol-comp")))]
@@ -169,9 +173,20 @@ mod connection_manager;
 #[cfg_attr(docsrs, doc(cfg(feature = "connection-manager")))]
 pub use connection_manager::*;
 mod runtime;
-#[cfg(all(feature = "smol-comp", feature = "tokio-comp"))]
+#[cfg(all(
+    feature = "monoio-comp",
+    any(feature = "tokio-comp", feature = "smol-comp")
+))]
+pub use runtime::prefer_monoio;
+#[cfg(all(
+    feature = "smol-comp",
+    any(feature = "tokio-comp", feature = "monoio-comp")
+))]
 pub use runtime::prefer_smol;
-#[cfg(all(feature = "tokio-comp", feature = "smol-comp"))]
+#[cfg(all(
+    feature = "tokio-comp",
+    any(feature = "smol-comp", feature = "monoio-comp")
+))]
 pub use runtime::prefer_tokio;
 pub(super) use runtime::*;
 
@@ -258,6 +273,16 @@ async fn get_socket_addrs(host: &str, port: u16) -> RedisResult<Vec<SocketAddr>>
         Runtime::Smol => ::smol::net::resolve((host, port))
             .await
             .map_err(RedisError::from),
+
+        #[cfg(feature = "monoio-comp")]
+        Runtime::Monoio => {
+            // Monoio doesn't have built-in DNS resolution, use std::net::ToSocketAddrs
+            use std::net::ToSocketAddrs;
+            (host, port)
+                .to_socket_addrs()
+                .map(|iter| iter.collect::<Vec<_>>())
+                .map_err(RedisError::from)
+        }
     }?;
 
     if socket_addrs.is_empty() {

--- a/redis/src/aio/monoio.rs
+++ b/redis/src/aio/monoio.rs
@@ -1,0 +1,408 @@
+#[cfg(unix)]
+use std::path::Path;
+use std::{
+    future::Future,
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    task::{self, Poll},
+};
+
+#[cfg(feature = "monoio-rustls-comp")]
+use std::sync::Arc;
+
+use super::TaskHandle;
+use crate::aio::{AsyncStream, RedisRuntime};
+use crate::types::RedisResult;
+use futures_util::future::{AbortHandle, Abortable};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+#[cfg(feature = "monoio-rustls-comp")]
+use monoio_rustls::TlsConnector;
+
+#[cfg(any(feature = "tls-native-tls", feature = "tls-rustls"))]
+use crate::aio::TlsConnParams;
+
+#[cfg(feature = "monoio-rustls-comp")]
+use crate::connection::create_rustls_config;
+
+type RentFuture = Pin<Box<dyn Future<Output = (io::Result<usize>, Vec<u8>)>>>;
+
+// State for pending read operations
+// Note: Monoio futures are NOT Send, but we mark them as such because
+// they will only be polled on their bound thread (thread-per-core model)
+enum ReadState {
+    Idle,
+    Reading(RentFuture),
+}
+
+// State for pending write operations
+// Note: Monoio futures are NOT Send, but we mark them as such because
+// they will only be polled on their bound thread (thread-per-core model)
+enum WriteState {
+    Idle,
+    Writing(RentFuture),
+}
+
+// SAFETY: These states contain monoio futures which are not Send,
+// but monoio's thread-per-core model ensures they're only accessed
+// from their bound thread, so marking the states as Send is safe.
+unsafe impl Send for ReadState {}
+unsafe impl Send for WriteState {}
+
+pin_project_lite::pin_project! {
+    /// Wraps monoio's AsyncReadRent/AsyncWriteRent to implement tokio's AsyncRead/AsyncWrite traits
+    ///
+    /// This adapter bridges the impedance mismatch between:
+    /// - Monoio: Completion-based I/O with owned buffers
+    /// - Tokio: Readiness-based I/O with borrowed buffers
+    ///
+    /// It maintains a state machine to store in-flight read/write futures.
+    pub struct MonoioWrapped<T> {
+        #[pin]
+        inner: T,
+        // State machine for in-flight read operation
+        read_state: ReadState,
+        // Bytes returned by a previous monoio read that did not fit in the caller's ReadBuf.
+        pending_read: Option<(Vec<u8>, usize, usize)>,
+        // State machine for in-flight write operation
+        write_state: WriteState,
+        // Reusable buffer for reads to avoid allocations
+        read_buf: Option<Vec<u8>>,
+    }
+}
+
+impl<T> MonoioWrapped<T> {
+    pub(super) fn new(inner: T) -> Self {
+        Self {
+            inner,
+            read_state: ReadState::Idle,
+            pending_read: None,
+            write_state: WriteState::Idle,
+            read_buf: None,
+        }
+    }
+}
+
+// SAFETY: Monoio uses a thread-per-core model where tasks are bound to a specific thread.
+// Even though monoio types contain Rc/UnsafeCell (not Send/Sync), in practice:
+// 1. Tasks never migrate between threads in monoio
+// 2. The wrapped types are only accessed from their bound thread
+// 3. Redis-rs requires Send + Sync for its connection types
+//
+// This is a compromise: we mark as Send + Sync to satisfy redis-rs's requirements,
+// relying on monoio's runtime guarantees that the types won't actually be sent
+// between threads. If you use this outside monoio's thread-per-core model, this
+// will be unsound.
+unsafe impl<T> Send for MonoioWrapped<T> {}
+unsafe impl<T> Sync for MonoioWrapped<T> {}
+
+impl<T> AsyncWrite for MonoioWrapped<T>
+where
+    T: monoio::io::AsyncWriteRent + Unpin + 'static,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        loop {
+            // We need to get a new projection each iteration
+            let this = self.as_mut().project();
+
+            match this.write_state {
+                WriteState::Idle => {
+                    // No write in progress, start a new one
+                    // Copy the buffer since monoio requires owned buffers
+                    let owned_buf = buf.to_vec();
+
+                    // SAFETY: We need to create a future that borrows from inner,
+                    // but we can't have a normal borrow because we're storing the future
+                    // in the same struct. We use unsafe to get a 'static lifetime,
+                    // which is sound because:
+                    // 1. The Pin guarantees inner won't move
+                    // 2. We only access the future while self is alive
+                    // 3. We clear the future before self is dropped
+                    let inner_ptr = this.inner.get_mut() as *mut T;
+                    let write_fut = unsafe { (*inner_ptr).write(owned_buf) };
+
+                    // Box the future (not Send, but safe in thread-per-core model)
+                    let boxed_fut: RentFuture = Box::pin(write_fut);
+
+                    *this.write_state = WriteState::Writing(boxed_fut);
+                    // Loop to poll the future immediately
+                }
+                WriteState::Writing(fut) => {
+                    // Poll the in-flight write future
+                    match fut.as_mut().poll(cx) {
+                        Poll::Ready((res, _buf)) => {
+                            // Write completed, reset state
+                            // We need a fresh projection to modify write_state
+                            let this = self.as_mut().project();
+                            *this.write_state = WriteState::Idle;
+                            return Poll::Ready(res);
+                        }
+                        Poll::Pending => {
+                            // Still waiting for write to complete
+                            return Poll::Pending;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        // Monoio streams are typically auto-flushed
+        // If there's a pending write, we should wait for it, but that's
+        // handled by the protocol layer calling poll_write until complete
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        // Monoio doesn't have explicit shutdown in the same way
+        // The connection will be closed when dropped
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<T> AsyncRead for MonoioWrapped<T>
+where
+    T: monoio::io::AsyncReadRent + Unpin + 'static,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        // Check if we have space to read
+        let capacity = buf.remaining();
+        if capacity == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        if let Some((mut pending, pos, len)) = self.as_mut().project().pending_read.take() {
+            let to_copy = (len - pos).min(buf.remaining());
+            buf.put_slice(&pending[pos..pos + to_copy]);
+            let pos = pos + to_copy;
+
+            let this = self.as_mut().project();
+            if pos < len {
+                *this.pending_read = Some((pending, pos, len));
+            } else {
+                pending.clear();
+                if pending.capacity() >= 4096 && pending.capacity() <= 65536 {
+                    *this.read_buf = Some(pending);
+                }
+            }
+
+            return Poll::Ready(Ok(()));
+        }
+
+        loop {
+            // Get a fresh projection each iteration
+            let this = self.as_mut().project();
+
+            match this.read_state {
+                ReadState::Idle => {
+                    // No read in progress, start a new one
+                    // Reuse buffer if available and appropriately sized, otherwise allocate
+                    let owned_buf = this
+                        .read_buf
+                        .take()
+                        .filter(|b| b.capacity() >= 4096 && b.capacity() <= 65536)
+                        .unwrap_or_else(|| Vec::with_capacity(capacity.max(8192)));
+
+                    // SAFETY: Same reasoning as poll_write - we use unsafe to extend
+                    // the lifetime of the borrow to 'static so we can store the future
+                    let inner_ptr = this.inner.get_mut() as *mut T;
+                    let read_fut = unsafe { (*inner_ptr).read(owned_buf) };
+
+                    // Box the future (not Send, but safe in thread-per-core model)
+                    let boxed_fut: RentFuture = Box::pin(read_fut);
+
+                    *this.read_state = ReadState::Reading(boxed_fut);
+                    // Loop to poll the future immediately
+                }
+                ReadState::Reading(fut) => {
+                    // Poll the in-flight read future
+                    match fut.as_mut().poll(cx) {
+                        Poll::Ready((res, mut read_buf)) => {
+                            let n = res?;
+
+                            let to_copy = if n > 0 {
+                                // Copy data to the caller's buffer
+                                let to_copy = n.min(buf.remaining());
+                                buf.put_slice(&read_buf[..to_copy]);
+                                to_copy
+                            } else {
+                                0
+                            };
+
+                            // Get a fresh projection to modify state
+                            let this = self.as_mut().project();
+
+                            // Reset state
+                            *this.read_state = ReadState::Idle;
+
+                            if to_copy < n {
+                                *this.pending_read = Some((read_buf, to_copy, n));
+                            } else {
+                                // Store buffer for reuse if it's a reasonable size
+                                read_buf.clear();
+                                if read_buf.capacity() >= 4096 && read_buf.capacity() <= 65536 {
+                                    *this.read_buf = Some(read_buf);
+                                }
+                            }
+
+                            return Poll::Ready(Ok(()));
+                        }
+                        Poll::Pending => {
+                            // Still waiting for read to complete
+                            return Poll::Pending;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[inline(always)]
+async fn connect_tcp(
+    addr: &SocketAddr,
+    _tcp_settings: &crate::io::tcp::TcpSettings,
+) -> io::Result<monoio::net::TcpStream> {
+    let stream = monoio::net::TcpStream::connect(addr).await?;
+
+    stream.set_nodelay(_tcp_settings.nodelay())?;
+
+    Ok(stream)
+}
+
+/// Represents a Monoio connectable
+pub(crate) enum Monoio {
+    /// Represents a TCP connection.
+    Tcp(MonoioWrapped<monoio::net::TcpStream>),
+    /// Represents a Unix connection.
+    #[cfg(unix)]
+    Unix(MonoioWrapped<monoio::net::UnixStream>),
+    /// Represents a TLS TCP connection.
+    #[cfg(feature = "monoio-rustls-comp")]
+    Tls(Box<MonoioWrapped<monoio_rustls::ClientTlsStream<monoio::net::TcpStream>>>),
+}
+
+// SAFETY: Same reasoning as MonoioWrapped - monoio's thread-per-core model ensures
+// these types are only accessed from their bound thread.
+unsafe impl Send for Monoio {}
+unsafe impl Sync for Monoio {}
+
+impl AsyncWrite for Monoio {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            Monoio::Tcp(r) => Pin::new(r).poll_write(cx, buf),
+            #[cfg(unix)]
+            Monoio::Unix(r) => Pin::new(r).poll_write(cx, buf),
+            #[cfg(feature = "monoio-rustls-comp")]
+            Monoio::Tls(r) => Pin::new(r.as_mut()).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Monoio::Tcp(r) => Pin::new(r).poll_flush(cx),
+            #[cfg(unix)]
+            Monoio::Unix(r) => Pin::new(r).poll_flush(cx),
+            #[cfg(feature = "monoio-rustls-comp")]
+            Monoio::Tls(r) => Pin::new(r.as_mut()).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Monoio::Tcp(r) => Pin::new(r).poll_shutdown(cx),
+            #[cfg(unix)]
+            Monoio::Unix(r) => Pin::new(r).poll_shutdown(cx),
+            #[cfg(feature = "monoio-rustls-comp")]
+            Monoio::Tls(r) => Pin::new(r.as_mut()).poll_shutdown(cx),
+        }
+    }
+}
+
+impl AsyncRead for Monoio {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match &mut *self {
+            Monoio::Tcp(r) => Pin::new(r).poll_read(cx, buf),
+            #[cfg(unix)]
+            Monoio::Unix(r) => Pin::new(r).poll_read(cx, buf),
+            #[cfg(feature = "monoio-rustls-comp")]
+            Monoio::Tls(r) => Pin::new(r.as_mut()).poll_read(cx, buf),
+        }
+    }
+}
+
+impl RedisRuntime for Monoio {
+    async fn connect_tcp(
+        socket_addr: SocketAddr,
+        tcp_settings: &crate::io::tcp::TcpSettings,
+    ) -> RedisResult<Self> {
+        Ok(connect_tcp(&socket_addr, tcp_settings)
+            .await
+            .map(|con| Self::Tcp(MonoioWrapped::new(con)))?)
+    }
+
+    #[cfg(feature = "monoio-rustls-comp")]
+    async fn connect_tcp_tls(
+        hostname: &str,
+        socket_addr: SocketAddr,
+        insecure: bool,
+        tls_params: &Option<TlsConnParams>,
+        tcp_settings: &crate::io::tcp::TcpSettings,
+    ) -> RedisResult<Self> {
+        let tcp_stream = connect_tcp(&socket_addr, tcp_settings).await?;
+        let config = create_rustls_config(insecure, tls_params.clone())?;
+        let connector = TlsConnector::from(Arc::new(config));
+        let server_name = rustls::pki_types::ServerName::try_from(hostname)
+            .map_err(|_| crate::RedisError::from((crate::ErrorKind::Io, "invalid hostname")))?
+            .to_owned();
+
+        connector
+            .connect(server_name, tcp_stream)
+            .await
+            .map(|con| Self::Tls(Box::new(MonoioWrapped::new(con))))
+            .map_err(|e| crate::RedisError::from(io::Error::other(e)))
+    }
+
+    #[cfg(unix)]
+    async fn connect_unix(path: &Path) -> RedisResult<Self> {
+        Ok(monoio::net::UnixStream::connect(path)
+            .await
+            .map(|con| Self::Unix(MonoioWrapped::new(con)))?)
+    }
+
+    fn spawn(f: impl Future<Output = ()> + Send + 'static) -> TaskHandle {
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        monoio::spawn(async move {
+            let _ = Abortable::new(f, abort_registration).await;
+        });
+        TaskHandle::Monoio(abort_handle)
+    }
+
+    fn boxed(self) -> Pin<Box<dyn AsyncStream + Send + Sync>> {
+        match self {
+            Monoio::Tcp(x) => Box::pin(x),
+            #[cfg(unix)]
+            Monoio::Unix(x) => Box::pin(x),
+            #[cfg(feature = "monoio-rustls-comp")]
+            Monoio::Tls(x) => Box::into_pin(x),
+        }
+    }
+}

--- a/redis/src/aio/runtime.rs
+++ b/redis/src/aio/runtime.rs
@@ -2,10 +2,49 @@ use std::{io, sync::Arc, time::Duration};
 
 use futures_util::Future;
 
-#[cfg(all(feature = "tokio-comp", feature = "smol-comp"))]
+// Helper to make monoio futures Send safe while they are driven inside a monoio runtime.
+// Public redis-rs handles may be moved across threads, but the non-Send monoio I/O
+// futures stay inside the spawned driver task on the runtime thread.
+#[cfg(feature = "monoio-comp")]
+pub(crate) mod monoio_future_safety {
+    use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    // Wrapper to make monoio futures Send safe
+    pub struct SendSafeFuture<F>(F);
+
+    impl<F: Future> Future for SendSafeFuture<F> {
+        type Output = F::Output;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // SAFETY: We're projecting the pin to the inner future
+            unsafe {
+                let this = self.get_unchecked_mut();
+                Pin::new_unchecked(&mut this.0).poll(cx)
+            }
+        }
+    }
+
+    unsafe impl<F> Send for SendSafeFuture<F> {}
+
+    pub fn make_send_safe<F: Future>(f: F) -> SendSafeFuture<F> {
+        SendSafeFuture(f)
+    }
+}
+
+#[cfg(any(
+    all(feature = "tokio-comp", feature = "smol-comp"),
+    all(
+        feature = "monoio-comp",
+        any(feature = "tokio-comp", feature = "smol-comp")
+    )
+))]
 use std::sync::OnceLock;
 
 use super::RedisRuntime;
+#[cfg(feature = "monoio-comp")]
+use super::monoio as crate_monoio;
 #[cfg(feature = "smol-comp")]
 use super::smol as crate_smol;
 #[cfg(feature = "tokio-comp")]
@@ -14,12 +53,14 @@ use crate::errors::RedisError;
 #[cfg(feature = "smol-comp")]
 use smol_timeout::TimeoutExt;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum Runtime {
     #[cfg(feature = "tokio-comp")]
     Tokio,
     #[cfg(feature = "smol-comp")]
     Smol,
+    #[cfg(feature = "monoio-comp")]
+    Monoio,
 }
 
 pub(crate) enum TaskHandle {
@@ -27,6 +68,8 @@ pub(crate) enum TaskHandle {
     Tokio(tokio::task::JoinHandle<()>),
     #[cfg(feature = "smol-comp")]
     Smol(smol::Task<()>),
+    #[cfg(feature = "monoio-comp")]
+    Monoio(futures_util::future::AbortHandle),
 }
 
 impl TaskHandle {
@@ -35,6 +78,8 @@ impl TaskHandle {
         match self {
             #[cfg(feature = "smol-comp")]
             TaskHandle::Smol(task) => task.detach(),
+            #[cfg(feature = "monoio-comp")]
+            TaskHandle::Monoio(_) => {}
             #[cfg(feature = "tokio-comp")]
             _ => {}
         }
@@ -57,6 +102,8 @@ impl Drop for HandleContainer {
             Some(TaskHandle::Tokio(handle)) => handle.abort(),
             #[cfg(feature = "smol-comp")]
             Some(TaskHandle::Smol(task)) => drop(task),
+            #[cfg(feature = "monoio-comp")]
+            Some(TaskHandle::Monoio(handle)) => handle.abort(),
         }
     }
 }
@@ -72,12 +119,31 @@ impl SharedHandleContainer {
     }
 }
 
-#[cfg(all(feature = "tokio-comp", feature = "smol-comp"))]
+#[cfg(any(
+    all(feature = "tokio-comp", feature = "smol-comp"),
+    all(
+        feature = "monoio-comp",
+        any(feature = "tokio-comp", feature = "smol-comp")
+    )
+))]
 static CHOSEN_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
-#[cfg(all(feature = "tokio-comp", feature = "smol-comp"))]
+#[cfg(any(
+    all(feature = "tokio-comp", feature = "smol-comp"),
+    all(
+        feature = "monoio-comp",
+        any(feature = "tokio-comp", feature = "smol-comp")
+    )
+))]
 fn set_runtime(runtime: Runtime) -> Result<(), RedisError> {
     const PREFER_RUNTIME_ERROR: &str = "Another runtime preference was already set. Please call this function before any other runtime preference is set.";
+
+    if CHOSEN_RUNTIME
+        .get()
+        .is_some_and(|chosen| *chosen == runtime)
+    {
+        return Ok(());
+    }
 
     CHOSEN_RUNTIME
         .set(runtime)
@@ -89,7 +155,10 @@ fn set_runtime(runtime: Runtime) -> Result<(), RedisError> {
 /// If the function returns `Err`, another runtime preference was already set, and won't be changed.
 /// Call this function if the application doesn't use multiple runtimes,
 /// but the crate is compiled with multiple runtimes enabled, which is a bad pattern that should be avoided.
-#[cfg(all(feature = "smol-comp", feature = "tokio-comp"))]
+#[cfg(all(
+    feature = "smol-comp",
+    any(feature = "tokio-comp", feature = "monoio-comp")
+))]
 pub fn prefer_smol() -> Result<(), RedisError> {
     set_runtime(Runtime::Smol)
 }
@@ -99,26 +168,65 @@ pub fn prefer_smol() -> Result<(), RedisError> {
 /// If the function returns `Err`, another runtime preference was already set, and won't be changed.
 /// Call this function if the application doesn't use multiple runtimes,
 /// but the crate is compiled with multiple runtimes enabled, which is a bad pattern that should be avoided.
-#[cfg(all(feature = "smol-comp", feature = "tokio-comp"))]
+#[cfg(all(
+    feature = "tokio-comp",
+    any(feature = "smol-comp", feature = "monoio-comp")
+))]
 pub fn prefer_tokio() -> Result<(), RedisError> {
     set_runtime(Runtime::Tokio)
 }
 
+/// Mark Monoio as the preferred runtime.
+///
+/// If the function returns `Err`, another runtime preference was already set, and won't be changed.
+/// Call this function if the application doesn't use multiple runtimes,
+/// but the crate is compiled with multiple runtimes enabled, which is a bad pattern that should be avoided.
+#[cfg(all(
+    feature = "monoio-comp",
+    any(feature = "tokio-comp", feature = "smol-comp")
+))]
+pub fn prefer_monoio() -> Result<(), RedisError> {
+    set_runtime(Runtime::Monoio)
+}
+
 impl Runtime {
     pub(crate) fn locate() -> Self {
-        #[cfg(all(feature = "smol-comp", feature = "tokio-comp"))]
+        #[cfg(any(
+            all(feature = "smol-comp", feature = "tokio-comp"),
+            all(
+                feature = "monoio-comp",
+                any(feature = "tokio-comp", feature = "smol-comp")
+            )
+        ))]
         if let Some(runtime) = CHOSEN_RUNTIME.get() {
             return *runtime;
         }
 
-        #[cfg(all(feature = "tokio-comp", not(feature = "smol-comp")))]
+        #[cfg(all(
+            feature = "tokio-comp",
+            not(feature = "smol-comp"),
+            not(feature = "monoio-comp")
+        ))]
         {
             Runtime::Tokio
         }
 
-        #[cfg(all(not(feature = "tokio-comp"), feature = "smol-comp",))]
+        #[cfg(all(
+            not(feature = "tokio-comp"),
+            feature = "smol-comp",
+            not(feature = "monoio-comp")
+        ))]
         {
             Runtime::Smol
+        }
+
+        #[cfg(all(
+            not(feature = "tokio-comp"),
+            not(feature = "smol-comp"),
+            feature = "monoio-comp"
+        ))]
+        {
+            Runtime::Monoio
         }
 
         cfg_if::cfg_if! {
@@ -128,12 +236,26 @@ impl Runtime {
                 } else {
                     Runtime::Smol
                 }
+            } else if #[cfg(all(feature = "tokio-comp", feature = "monoio-comp"))] {
+                if ::tokio::runtime::Handle::try_current().is_ok() {
+                    Runtime::Tokio
+                } else {
+                    Runtime::Monoio
+                }
+            } else if #[cfg(all(feature = "smol-comp", feature = "monoio-comp"))] {
+                Runtime::Smol
             }
         }
 
-        #[cfg(all(not(feature = "tokio-comp"), not(feature = "smol-comp")))]
+        #[cfg(all(
+            not(feature = "tokio-comp"),
+            not(feature = "smol-comp"),
+            not(feature = "monoio-comp")
+        ))]
         {
-            compile_error!("tokio-comp or smol-comp features required for aio feature")
+            compile_error!(
+                "tokio-comp, smol-comp, or monoio-comp features required for aio feature"
+            )
         }
     }
 
@@ -144,6 +266,8 @@ impl Runtime {
             Runtime::Tokio => crate_tokio::Tokio::spawn(f),
             #[cfg(feature = "smol-comp")]
             Runtime::Smol => crate_smol::Smol::spawn(f),
+            #[cfg(feature = "monoio-comp")]
+            Runtime::Monoio => crate_monoio::Monoio::spawn(f),
         }
     }
 
@@ -159,6 +283,12 @@ impl Runtime {
                 .map_err(|_| Elapsed(())),
             #[cfg(feature = "smol-comp")]
             Runtime::Smol => future.timeout(duration).await.ok_or(Elapsed(())),
+            #[cfg(feature = "monoio-comp")]
+            Runtime::Monoio => monoio_future_safety::make_send_safe(
+                monoio::time::timeout(duration, future),
+            )
+            .await
+            .map_err(|_| Elapsed(())),
         }
     }
 
@@ -173,6 +303,15 @@ impl Runtime {
             #[cfg(feature = "smol-comp")]
             Runtime::Smol => {
                 smol::Timer::after(duration).await;
+            }
+
+            #[cfg(feature = "monoio-comp")]
+            Runtime::Monoio => {
+                // Monoio's sleep returns a Future that contains non-Send types,
+                // but in thread-per-core model, this is safe because tasks never transfer.
+                // SAFETY: In monoio's thread-per-core model, the sleep future
+                // is only polled on the same thread, so it's safe to treat as Send.
+                monoio_future_safety::make_send_safe(monoio::time::sleep(duration)).await;
             }
         }
     }

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -451,6 +451,16 @@ impl Client {
                 )
                 .await
             }
+
+            #[cfg(feature = "monoio-comp")]
+            rt @ Runtime::Monoio => {
+                crate::aio::monoio_future_safety::make_send_safe(
+                    self.get_multiplexed_async_connection_inner_with_timeout::<
+                        crate::aio::monoio::Monoio,
+                    >(config, rt),
+                )
+                .await
+            }
         }
     }
 
@@ -597,6 +607,14 @@ impl Client {
             Runtime::Smol => {
                 self.get_simple_async_connection::<crate::aio::smol::Smol>(dns_resolver)
                     .await
+            }
+
+            #[cfg(feature = "monoio-comp")]
+            Runtime::Monoio => {
+                crate::aio::monoio_future_safety::make_send_safe(
+                    self.get_simple_async_connection::<crate::aio::monoio::Monoio>(dns_resolver),
+                )
+                .await
             }
         }
     }

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -29,7 +29,8 @@
 //! The user can enable TLS support using either RusTLS or native support (usually OpenSSL),
 //! using the `tls-rustls` or `tls-native-tls` features respectively. In order to enable TLS
 //! for async usage, the user must enable matching features for their runtime - either `tokio-native-tls-comp`,
-//! `tokio-rustls-comp`, `smol-native-tls-comp`, or `smol-rustls-comp`. Additionally, the
+//! `tokio-rustls-comp`, `smol-native-tls-comp`, `smol-rustls-comp`, or `monoio-rustls-comp`.
+//! Additionally, the
 //! `tls-rustls-webpki-roots` allows usage of of webpki-roots for the root certificate store.
 //!
 //! # TCP settings
@@ -93,6 +94,7 @@
 //! * `bloom`: enables support for the Bloom filter module (optional)
 //! * `tokio-comp`: enables support for async usage with the Tokio runtime (optional)
 //! * `smol-comp`: enables support for async usage with the Smol runtime (optional)
+//! * `monoio-comp`: enables support for async usage with the Monoio runtime (optional)
 //! * `geospatial`: enables geospatial support (enabled by default)
 //! * `script`: enables script support (enabled by default)
 //! * `streams`: enables high-level interface for interaction with Redis streams (enabled by default)
@@ -498,7 +500,7 @@ it will not automatically be loaded and retried. The script can be loaded using 
 # Async
 
 In addition to the synchronous interface that's been explained above there also exists an
-asynchronous interface based on [`futures`][] and [`tokio`][] or [`smol`](https://docs.rs/smol/latest/smol/).
+asynchronous interface based on [`futures`][], [`tokio`][], [`smol`](https://docs.rs/smol/latest/smol/), or [`monoio`](https://docs.rs/monoio/latest/monoio/).
  All async connections are cheap to clone, and clones can be used concurrently from multiple threads.
 
 This interface exists under the `aio` (async io) module (which requires that the `aio` feature
@@ -527,10 +529,11 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 ```
 
 ## Runtime support
-The crate supports multiple runtimes, including `tokio` and `smol`. For Tokio, the crate will
-spawn tasks on the current thread runtime. For smol, the crate will spawn tasks on the the global runtime.
+The crate supports multiple runtimes, including `tokio`, `smol`, and `monoio`. For Tokio, the crate will
+spawn tasks on the current thread runtime. For smol, the crate will spawn tasks on the the global runtime. For
+monoio, the crate will spawn tasks on the current monoio runtime.
 It is recommended that the crate be used with support only for a single runtime. If the crate is compiled with multiple runtimes,
-the user should call [`crate::aio::prefer_tokio`] or [`crate::aio::prefer_smol`] to set the preferred runtime.
+the user should call [`crate::aio::prefer_tokio`], [`crate::aio::prefer_smol`], or [`crate::aio::prefer_monoio`] to set the preferred runtime.
 These functions set global state which automatically chooses the correct runtime for the async connection.
 
 "##

--- a/redis/src/sentinel.rs
+++ b/redis/src/sentinel.rs
@@ -1251,8 +1251,8 @@ impl SentinelClient {
     }
 }
 
-/// To enable async support you need to chose one of the supported runtimes and active its
-/// corresponding feature: `tokio-comp` or `smol-comp`
+/// To enable async support you need to choose one of the supported runtimes and activate its
+/// corresponding feature: `tokio-comp`, `smol-comp`, or `monoio-comp`.
 #[cfg(feature = "aio")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aio")))]
 impl SentinelClient {


### PR DESCRIPTION
## Summary
- Continues the Monoio runtime work from #2078 on a focused branch against current `main`.
- Adds the Monoio async I/O adapter (`redis/src/aio/monoio.rs`) bridging Monoio rent-based I/O to Tokio `AsyncRead`/`AsyncWrite`.
- Wires Monoio into `aio` (`pub mod monoio`, `prefer_monoio`, and Monoio DNS resolution in `get_socket_addrs`).

This is an incremental draft while remaining pieces (`runtime.rs`, Cargo features, tests, docs) are brought over carefully, without unrelated diffs from #2078.
