### PR TITLE
Make test names greppable

### DIFF
--- a/redis/tests/test_acl.rs
+++ b/redis/tests/test_acl.rs
@@ -621,7 +621,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn authentication_with_mock_streaming_credentials_provider() {
+    async fn test_authentication_with_mock_streaming_credentials_provider() {
         init_logger();
         let ctx = TestContext::new();
         // Set up a Redis user that expects a JWT token as password
@@ -761,7 +761,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn authentication_error_handling_with_mock_streaming_credentials_provider() {
+    async fn test_authentication_error_handling_with_mock_streaming_credentials_provider() {
         init_logger();
         let ctx = TestContext::new();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
@@ -820,7 +820,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn multiple_connections_from_one_client_sharing_a_single_credentials_provider() {
+    async fn test_multiple_connections_from_one_client_sharing_a_single_credentials_provider() {
         init_logger();
         let ctx = TestContext::new();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
@@ -887,7 +887,7 @@ mod token_based_authentication_acl_tests {
     }
 
     #[async_test]
-    async fn multiple_clients_sharing_a_single_credentials_provider() {
+    async fn test_multiple_clients_sharing_a_single_credentials_provider() {
         init_logger();
         let ctx1 = TestContext::new();
         let whoami_cmd = redis::cmd("ACL").arg("WHOAMI").clone();
@@ -958,7 +958,7 @@ mod token_based_authentication_acl_tests {
     /// 4. Admin invalidates Alice via ACL DELUSER
     /// 5. The server rejects the next command — proving we rely on the server for auth enforcement
     #[async_test]
-    async fn server_rejects_after_user_invalidated() {
+    async fn test_server_rejects_after_user_invalidated() {
         init_logger();
         let ctx = TestContext::new();
 
@@ -1051,7 +1051,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_authentication_with_mock_streaming_credentials_provider() {
+        async fn test_cluster_authentication_with_mock_streaming_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1089,7 +1089,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_token_rotation_with_mock_streaming_credentials_provider() {
+        async fn test_cluster_token_rotation_with_mock_streaming_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1119,7 +1119,8 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_authentication_error_handling_with_mock_streaming_credentials_provider() {
+        async fn test_cluster_authentication_error_handling_with_mock_streaming_credentials_provider()
+         {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1155,7 +1156,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_multiple_connections_sharing_a_single_credentials_provider() {
+        async fn test_cluster_multiple_connections_sharing_a_single_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {
@@ -1197,7 +1198,7 @@ mod token_based_authentication_acl_tests {
         }
 
         #[async_test]
-        async fn cluster_multiple_clients_sharing_a_single_credentials_provider() {
+        async fn test_cluster_multiple_clients_sharing_a_single_credentials_provider() {
             init_logger();
             let cluster = TestClusterContext::new();
 
@@ -1266,7 +1267,7 @@ mod token_based_authentication_acl_tests {
         /// 4. Admin invalidates Alice via ACL DELUSER on all nodes
         /// 5. The server rejects the next command — proving we rely on the server for auth enforcement
         #[async_test]
-        async fn cluster_server_rejects_after_user_invalidated() {
+        async fn test_cluster_server_rejects_after_user_invalidated() {
             init_logger();
             let cluster = TestClusterContext::new_with_cluster_client_builder(
                 |builder: ClusterClientBuilder| {

--- a/redis/tests/test_async.rs
+++ b/redis/tests/test_async.rs
@@ -56,7 +56,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn args(mut con: impl ConnectionLike) {
+    async fn test_args(mut con: impl ConnectionLike) {
         redis::cmd("SET")
             .arg("key1")
             .arg(b"foo")
@@ -76,7 +76,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn no_response_skips_response_even_on_error(mut con: impl ConnectionLike) {
+    async fn test_no_response_skips_response_even_on_error(mut con: impl ConnectionLike) {
         redis::cmd("SET")
             .arg("key")
             .arg(b"foo")
@@ -155,7 +155,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn set_write_backpressure_boundary_does_not_break_connection() {
+    async fn test_set_write_backpressure_boundary_does_not_break_connection() {
         let ctx = TestContext::new();
         let config =
             redis::AsyncConnectionConfig::new().set_write_backpressure_boundary(16 * 1024 * 1024);
@@ -170,7 +170,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn can_authenticate_with_username_and_password() {
+    async fn test_can_authenticate_with_username_and_password() {
         let ctx = TestContext::new();
         let mut con = ctx.async_connection().await.unwrap();
 
@@ -207,7 +207,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn nice_hash_api(mut connection: impl AsyncCommands) {
+    async fn test_nice_hash_api(mut connection: impl AsyncCommands) {
         assert_eq!(
             connection
                 .hset_multiple("my_hash", &[("f1", 1), ("f2", 2), ("f3", 4), ("f4", 8)])
@@ -224,7 +224,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn nice_hash_api_in_pipe(mut connection: impl AsyncCommands) {
+    async fn test_nice_hash_api_in_pipe(mut connection: impl AsyncCommands) {
         assert_eq!(
             connection
                 .hset_multiple("my_hash", &[("f1", 1), ("f2", 2), ("f3", 4), ("f4", 8)])
@@ -245,7 +245,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn dont_panic_on_closed_multiplexed_connection() {
+    async fn test_dont_panic_on_closed_multiplexed_connection() {
         let ctx = TestContext::new();
         let client = ctx.client.clone();
         let connect = client.get_multiplexed_async_connection();
@@ -274,7 +274,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_transaction(mut con: impl ConnectionLike) {
+    async fn test_pipeline_transaction(mut con: impl ConnectionLike) {
         let mut pipe = redis::pipe();
         pipe.atomic()
             .cmd("SET")
@@ -297,7 +297,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn client_tracking_doesnt_block_execution(mut con: impl AsyncCommands) {
+    async fn test_client_tracking_doesnt_block_execution(mut con: impl AsyncCommands) {
         //It checks if the library distinguish a push-type message from the others and continues its normal operation.
 
         let mut pipe = redis::pipe();
@@ -318,7 +318,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_transaction_with_errors(mut con: impl AsyncCommands) {
+    async fn test_pipeline_transaction_with_errors(mut con: impl AsyncCommands) {
         con.set::<_, _, ()>("x", 42).await.unwrap();
 
         // Make Redis a replica of a nonexistent master, thereby making it read-only.
@@ -355,7 +355,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "json")]
-    async fn module_json_and_pipeline_transaction_with_ignore_errors() {
+    async fn test_module_json_and_pipeline_transaction_with_ignore_errors() {
         let ctx = TestContext::with_modules(&[Module::Json]);
         let mut con = ctx.async_connection().await.unwrap();
         con.set::<_, _, ()>("x", 42).await.unwrap();
@@ -406,7 +406,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_with_ignore_errors(mut con: impl AsyncCommands) {
+    async fn test_pipeline_with_ignore_errors(mut con: impl AsyncCommands) {
         con.set::<_, _, ()>("x", 42).await.unwrap();
 
         let mut pipeline = redis::pipe();
@@ -435,7 +435,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipeline_returns_server_errors(mut con: impl AsyncCommands) {
+    async fn test_pipeline_returns_server_errors(mut con: impl AsyncCommands) {
         let mut pipe = redis::pipe();
         pipe.set("x", "x-value")
             .ignore()
@@ -483,7 +483,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn pipe_over_multiplexed_connection(mut con: impl ConnectionLike) {
+    async fn test_pipe_over_multiplexed_connection(mut con: impl ConnectionLike) {
         let mut pipe = pipe();
         pipe.zrange("zset", 0, 0);
         pipe.zrange("zset", 0, 0);
@@ -494,13 +494,13 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn running_multiple_commands(con: impl AsyncCommands + Clone) {
+    async fn test_running_multiple_commands(con: impl AsyncCommands + Clone) {
         let cmds = (0..100).map(move |i| test_cmd(con.clone(), i));
         future::join_all(cmds).await;
     }
 
     #[async_test]
-    async fn transaction_multiplexed_connection(con: impl ConnectionLike + Clone) {
+    async fn test_async_transaction(con: impl ConnectionLike + Clone) {
         let cmds = (0..100).map(move |i| {
             let mut con = con.clone();
             async move {
@@ -537,7 +537,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_scanning(mut con: impl ConnectionLike + Send) {
+    async fn test_async_scanning(mut con: impl ConnectionLike + Send) {
         let mut unseen = std::collections::HashSet::new();
 
         for x in 0..1000 {
@@ -569,7 +569,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_scanning_iterative(mut con: impl ConnectionLike + Send) {
+    async fn test_async_scanning_iterative(mut con: impl ConnectionLike + Send) {
         let mut unseen = std::collections::HashSet::new();
 
         for x in 0..1000 {
@@ -605,7 +605,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_scanning_stream(mut con: impl ConnectionLike + Sync + Send) {
+    async fn test_async_scanning_stream(mut con: impl ConnectionLike + Sync + Send) {
         let mut unseen = std::collections::HashSet::new();
 
         for x in 0..1000 {
@@ -641,7 +641,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn response_timeout_multiplexed_connection() {
+    async fn test_response_timeout_multiplexed_connection() {
         let ctx = TestContext::new();
 
         let mut connection = ctx.async_connection().await.unwrap();
@@ -655,7 +655,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "script")]
-    async fn script(mut con: impl ConnectionLike) {
+    async fn test_script(mut con: impl ConnectionLike) {
         // Note this test runs both scripts twice to test when they have already been loaded
         // into Redis and when they need to be loaded in
         let script1 = redis::Script::new("return redis.call('SET', KEYS[1], ARGV[1])");
@@ -685,7 +685,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "script")]
-    async fn script_load(mut con: impl ConnectionLike) {
+    async fn test_script_load(mut con: impl ConnectionLike) {
         let script = redis::Script::new("return 'Hello World'");
 
         let hash = script.prepare_invoke().load_async(&mut con).await.unwrap();
@@ -694,7 +694,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "script")]
-    async fn script_returning_complex_type(mut con: impl ConnectionLike) {
+    async fn test_script_returning_complex_type(mut con: impl ConnectionLike) {
         redis::Script::new("return {1, ARGV[1], true}")
             .arg("hello")
             .invoke_async(&mut con)
@@ -711,7 +711,7 @@ mod basic_async {
     // Allowing `let ()` as `query_async` requires the type it converts the result to.
     #[allow(clippy::let_unit_value, clippy::iter_nth_zero)]
     #[async_test]
-    async fn io_error_on_kill_issue_320() {
+    async fn test_io_error_on_kill_issue_320() {
         let ctx = TestContext::new();
 
         let mut conn_to_kill = ctx.async_connection().await.unwrap();
@@ -731,7 +731,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn invalid_password_issue_343() {
+    async fn test_invalid_password_issue_343() {
         let ctx = TestContext::new();
 
         let redis = RedisConnectionInfo::default().set_password("asdcasc");
@@ -758,7 +758,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn scan_with_options_works(mut con: impl AsyncCommands) {
+    async fn test_scan_with_options_works(mut con: impl AsyncCommands) {
         for i in 0..20usize {
             let _: () = con.append(format!("test/{i}"), i).await.unwrap();
             let _: () = con.append(format!("other/{i}"), i).await.unwrap();
@@ -787,7 +787,7 @@ mod basic_async {
     // Test issue of Stream trait blocking if we try to iterate more than 10 items
     // https://github.com/mitsuhiko/redis-rs/issues/537 and https://github.com/mitsuhiko/redis-rs/issues/583
     #[async_test]
-    async fn issue_stream_blocks(mut con: impl AsyncCommands) {
+    async fn test_issue_stream_blocks(mut con: impl AsyncCommands) {
         for i in 0..20usize {
             let _: () = con.append(format!("test/{i}"), i).await.unwrap();
         }
@@ -804,7 +804,7 @@ mod basic_async {
     // Test issue of AsyncCommands::scan returning the wrong number of keys
     // https://github.com/redis-rs/redis-rs/issues/759
     #[async_test]
-    async fn issue_async_commands_scan_broken(mut con: impl AsyncCommands) {
+    async fn test_issue_async_commands_scan_broken(mut con: impl AsyncCommands) {
         let mut keys: Vec<String> = (0..100).map(|k| format!("async-key{k}")).collect();
         keys.sort();
         for key in &keys {
@@ -824,7 +824,7 @@ mod basic_async {
         use super::*;
 
         #[async_test]
-        async fn pub_sub_subscription() {
+        async fn test_pub_sub_subscription() {
             let ctx = TestContext::new();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
@@ -846,7 +846,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_subscription_to_multiple_channels() {
+        async fn test_pub_sub_subscription_to_multiple_channels() {
             let ctx = TestContext::new();
 
             let mut pubsub_conn = ctx.async_pubsub().await.unwrap();
@@ -869,7 +869,7 @@ mod basic_async {
         // Test issue of AsyncCommands::scan not returning keys because wrong assumptions about the key type were made
         // https://github.com/redis-rs/redis-rs/issues/1309
         #[async_test]
-        async fn issue_async_commands_scan_finishing_prematurely(mut con: impl AsyncCommands) {
+        async fn test_issue_async_commands_scan_finishing_prematurely(mut con: impl AsyncCommands) {
             const PREFIX: &str = "async-key";
             const NUM_KEYS: usize = 100;
 
@@ -927,7 +927,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_unsubscription() {
+        async fn test_pub_sub_unsubscription() {
             const SUBSCRIPTION_KEY: &str = "phonewave-pub-sub-unsubscription";
 
             let ctx = TestContext::new();
@@ -948,7 +948,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_receive_messages_while_sending_requests_from_split_pub_sub() {
+        async fn test_can_receive_messages_while_sending_requests_from_split_pub_sub() {
             let ctx = TestContext::new();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
@@ -968,7 +968,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_send_ping_on_split_pubsub() {
+        async fn test_can_send_ping_on_split_pubsub() {
             let ctx = TestContext::new();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
@@ -1011,7 +1011,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_receive_messages_from_split_pub_sub_after_sink_was_dropped() {
+        async fn test_can_receive_messages_from_split_pub_sub_after_sink_was_dropped() {
             let ctx = TestContext::new();
 
             let (mut sink, mut stream) = ctx.async_pubsub().await.unwrap().split();
@@ -1032,7 +1032,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn can_receive_messages_from_split_pub_sub_after_into_on_message() {
+        async fn test_can_receive_messages_from_split_pub_sub_after_into_on_message() {
             let ctx = TestContext::new();
 
             let mut pubsub = ctx.async_pubsub().await.unwrap();
@@ -1055,7 +1055,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn cannot_subscribe_on_split_pub_sub_after_stream_was_dropped() {
+        async fn test_cannot_subscribe_on_split_pub_sub_after_stream_was_dropped() {
             let ctx = TestContext::new();
 
             let (mut sink, stream) = ctx.async_pubsub().await.unwrap().split();
@@ -1065,7 +1065,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn automatic_unsubscription() {
+        async fn test_automatic_unsubscription() {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription";
 
             let ctx = TestContext::new();
@@ -1095,7 +1095,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn automatic_unsubscription_on_split() {
+        async fn test_automatic_unsubscription_on_split() {
             const SUBSCRIPTION_KEY: &str = "phonewave-automatic-unsubscription-on-split";
 
             let ctx = TestContext::new();
@@ -1139,7 +1139,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pipe_errors_do_not_affect_subsequent_commands(mut conn: impl AsyncCommands) {
+        async fn test_pipe_errors_do_not_affect_subsequent_commands(mut conn: impl AsyncCommands) {
             conn.lpush::<&str, &str, ()>("key", "value").await.unwrap();
 
             redis::pipe()
@@ -1154,7 +1154,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn multiplexed_pub_sub_subscribe_on_multiple_channels() {
+        async fn test_multiplexed_pub_sub_subscribe_on_multiple_channels() {
             let ctx = TestContext::new();
             if !ctx.protocol.supports_resp3() {
                 return;
@@ -1184,7 +1184,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn non_transaction_errors_do_not_affect_other_results_in_pipeline(
+        async fn test_non_transaction_errors_do_not_affect_other_results_in_pipeline(
             mut conn: impl AsyncCommands,
         ) {
             conn.lpush::<&str, &str, ()>("key", "value").await.unwrap();
@@ -1205,7 +1205,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_multiple() {
+        async fn test_pub_sub_multiple() {
             let ctx = TestContext::new();
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1269,7 +1269,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn pub_sub_requires_resp3() {
+        async fn test_pub_sub_requires_resp3() {
             if use_protocol().supports_resp3() {
                 return;
             }
@@ -1285,7 +1285,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn push_sender_send_on_disconnect() {
+        async fn test_push_sender_send_on_disconnect() {
             let ctx = TestContext::new();
             let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
             let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1307,7 +1307,7 @@ mod basic_async {
 
         #[cfg(feature = "connection-manager")]
         #[async_test]
-        async fn manager_should_resubscribe_to_pubsub_channels_after_disconnect() {
+        async fn test_manager_should_resubscribe_to_pubsub_channels_after_disconnect() {
             let ctx = TestContext::new();
             if !ctx.protocol.supports_resp3() {
                 return;
@@ -1402,7 +1402,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn async_basic_pipe_with_parsing_error(mut conn: impl ConnectionLike) {
+    async fn test_async_basic_pipe_with_parsing_error(mut conn: impl ConnectionLike) {
         // Tests a specific case involving repeated errors in transactions.
 
         // create a transaction where 2 errors are returned.
@@ -1432,7 +1432,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "connection-manager")]
-    async fn connection_manager_reconnect_after_delay() {
+    async fn test_connection_manager_reconnect_after_delay() {
         let max_delay_between_attempts = Duration::from_millis(2);
         let mut config = redis::aio::ConnectionManagerConfig::new()
             .set_exponent_base(10000.0)
@@ -1486,7 +1486,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn manager_should_reconnect_without_actions_if_resp3_is_set() {
+    async fn test_manager_should_reconnect_without_actions_if_resp3_is_set() {
         let ctx = TestContext::new();
         if !ctx.protocol.supports_resp3() {
             return;
@@ -1514,7 +1514,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn manager_should_completely_disconnect_when_drop() {
+    async fn test_manager_should_completely_disconnect_when_drop() {
         let ctx = TestContext::new();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1555,7 +1555,7 @@ mod basic_async {
 
     #[cfg(feature = "connection-manager")]
     #[async_test]
-    async fn manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error()
+    async fn test_manager_should_reconnect_without_actions_if_push_sender_is_set_even_after_sender_returns_error()
      {
         let ctx = TestContext::new();
         if !ctx.protocol.supports_resp3() {
@@ -1598,7 +1598,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn multiplexed_connection_kills_connection_on_drop_even_when_blocking() {
+    async fn test_multiplexed_connection_kills_connection_on_drop_even_when_blocking() {
         let ctx = TestContext::new();
 
         let mut conn = ctx.async_connection().await.unwrap();
@@ -1635,7 +1635,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn monitor() {
+    async fn test_monitor() {
         let ctx = TestContext::new();
 
         let mut conn = ctx.async_connection().await.unwrap();
@@ -1731,7 +1731,7 @@ mod basic_async {
 
     #[async_test]
     #[cfg(feature = "connection-manager")]
-    async fn resp3_pushes_connection_manager() {
+    async fn test_resp3_pushes_connection_manager() {
         let ctx = TestContext::new();
         let redis = RedisConnectionInfo::default().set_protocol(ProtocolVersion::RESP3);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1757,7 +1757,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn select_db() {
+    async fn test_select_db() {
         let ctx = TestContext::new();
         let redis = redis_settings().set_db(5);
         let connection_info = ctx.server.connection_info().set_redis_settings(redis);
@@ -1774,7 +1774,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn multiplexed_connection_send_single_disconnect_on_connection_failure() {
+    async fn test_multiplexed_connection_send_single_disconnect_on_connection_failure() {
         let mut ctx = TestContext::new();
         if !ctx.protocol.supports_resp3() {
             return;
@@ -1797,7 +1797,7 @@ mod basic_async {
     }
 
     #[async_test]
-    async fn fail_on_empty_command() {
+    async fn test_fail_on_empty_command() {
         let ctx = TestContext::new();
         let mut connection = ctx.async_connection().await.unwrap();
 
@@ -1830,7 +1830,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn simple_case_success(mut con: impl AsyncCommands + Clone) {
+        async fn test_simple_case_success(mut con: impl AsyncCommands + Clone) {
             let res: Vec<usize> = redis::aio::transaction_async(
                 con.clone(),
                 &["x", "y"],
@@ -1853,7 +1853,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_watch() {
+        async fn test_transaction_should_retry_on_watch() {
             let ctx = TestContext::new();
             let con1 = ctx.async_connection().await.unwrap();
             let mut con2 = ctx.async_connection().await.unwrap();
@@ -1899,7 +1899,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_none_from_closure() {
+        async fn test_transaction_should_retry_on_none_from_closure() {
             let ctx = TestContext::new();
             let con = ctx.async_connection().await.unwrap();
 
@@ -1926,7 +1926,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn transaction_abort_if_internal_function_returns_error() {
+        async fn test_transaction_abort_if_internal_function_returns_error() {
             let ctx = TestContext::new();
             let con = ctx.async_connection().await.unwrap();
             let attempts = Arc::new(AtomicUsize::new(0));
@@ -1968,7 +1968,7 @@ mod basic_async {
         use super::*;
 
         #[async_test]
-        async fn lazy_connection_manager_can_be_created_synchronously() {
+        async fn test_lazy_connection_manager_can_be_created_synchronously() {
             let ctx = TestContext::new();
 
             let config = redis::aio::ConnectionManagerConfig::new()
@@ -1984,7 +1984,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn lazy_connection_manager_reconnects_after_disconnect() {
+        async fn test_lazy_connection_manager_reconnects_after_disconnect() {
             let ctx = TestContext::new();
 
             let max_delay_between_attempts = Duration::from_millis(2);
@@ -2015,7 +2015,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn lazy_connection_manager_can_be_cloned_before_sending() {
+        async fn test_lazy_connection_manager_can_be_cloned_before_sending() {
             let ctx = TestContext::new();
 
             let config = redis::aio::ConnectionManagerConfig::new();
@@ -2034,7 +2034,7 @@ mod basic_async {
         }
 
         #[async_test]
-        async fn lazy_connection_manager_with_resp3_push() {
+        async fn test_lazy_connection_manager_with_resp3_push() {
             let ctx = TestContext::new();
             if !ctx.protocol.supports_resp3() {
                 return;

--- a/redis/tests/test_cache.rs
+++ b/redis/tests/test_cache.rs
@@ -93,7 +93,7 @@ async fn test_cache_basic(test_with_optin: bool) {
 }
 
 #[async_test]
-async fn cache_mget() {
+async fn test_cache_mget() {
     let ctx = TestContext::new();
     if !ctx.protocol.supports_resp3() {
         return;
@@ -149,7 +149,7 @@ async fn cache_mget() {
 
 #[cfg(feature = "json")]
 #[async_test]
-async fn module_cache_json_get_mget() {
+async fn test_module_cache_json_get_mget() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     if !ctx.protocol.supports_resp3() {
         return;
@@ -219,7 +219,7 @@ async fn module_cache_json_get_mget() {
 
 #[cfg(feature = "json")]
 #[async_test]
-async fn module_cache_json_get_mget_different_paths() {
+async fn test_module_cache_json_get_mget_different_paths() {
     let ctx = TestContext::with_modules(&[Module::Json]);
     if !ctx.protocol.supports_resp3() {
         return;
@@ -332,7 +332,7 @@ async fn module_cache_json_get_mget_different_paths() {
 }
 
 #[async_test]
-async fn cache_is_not_target_type_dependent() {
+async fn test_cache_is_not_target_type_dependent() {
     let ctx = TestContext::new();
     if !ctx.protocol.supports_resp3() {
         return;
@@ -398,7 +398,7 @@ async fn test_cache_with_pipeline(atomic: bool) {
 }
 
 #[async_test]
-async fn cache_basic_partial_opt_in() {
+async fn test_cache_basic_partial_opt_in() {
     // In OptIn mode cache must not be utilized without explicit per command configuration.
     let ctx = TestContext::new();
     if !ctx.protocol.supports_resp3() {
@@ -645,7 +645,7 @@ async fn test_connection_manager_maintains_statistics_after_crashes(test_with_op
 
 #[cfg(feature = "cluster-async")]
 #[async_test]
-async fn cache_async_cluster_reconnect_all_nodes() {
+async fn test_cache_async_cluster_reconnect_all_nodes() {
     let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
         builder.cache_config(CacheConfig::default())
     });
@@ -708,7 +708,7 @@ async fn cache_async_cluster_reconnect_all_nodes() {
 
 #[cfg(feature = "cluster-async")]
 #[async_test]
-async fn cache_async_cluster_mget() {
+async fn test_cache_async_cluster_mget() {
     let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
         builder.cache_config(CacheConfig::default())
     });

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -63,7 +63,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_cmd() {
+    async fn test_async_cluster_basic_cmd() {
         let cluster = TestClusterContext::new();
 
         let connection = cluster.async_connection().await;
@@ -124,7 +124,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn no_response_skips_response_even_on_error() {
+    async fn test_no_response_skips_response_even_on_error() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -154,7 +154,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn reconnect_only_the_disconnected_node_leave_other_connections_intact() {
+    async fn test_reconnect_only_the_disconnected_node_leave_other_connections_intact() {
         // we remove retries in order to know that a request will fail immediately when discovering that a connection disconnected, instead of reconnecting and succeeding
         let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(0));
 
@@ -203,7 +203,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_eval() {
+    async fn test_async_cluster_basic_eval() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -219,7 +219,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_script() {
+    async fn test_async_cluster_basic_script() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -235,7 +235,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_route_flush_to_specific_node() {
+    async fn test_async_cluster_route_flush_to_specific_node() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -264,7 +264,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_route_flush_to_node_by_address() {
+    async fn test_async_cluster_route_flush_to_node_by_address() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -300,7 +300,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_route_info_to_nodes() {
+    async fn test_async_cluster_route_info_to_nodes() {
         let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
             num_nodes: 6,
             num_replicas: 1,
@@ -378,7 +378,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn cluster_resp3() {
+    async fn test_cluster_resp3() {
         if !use_protocol().supports_resp3() {
             return;
         }
@@ -395,7 +395,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_pipe() {
+    async fn test_async_cluster_basic_pipe() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -447,7 +447,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_multi_shard_commands() {
+    async fn test_async_cluster_multi_shard_commands() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -462,7 +462,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_can_run_a_transaction() {
+    async fn test_async_cluster_can_run_a_transaction() {
         let cluster = TestClusterContext::new();
 
         let mut connection = cluster.async_connection().await;
@@ -480,7 +480,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls")]
     #[async_test]
-    async fn async_cluster_default_reject_invalid_hostnames() {
+    async fn test_async_cluster_default_reject_invalid_hostnames() {
         use redis_test::cluster::ClusterType;
 
         if ClusterType::get_intended() != ClusterType::TcpTls {
@@ -499,7 +499,7 @@ mod cluster_async {
 
     #[cfg(feature = "tls-rustls-insecure")]
     #[async_test]
-    async fn async_cluster_danger_accept_invalid_hostnames() {
+    async fn test_async_cluster_danger_accept_invalid_hostnames() {
         use redis_test::cluster::ClusterType;
 
         if ClusterType::get_intended() != ClusterType::TcpTls {
@@ -521,7 +521,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_basic_failover() {
+    async fn test_async_cluster_basic_failover() {
         test_failover(
                 &TestClusterContext::new_with_config(
                     RedisClusterConfiguration::single_replica_config(),
@@ -697,7 +697,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_error_in_inner_connection() {
+    async fn test_async_cluster_error_in_inner_connection() {
         let cluster = TestClusterContext::new();
 
         let mut con = cluster.async_generic_connection::<ErrorConnection>().await;
@@ -2050,7 +2050,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_with_username_and_password() {
+    async fn test_async_cluster_with_username_and_password() {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder
                 .username(RedisCluster::username())
@@ -2183,7 +2183,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_handle_complete_server_disconnect_without_panicking() {
+    async fn test_async_cluster_handle_complete_server_disconnect_without_panicking() {
         let cluster =
             TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(2));
 
@@ -2207,7 +2207,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_reconnect_after_complete_server_disconnect() {
+    async fn test_async_cluster_reconnect_after_complete_server_disconnect() {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder.retries(2)
         });
@@ -2243,7 +2243,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_reconnect_after_complete_server_disconnect_route_to_many() {
+    async fn test_async_cluster_reconnect_after_complete_server_disconnect_route_to_many() {
         let cluster = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
             builder.retries(3)
         });
@@ -2343,7 +2343,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn kill_connection_on_drop_even_when_blocking() {
+    async fn test_kill_connection_on_drop_even_when_blocking() {
         let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| builder.retries(3));
 
         async fn count_ids(conn: &mut impl redis::aio::ConnectionLike) -> RedisResult<usize> {
@@ -2447,7 +2447,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn async_cluster_connect_lazily() {
+    async fn test_async_cluster_connect_lazily() {
         let cluster = TestClusterContext::new();
 
         let connection = cluster
@@ -2457,7 +2457,7 @@ mod cluster_async {
     }
 
     #[async_test]
-    async fn fail_on_empty_command() {
+    async fn test_fail_on_empty_command() {
         let cluster = TestClusterContext::new();
         let mut connection = cluster.async_connection().await;
 
@@ -2574,7 +2574,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_subscription() {
+        async fn test_pub_sub_subscription() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
@@ -2592,7 +2592,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_subscription_with_config() {
+        async fn test_pub_sub_subscription_with_config() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder.use_protocol(ProtocolVersion::RESP3)
@@ -2611,7 +2611,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_shardnumsub() {
+        async fn test_pub_sub_shardnumsub() {
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder.use_protocol(ProtocolVersion::RESP3)
             });
@@ -2630,7 +2630,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_unsubscription() {
+        async fn test_pub_sub_unsubscription() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
@@ -2720,7 +2720,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn connection_is_still_usable_if_pubsub_receiver_is_dropped() {
+        async fn test_connection_is_still_usable_if_pubsub_receiver_is_dropped() {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
                 builder
@@ -2745,7 +2745,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn multiple_subscribes_and_unsubscribes_work() {
+        async fn test_multiple_subscribes_and_unsubscribes_work() {
             // In this test we subscribe on all subscription variations to 3 channels in a single call, then unsubscribe from 2 channels.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_with_cluster_client_builder(|builder| {
@@ -2868,7 +2868,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_reconnect_after_disconnect() {
+        async fn test_pub_sub_reconnect_after_disconnect() {
             // in this test we will subscribe to channels, then restart the server, and check that the connection
             // doesn't send disconnect message, but instead resubscribes automatically.
 
@@ -2955,7 +2955,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn pub_sub_should_not_reconnect_if_subscription_failed() {
+        async fn test_pub_sub_should_not_reconnect_if_subscription_failed() {
             // in this test we will try to subscribe to a disconnected cluster, fail, and check that once the connection reconnects it won't try and resubscribe.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let ctx = TestClusterContext::new_insecure_with_cluster_client_builder(|builder| {
@@ -3031,7 +3031,7 @@ mod cluster_async {
         use super::*;
 
         #[async_test]
-        async fn async_cluster_basic_cmd_with_mtls() {
+        async fn test_async_cluster_basic_cmd_with_mtls() {
             let cluster = TestClusterContext::new_with_mtls();
 
             let client = create_cluster_client_from_cluster(&cluster, true).unwrap();
@@ -3052,7 +3052,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn async_cluster_should_not_connect_without_mtls_enabled() {
+        async fn test_async_cluster_should_not_connect_without_mtls_enabled() {
             let cluster = TestClusterContext::new_with_mtls();
 
             let client = create_cluster_client_from_cluster(&cluster, false).unwrap();
@@ -3110,7 +3110,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn simple_case_success() {
+        async fn test_simple_case_success() {
             let cluster = TestClusterContext::new();
             let mut con = cluster.async_connection().await;
 
@@ -3136,7 +3136,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_watch() {
+        async fn test_transaction_should_retry_on_watch() {
             let cluster = TestClusterContext::new();
             let con1 = cluster.async_connection().await;
             let mut con2 = cluster.async_connection().await;
@@ -3185,7 +3185,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn transaction_should_retry_on_none_from_closure() {
+        async fn test_transaction_should_retry_on_none_from_closure() {
             let cluster = TestClusterContext::new();
             let con = cluster.async_connection().await;
 
@@ -3215,7 +3215,7 @@ mod cluster_async {
         }
 
         #[async_test]
-        async fn transaction_abort_if_internal_function_returns_error() {
+        async fn test_transaction_abort_if_internal_function_returns_error() {
             let cluster = TestClusterContext::new();
             let con = cluster.async_connection().await;
             let attempts = Arc::new(AtomicUsize::new(0));

--- a/redis/tests/test_sentinel.rs
+++ b/redis/tests/test_sentinel.rs
@@ -679,7 +679,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_connect_to_random_replica_async() {
+    async fn test_sentinel_connect_to_random_replica_async() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let node_conn_info = context.sentinel_node_connection_info();
@@ -708,7 +708,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_connect_to_multiple_replicas_async() {
+    async fn test_sentinel_connect_to_multiple_replicas_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut cluster = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -747,7 +747,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_server_down_async() {
+    async fn test_sentinel_server_down_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -792,7 +792,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_redis_client_async() {
+    async fn test_sentinel_redis_client_async() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -832,7 +832,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async() {
+    async fn test_sentinel_client_async() {
         let master_name = "master1";
         let context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -867,7 +867,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_not_sentinel_error() {
+    async fn test_sentinel_client_async_not_sentinel_error() {
         let master_name = "master1";
 
         let mut context = TestSentinelContext::new(2, 3, 3);
@@ -898,7 +898,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_io_error() {
+    async fn test_sentinel_client_async_io_error() {
         let master_name = "master1";
 
         let mut master_client = SentinelClient::build(
@@ -915,7 +915,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_with_connection_timeout() {
+    async fn test_sentinel_client_async_with_connection_timeout() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -964,7 +964,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_with_response_timeout() {
+    async fn test_sentinel_client_async_with_response_timeout() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -1012,7 +1012,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn sentinel_client_async_with_timeouts() {
+    async fn test_sentinel_client_async_with_timeouts() {
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, 3, 3);
         let mut master_client = SentinelClient::build(
@@ -1060,7 +1060,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_success_async() {
+    async fn test_get_replica_clients_success_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -1075,7 +1075,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_invalid_master_name_async() {
+    async fn test_get_replica_clients_invalid_master_name_async() {
         let mut context = TestSentinelContext::new(2, 2, 3);
         let node_conn_info = context.sentinel_node_connection_info();
         let sentinel = context.sentinel_mut();
@@ -1095,7 +1095,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_report_correct_master_async() {
+    async fn test_get_replica_clients_report_correct_master_async() {
         let number_of_replicas = 3;
         let master_name = "master1";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);
@@ -1121,7 +1121,7 @@ pub mod async_tests {
     }
 
     #[async_test]
-    async fn get_replica_clients_with_one_replica_down_async() {
+    async fn test_get_replica_clients_with_one_replica_down_async() {
         let number_of_replicas = 3;
         let master_name = "master0";
         let mut context = TestSentinelContext::new(2, number_of_replicas, 3);

--- a/test-macros/src/lib.rs
+++ b/test-macros/src/lib.rs
@@ -3,11 +3,15 @@ use quote::quote;
 
 #[proc_macro_attribute]
 pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
-    let item = syn::parse_macro_input!(input as syn::ItemFn);
+    let mut item = syn::parse_macro_input!(input as syn::ItemFn);
 
+    let test_function_name = item.sig.ident.clone();
+
+    item.sig.ident = syn::Ident::new(
+        &format!("{test_function_name}_internal"),
+        test_function_name.span(),
+    );
     let function_name = item.sig.ident.clone();
-    let test_function_name =
-        syn::Ident::new(&format!("test_{function_name}"), function_name.span());
 
     let final_code = if item.sig.inputs.len() == 1 {
         let Some(syn::FnArg::Typed(pat_type)) = item.sig.inputs.last() else {
@@ -16,7 +20,7 @@ pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
                 .into();
         };
         // Verify the argument is a boolean
-        let is_bool = matches!(&*pat_type.ty, syn::Type::Path(type_path) 
+        let is_bool = matches!(&*pat_type.ty, syn::Type::Path(type_path)
                 if type_path.path.is_ident("bool"));
         let is_connection = matches!(&*pat_type.ty, syn::Type::ImplTrait(impl_trait)
         if impl_trait.bounds.iter().any(|bound| {
@@ -25,39 +29,34 @@ pub fn async_test(_: TokenStream, input: TokenStream) -> TokenStream {
         }));
 
         if is_connection {
-            let test_multiplexed_connection_function_name = syn::Ident::new(
-                &format!("test_multiplexed_connection_{function_name}"),
-                function_name.span(),
-            );
-            let test_connection_manager_function_name = syn::Ident::new(
-                &format!("test_connection_manager_{function_name}"),
-                function_name.span(),
-            );
-
             quote! {
-                #item
+                mod #test_function_name {
+                    use super::*;
+                    #item
 
-                #[rstest::rstest]
-                #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
-                #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
-                fn #test_multiplexed_connection_function_name (#[case]runtime: support::RuntimeType) {
-                    let ctx = TestContext::new();
-                    support::block_on_all(async move {
-                        let conn = ctx.async_connection().await.unwrap();
-                        #function_name (conn).await
-                    }, runtime);
-                }
+                    #[rstest::rstest]
+                    #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
+                    #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
+                    fn multiplexed_connection (#[case]runtime: support::RuntimeType) {
+                        let ctx = TestContext::new();
+                        support::block_on_all(async move {
+                            let conn = ctx.async_connection().await.unwrap();
+                            #function_name (conn).await
+                        }, runtime);
+                    }
 
-                #[rstest::rstest]
-                #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
-                #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
-                #[cfg(feature = "connection-manager")]
-                fn #test_connection_manager_function_name (#[case]runtime: support::RuntimeType) {
-                    let ctx = TestContext::new();
-                    support::block_on_all(async move {
-                        let conn = ctx.client.get_connection_manager().await.unwrap();
-                        #function_name (conn).await
-                    }, runtime);
+                    #[rstest::rstest]
+                    #[cfg_attr(feature = "tokio-comp", case::tokio(support::RuntimeType::Tokio))]
+                    #[cfg_attr(feature = "smol-comp", case::smol(support::RuntimeType::Smol))]
+                    #[cfg(feature = "connection-manager")]
+                    fn connection_manager (#[case]runtime: support::RuntimeType) {
+                        let ctx = TestContext::new();
+                        support::block_on_all(async move {
+                            let conn = ctx.client.get_connection_manager().await.unwrap();
+                            #function_name (conn).await
+                        }, runtime);
+                    }
+
                 }
             }
         } else if is_bool {


### PR DESCRIPTION
rework the async tests so their names in the code will be the same as during the test run.

also the reported tests are changed from:
```
        PASS [   0.034s] (357/968) redis::test_async basic_async::test_connection_manager_scan_with_options_works::case_1_tokio
        PASS [   0.041s] (358/968) redis::test_async basic_async::test_connection_manager_scan_with_options_works::case_2_smol
```
 to
```
        PASS [   0.030s] redis::test_async basic_async::test_scan_with_options_works::connection_manager::case_1_tokio
        PASS [   0.036s] redis::test_async basic_async::test_scan_with_options_works::multiplexed_connection::case_1_tokio
```