### PR TITLE
Optimize async Cluster routing and add diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,6 +2226,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.17.1",
  "itoa",
+ "libc",
  "log",
  "lru",
  "native-tls",

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -54,6 +54,7 @@ tokio = { version = "1", features = [
 arc-swap = { version = "1.9.1", optional = true }
 futures-channel = { version = "0.3.31", optional = true }
 backon = { version = "1.6.0", optional = true, default-features = false }
+libc = { version = "0.2", optional = true }
 
 # Only needed for the r2d2 feature
 r2d2 = { version = "0.8.10", optional = true }
@@ -147,7 +148,17 @@ connection-manager = [
   "dep:backon",
 ]
 streams = []
-cluster-async = ["aio", "cluster", "dep:log"]
+cluster-async = ["aio", "cluster", "dep:arc-swap", "dep:log"]
+# Low-overhead counters and timing aggregates for diagnosing queueing in the
+# async cluster driver. This is intentionally opt-in so the normal hot path
+# remains unchanged.
+cluster-async-diagnostics = ["cluster-async"]
+# More intrusive, sampled Linux CPU/wall profiling for diagnostic benchmark
+# builds. Keep this separate from aggregate diagnostics and normal clients.
+cluster-async-profiling = ["cluster-async-diagnostics", "dep:libc"]
+# Experimental stable per-node connection handles. When disabled, the same
+# atomic routing table uses an original-style locked connection-state map.
+cluster-async-atomic-node-connections = ["cluster-async"]
 sentinel = ["dep:log", "dep:rand"]
 num-bigint = ["dep:num-bigint"]
 cache-aio = ["aio", "dep:lru"]

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -35,6 +35,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{self, Poll};
 use std::time::Duration;
+#[cfg(feature = "cluster-async-diagnostics")]
+use std::time::Instant;
 use tokio_util::codec::Decoder;
 
 // Senders which the result of a single request are sent through
@@ -82,6 +84,8 @@ impl ResponseAggregate {
 struct InFlight {
     output: Option<PipelineOutput>,
     response_aggregate: ResponseAggregate,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    diagnostics: Option<crate::cluster_async::ClusterDiagnostics>,
 }
 
 // A single message sent through the pipeline
@@ -93,6 +97,10 @@ struct PipelineMessage {
     // If `Some`, the first value is the number of responses to skip,
     // the second is the number of responses to keep, and the third is whether the pipeline is a transaction.
     expectation: Option<PipelineResponseExpectation>,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    enqueued_at: Option<Instant>,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    diagnostics: Option<crate::cluster_async::ClusterDiagnostics>,
 }
 
 /// Wrapper around a `Stream + Sink` where each item sent through the `Sink` results in one or more
@@ -102,6 +110,8 @@ struct PipelineMessage {
 #[derive(Clone)]
 struct Pipeline {
     sender: mpsc::Sender<PipelineMessage>,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    diagnostics: Option<crate::cluster_async::ClusterDiagnostics>,
 }
 
 impl Debug for Pipeline {
@@ -110,7 +120,20 @@ impl Debug for Pipeline {
     }
 }
 
-#[cfg(feature = "cache-aio")]
+#[cfg(all(feature = "cache-aio", feature = "cluster-async-diagnostics"))]
+pin_project! {
+    struct PipelineSink<T> {
+        #[pin]
+        sink_stream: T,
+        in_flight: VecDeque<InFlight>,
+        error: Option<RedisError>,
+        push_sender: Option<Arc<dyn AsyncPushSender>>,
+        cache_manager: Option<CacheManager>,
+        diagnostics: Option<crate::cluster_async::ClusterDiagnostics>,
+    }
+}
+
+#[cfg(all(feature = "cache-aio", not(feature = "cluster-async-diagnostics")))]
 pin_project! {
     struct PipelineSink<T> {
         #[pin]
@@ -122,7 +145,19 @@ pin_project! {
     }
 }
 
-#[cfg(not(feature = "cache-aio"))]
+#[cfg(all(not(feature = "cache-aio"), feature = "cluster-async-diagnostics"))]
+pin_project! {
+    struct PipelineSink<T> {
+        #[pin]
+        sink_stream: T,
+        in_flight: VecDeque<InFlight>,
+        error: Option<RedisError>,
+        push_sender: Option<Arc<dyn AsyncPushSender>>,
+        diagnostics: Option<crate::cluster_async::ClusterDiagnostics>,
+    }
+}
+
+#[cfg(all(not(feature = "cache-aio"), not(feature = "cluster-async-diagnostics")))]
 pin_project! {
     struct PipelineSink<T> {
         #[pin]
@@ -151,6 +186,9 @@ where
         sink_stream: T,
         push_sender: Option<Arc<dyn AsyncPushSender>>,
         #[cfg(feature = "cache-aio")] cache_manager: Option<CacheManager>,
+        #[cfg(feature = "cluster-async-diagnostics")] diagnostics: Option<
+            crate::cluster_async::ClusterDiagnostics,
+        >,
     ) -> Self
     where
         T: Sink<Vec<u8>, Error = RedisError> + Stream<Item = RedisResult<Value>> + 'static,
@@ -162,6 +200,8 @@ where
             push_sender,
             #[cfg(feature = "cache-aio")]
             cache_manager,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            diagnostics,
         }
     }
 
@@ -216,6 +256,10 @@ where
             Some(entry) => entry,
             None => return,
         };
+        #[cfg(feature = "cluster-async-diagnostics")]
+        if let Some(diagnostics) = &entry.diagnostics {
+            diagnostics.response_received();
+        }
 
         match &mut entry.response_aggregate {
             ResponseAggregate::SingleCommand => {
@@ -328,6 +372,10 @@ where
             input,
             mut output,
             expectation,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            enqueued_at,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            diagnostics,
         }: PipelineMessage,
     ) -> Result<(), Self::Error> {
         // If initially a receiver was created, but then dropped, there is nothing to receive our output we do not need to send the message as it is
@@ -348,10 +396,16 @@ where
 
         match self_.sink_stream.start_send(input) {
             Ok(()) => {
+                #[cfg(feature = "cluster-async-diagnostics")]
+                if let (Some(diagnostics), Some(enqueued_at)) = (&diagnostics, enqueued_at) {
+                    diagnostics.socket_buffered(enqueued_at);
+                }
                 let response_aggregate = ResponseAggregate::new(expectation);
                 let entry = InFlight {
                     output,
                     response_aggregate,
+                    #[cfg(feature = "cluster-async-diagnostics")]
+                    diagnostics,
                 };
 
                 self_.in_flight.push_back(entry);
@@ -379,13 +433,29 @@ where
         if matches!(self.as_mut().poll_read(cx), Poll::Ready(Err(()))) {
             return Poll::Ready(Err(()));
         }
-        self.as_mut()
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let flush_started = self
+            .as_ref()
+            .project_ref()
+            .diagnostics
+            .is_some()
+            .then(Instant::now);
+        let result = self
+            .as_mut()
             .project()
             .sink_stream
             .poll_flush(cx)
             .map_err(|err| {
                 self.as_mut().send_result(Err(err));
-            })
+            });
+        #[cfg(feature = "cluster-async-diagnostics")]
+        if matches!(result, Poll::Ready(Ok(())))
+            && let (Some(diagnostics), Some(flush_started)) =
+                (self.as_ref().project_ref().diagnostics, flush_started)
+        {
+            diagnostics.socket_flushed(flush_started);
+        }
+        result
     }
 
     fn poll_close(
@@ -415,6 +485,9 @@ impl Pipeline {
         sink_stream: T,
         push_sender: Option<Arc<dyn AsyncPushSender>>,
         #[cfg(feature = "cache-aio")] cache_manager: Option<CacheManager>,
+        #[cfg(feature = "cluster-async-diagnostics")] diagnostics: Option<
+            crate::cluster_async::ClusterDiagnostics,
+        >,
         buffer_size: usize,
     ) -> (Self, impl Future<Output = ()>)
     where
@@ -429,12 +502,21 @@ impl Pipeline {
             push_sender,
             #[cfg(feature = "cache-aio")]
             cache_manager,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            diagnostics.clone(),
         );
         let f = stream::poll_fn(move |cx| receiver.poll_recv(cx))
             .map(Ok)
             .forward(sink)
             .map(|_| ());
-        (Pipeline { sender }, f)
+        (
+            Pipeline {
+                sender,
+                #[cfg(feature = "cluster-async-diagnostics")]
+                diagnostics,
+            },
+            f,
+        )
     }
 
     async fn send_recv(
@@ -452,6 +534,46 @@ impl Pipeline {
 
         let request = async {
             if skip_response {
+                #[cfg(feature = "cluster-async-diagnostics")]
+                {
+                    if let Some(diagnostics) = &self.diagnostics {
+                        let enqueue_started = Instant::now();
+                        #[cfg(feature = "cluster-async-profiling")]
+                        let permit = match self.sender.try_reserve() {
+                            Ok(permit) => {
+                                diagnostics.node_channel_admission(true);
+                                permit
+                            }
+                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                                diagnostics.node_channel_admission(false);
+                                self.sender.reserve().await.map_err(|_| None)?
+                            }
+                            Err(_) => return Err(None),
+                        };
+                        #[cfg(not(feature = "cluster-async-profiling"))]
+                        let permit = self.sender.reserve().await.map_err(|_| None)?;
+                        diagnostics.node_enqueued(enqueue_started);
+                        permit.send(PipelineMessage {
+                            input,
+                            expectation,
+                            output: None,
+                            enqueued_at: Some(Instant::now()),
+                            diagnostics: Some(diagnostics.clone()),
+                        });
+                    } else {
+                        self.sender
+                            .send(PipelineMessage {
+                                input,
+                                expectation,
+                                output: None,
+                                enqueued_at: None,
+                                diagnostics: None,
+                            })
+                            .await
+                            .map_err(|_| None)?;
+                    }
+                }
+                #[cfg(not(feature = "cluster-async-diagnostics"))]
                 self.sender
                     .send(PipelineMessage {
                         input,
@@ -466,6 +588,46 @@ impl Pipeline {
 
             let (sender, receiver) = oneshot::channel();
 
+            #[cfg(feature = "cluster-async-diagnostics")]
+            {
+                if let Some(diagnostics) = &self.diagnostics {
+                    let enqueue_started = Instant::now();
+                    #[cfg(feature = "cluster-async-profiling")]
+                    let permit = match self.sender.try_reserve() {
+                        Ok(permit) => {
+                            diagnostics.node_channel_admission(true);
+                            permit
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            diagnostics.node_channel_admission(false);
+                            self.sender.reserve().await.map_err(|_| None)?
+                        }
+                        Err(_) => return Err(None),
+                    };
+                    #[cfg(not(feature = "cluster-async-profiling"))]
+                    let permit = self.sender.reserve().await.map_err(|_| None)?;
+                    diagnostics.node_enqueued(enqueue_started);
+                    permit.send(PipelineMessage {
+                        input,
+                        expectation,
+                        output: Some(sender),
+                        enqueued_at: Some(Instant::now()),
+                        diagnostics: Some(diagnostics.clone()),
+                    });
+                } else {
+                    self.sender
+                        .send(PipelineMessage {
+                            input,
+                            expectation,
+                            output: Some(sender),
+                            enqueued_at: None,
+                            diagnostics: None,
+                        })
+                        .await
+                        .map_err(|_| None)?;
+                }
+            }
+            #[cfg(not(feature = "cluster-async-diagnostics"))]
             self.sender
                 .send(PipelineMessage {
                     input,
@@ -681,6 +843,8 @@ impl MultiplexedConnection {
             config.push_sender,
             #[cfg(feature = "cache-aio")]
             cache_manager_opt.clone(),
+            #[cfg(feature = "cluster-async-diagnostics")]
+            config.cluster_diagnostics,
             Pipeline::resolve_buffer_size(config.pipeline_buffer_size),
         );
 

--- a/redis/src/client.rs
+++ b/redis/src/client.rs
@@ -197,6 +197,8 @@ pub struct AsyncConnectionConfig {
     pub(crate) concurrency_limit: Option<usize>,
     /// Flush threshold for the outbound write buffer; see [`AsyncConnectionConfig::set_write_backpressure_boundary`].
     pub(crate) write_backpressure_boundary: Option<usize>,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    pub(crate) cluster_diagnostics: Option<crate::cluster_async::ClusterDiagnostics>,
     /// Optional credentials provider for dynamic authentication (e.g., token-based authentication)
     #[cfg(feature = "token-based-authentication")]
     pub(crate) credentials_provider: Option<std::sync::Arc<dyn StreamingCredentialsProvider>>,
@@ -215,6 +217,8 @@ impl Default for AsyncConnectionConfig {
             pipeline_buffer_size: None,
             concurrency_limit: None,
             write_backpressure_boundary: None,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            cluster_diagnostics: None,
             #[cfg(feature = "token-based-authentication")]
             credentials_provider: None,
         }
@@ -371,6 +375,15 @@ impl AsyncConnectionConfig {
     /// When left unset, the connection keeps `tokio_util`'s default boundary (8 KiB).
     pub fn set_write_backpressure_boundary(mut self, boundary: usize) -> Self {
         self.write_backpressure_boundary = Some(boundary);
+        self
+    }
+
+    #[cfg(feature = "cluster-async-diagnostics")]
+    pub(crate) fn set_cluster_diagnostics(
+        mut self,
+        diagnostics: crate::cluster_async::ClusterDiagnostics,
+    ) -> Self {
+        self.cluster_diagnostics = Some(diagnostics);
         self
     }
 

--- a/redis/src/cluster_handling/async_connection/connection_store.rs
+++ b/redis/src/cluster_handling/async_connection/connection_store.rs
@@ -1,0 +1,513 @@
+use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "cluster-async-atomic-node-connections")]
+use std::sync::Arc;
+
+#[cfg(feature = "cluster-async-atomic-node-connections")]
+use arc_swap::ArcSwap;
+use rand::{rng, seq::IteratorRandom};
+#[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use crate::cluster_handling::{NodeAddress, client::ClusterParams};
+
+#[cfg(feature = "cluster-async-atomic-node-connections")]
+enum NodeConnectionState<C> {
+    Connected(C),
+    Reconnecting(Option<C>),
+    Connecting,
+}
+
+#[cfg(feature = "cluster-async-atomic-node-connections")]
+struct NodeHandle<C> {
+    state: ArcSwap<NodeConnectionState<C>>,
+}
+
+#[cfg(feature = "cluster-async-atomic-node-connections")]
+impl<C> NodeHandle<C> {
+    fn connected(connection: C) -> Self {
+        Self {
+            state: ArcSwap::from_pointee(NodeConnectionState::Connected(connection)),
+        }
+    }
+
+    fn connecting() -> Self {
+        Self {
+            state: ArcSwap::from_pointee(NodeConnectionState::Connecting),
+        }
+    }
+
+    fn connected_connection(&self) -> Option<C>
+    where
+        C: Clone,
+    {
+        match &**self.state.load() {
+            NodeConnectionState::Connected(connection) => Some(connection.clone()),
+            NodeConnectionState::Reconnecting(_) | NodeConnectionState::Connecting => None,
+        }
+    }
+
+    fn connection_for_repair(&self) -> Option<C>
+    where
+        C: Clone,
+    {
+        match &**self.state.load() {
+            NodeConnectionState::Connected(connection) => Some(connection.clone()),
+            NodeConnectionState::Reconnecting(connection) => connection.clone(),
+            NodeConnectionState::Connecting => None,
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        matches!(&**self.state.load(), NodeConnectionState::Connected(_))
+    }
+
+    fn begin_reconnect(&self) -> bool
+    where
+        C: Clone,
+    {
+        loop {
+            let current = self.state.load();
+            let replacement = match &**current {
+                NodeConnectionState::Connected(connection) => {
+                    NodeConnectionState::Reconnecting(Some(connection.clone()))
+                }
+                NodeConnectionState::Connecting => NodeConnectionState::Reconnecting(None),
+                NodeConnectionState::Reconnecting(_) => return false,
+            };
+            let previous = self.state.compare_and_swap(&current, Arc::new(replacement));
+            if Arc::ptr_eq(&previous, &current) {
+                return true;
+            }
+        }
+    }
+
+    fn install_connected(&self, connection: C) {
+        self.state
+            .store(Arc::new(NodeConnectionState::Connected(connection)));
+    }
+
+    fn install_repaired(&self, connection: C) -> bool {
+        let current = self.state.load();
+        if matches!(&**current, NodeConnectionState::Connected(_)) {
+            return false;
+        }
+        let previous = self.state.compare_and_swap(
+            &current,
+            Arc::new(NodeConnectionState::Connected(connection)),
+        );
+        Arc::ptr_eq(&previous, &current)
+    }
+}
+
+#[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+enum ConnState<C> {
+    Connected(C),
+    Reconnecting(Option<C>),
+    Connecting,
+}
+
+#[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+impl<C: Clone> ConnState<C> {
+    fn connected(&self) -> Option<C> {
+        match self {
+            Self::Connected(connection) => Some(connection.clone()),
+            Self::Reconnecting(_) | Self::Connecting => None,
+        }
+    }
+
+    fn connection_for_repair(&self) -> Option<C> {
+        match self {
+            Self::Connected(connection) => Some(connection.clone()),
+            Self::Reconnecting(connection) => connection.clone(),
+            Self::Connecting => None,
+        }
+    }
+}
+
+/// Connection state is deliberately independent of the immutable routing
+/// table. The default backend preserves a locked connection map; the optional
+/// experimental backend gives every address a stable atomically-swapped
+/// handle. Keeping the API identical makes the reconnect-state A/B precise.
+pub(super) struct ConnectionStore<C> {
+    #[cfg(feature = "cluster-async-atomic-node-connections")]
+    nodes: ArcSwap<HashMap<NodeAddress, Arc<NodeHandle<C>>>>,
+    #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+    connections: RwLock<HashMap<NodeAddress, ConnState<C>>>,
+}
+
+impl<C: Clone> ConnectionStore<C> {
+    pub(super) fn new() -> Self {
+        Self {
+            #[cfg(feature = "cluster-async-atomic-node-connections")]
+            nodes: ArcSwap::from_pointee(HashMap::new()),
+            #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+            connections: RwLock::new(HashMap::new()),
+        }
+    }
+
+    #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+    async fn read<'a>(
+        &'a self,
+        params: &ClusterParams,
+    ) -> RwLockReadGuard<'a, HashMap<NodeAddress, ConnState<C>>> {
+        #[cfg(not(feature = "cluster-async-profiling"))]
+        let _ = params;
+        match self.connections.try_read() {
+            Ok(guard) => {
+                #[cfg(feature = "cluster-async-profiling")]
+                params.diagnostics.connection_lock_acquired(None);
+                guard
+            }
+            Err(_) => {
+                #[cfg(feature = "cluster-async-profiling")]
+                let started = std::time::Instant::now();
+                let guard = self.connections.read().await;
+                #[cfg(feature = "cluster-async-profiling")]
+                params.diagnostics.connection_lock_acquired(Some(started));
+                guard
+            }
+        }
+    }
+
+    #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+    async fn write<'a>(
+        &'a self,
+        params: &ClusterParams,
+    ) -> RwLockWriteGuard<'a, HashMap<NodeAddress, ConnState<C>>> {
+        #[cfg(not(feature = "cluster-async-profiling"))]
+        let _ = params;
+        match self.connections.try_write() {
+            Ok(guard) => {
+                #[cfg(feature = "cluster-async-profiling")]
+                params.diagnostics.connection_lock_acquired(None);
+                guard
+            }
+            Err(_) => {
+                #[cfg(feature = "cluster-async-profiling")]
+                let started = std::time::Instant::now();
+                let guard = self.connections.write().await;
+                #[cfg(feature = "cluster-async-profiling")]
+                params.diagnostics.connection_lock_acquired(Some(started));
+                guard
+            }
+        }
+    }
+
+    #[cfg(feature = "cluster-async-atomic-node-connections")]
+    fn node(&self, address: &NodeAddress) -> Option<Arc<NodeHandle<C>>> {
+        self.nodes.load().get(address).cloned()
+    }
+
+    #[cfg(feature = "cluster-async-atomic-node-connections")]
+    fn ensure_node(&self, address: NodeAddress) -> Arc<NodeHandle<C>> {
+        loop {
+            let current = self.nodes.load();
+            if let Some(node) = current.get(&address) {
+                return Arc::clone(node);
+            }
+            let node = Arc::new(NodeHandle::connecting());
+            let mut replacement = (**current).clone();
+            replacement.insert(address.clone(), Arc::clone(&node));
+            let previous = self.nodes.compare_and_swap(&current, Arc::new(replacement));
+            if Arc::ptr_eq(&previous, &current) {
+                return node;
+            }
+        }
+    }
+
+    pub(super) async fn replace_connected(
+        &self,
+        connections: HashMap<NodeAddress, C>,
+        params: &ClusterParams,
+    ) {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let nodes = connections
+                .into_iter()
+                .map(|(address, connection)| {
+                    let node = Arc::new(NodeHandle::connected(connection));
+                    (address, node)
+                })
+                .collect();
+            self.nodes.store(Arc::new(nodes));
+            let _ = params;
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            let mut guard = self.write(params).await;
+            *guard = connections
+                .into_iter()
+                .map(|(address, connection)| (address, ConnState::Connected(connection)))
+                .collect();
+        }
+    }
+
+    pub(super) async fn connected(
+        &self,
+        address: &NodeAddress,
+        params: &ClusterParams,
+    ) -> Option<C> {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            self.node(address)
+                .and_then(|node| node.connected_connection())
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            self.read(params)
+                .await
+                .get(address)
+                .and_then(ConnState::connected)
+        }
+    }
+
+    pub(super) async fn connection_for_repair(
+        &self,
+        address: &NodeAddress,
+        params: &ClusterParams,
+    ) -> Option<C> {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            self.node(address)
+                .and_then(|node| node.connection_for_repair())
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            self.read(params)
+                .await
+                .get(address)
+                .and_then(ConnState::connection_for_repair)
+        }
+    }
+
+    pub(super) async fn connected_for_addresses(
+        &self,
+        addresses: &[NodeAddress],
+        include_reconnecting: bool,
+        params: &ClusterParams,
+    ) -> Vec<(NodeAddress, C)> {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            let nodes = self.nodes.load();
+            addresses
+                .iter()
+                .filter_map(|address| {
+                    let node = nodes.get(address)?;
+                    let connection = if include_reconnecting {
+                        node.connection_for_repair()
+                    } else {
+                        node.connected_connection()
+                    }?;
+                    Some((address.clone(), connection))
+                })
+                .collect()
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            let guard = self.read(params).await;
+            addresses
+                .iter()
+                .filter_map(|address| {
+                    let state = guard.get(address)?;
+                    let connection = if include_reconnecting {
+                        state.connection_for_repair()
+                    } else {
+                        state.connected()
+                    }?;
+                    Some((address.clone(), connection))
+                })
+                .collect()
+        }
+    }
+
+    pub(super) async fn random_connected(
+        &self,
+        params: &ClusterParams,
+    ) -> Option<(NodeAddress, C)> {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            self.nodes
+                .load()
+                .iter()
+                .filter_map(|(address, node)| {
+                    node.connected_connection()
+                        .map(|connection| (address.clone(), connection))
+                })
+                .choose(&mut rng())
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            self.read(params)
+                .await
+                .iter()
+                .filter_map(|(address, state)| {
+                    state
+                        .connected()
+                        .map(|connection| (address.clone(), connection))
+                })
+                .choose(&mut rng())
+        }
+    }
+
+    pub(super) async fn known_connections(
+        &self,
+        params: &ClusterParams,
+    ) -> Vec<(NodeAddress, Option<C>)> {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            self.nodes
+                .load()
+                .iter()
+                .map(|(address, node)| (address.clone(), node.connection_for_repair()))
+                .collect()
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            self.read(params)
+                .await
+                .iter()
+                .map(|(address, state)| (address.clone(), state.connection_for_repair()))
+                .collect()
+        }
+    }
+
+    pub(super) async fn install_connected(
+        &self,
+        address: NodeAddress,
+        connection: C,
+        params: &ClusterParams,
+    ) {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let node = self.ensure_node(address);
+            node.install_connected(connection);
+            let _ = params;
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            self.write(params)
+                .await
+                .insert(address, ConnState::Connected(connection));
+        }
+    }
+
+    pub(super) async fn begin_reconnect(
+        &self,
+        address: NodeAddress,
+        params: &ClusterParams,
+    ) -> bool {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            self.ensure_node(address).begin_reconnect()
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            let mut guard = self.write(params).await;
+            match guard.get_mut(&address) {
+                Some(ConnState::Reconnecting(_) | ConnState::Connecting) => false,
+                Some(state @ ConnState::Connected(_)) => {
+                    let old = match std::mem::replace(state, ConnState::Connecting) {
+                        ConnState::Connected(connection) => Some(connection),
+                        _ => unreachable!(),
+                    };
+                    *state = ConnState::Reconnecting(old);
+                    true
+                }
+                None => {
+                    guard.insert(address, ConnState::Connecting);
+                    true
+                }
+            }
+        }
+    }
+
+    pub(super) async fn is_connected(&self, address: &NodeAddress, params: &ClusterParams) -> bool {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            self.node(address).is_some_and(|node| node.is_connected())
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            matches!(
+                self.read(params).await.get(address),
+                Some(ConnState::Connected(_))
+            )
+        }
+    }
+
+    pub(super) async fn install_repaired(
+        &self,
+        address: NodeAddress,
+        connection: C,
+        params: &ClusterParams,
+    ) -> bool {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            let _ = params;
+            self.ensure_node(address).install_repaired(connection)
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            let mut guard = self.write(params).await;
+            if matches!(guard.get(&address), Some(ConnState::Connected(_))) {
+                false
+            } else {
+                guard.insert(address, ConnState::Connected(connection));
+                true
+            }
+        }
+    }
+
+    pub(super) async fn retain(&self, addresses: &HashSet<NodeAddress>, params: &ClusterParams) {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            loop {
+                let current = self.nodes.load();
+                let mut replacement = (**current).clone();
+                replacement.retain(|address, _| addresses.contains(address));
+                let previous = self.nodes.compare_and_swap(&current, Arc::new(replacement));
+                if Arc::ptr_eq(&previous, &current) {
+                    break;
+                }
+            }
+            let _ = params;
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            self.write(params)
+                .await
+                .retain(|address, _| addresses.contains(address));
+        }
+    }
+
+    pub(super) async fn remove(&self, address: &NodeAddress, params: &ClusterParams) {
+        #[cfg(feature = "cluster-async-atomic-node-connections")]
+        {
+            loop {
+                let current = self.nodes.load();
+                if !current.contains_key(address) {
+                    break;
+                }
+                let mut replacement = (**current).clone();
+                replacement.remove(address);
+                let previous = self.nodes.compare_and_swap(&current, Arc::new(replacement));
+                if Arc::ptr_eq(&previous, &current) {
+                    break;
+                }
+            }
+            let _ = params;
+        }
+        #[cfg(not(feature = "cluster-async-atomic-node-connections"))]
+        {
+            self.write(params).await.remove(address);
+        }
+    }
+}

--- a/redis/src/cluster_handling/async_connection/diagnostics.rs
+++ b/redis/src/cluster_handling/async_connection/diagnostics.rs
@@ -1,0 +1,904 @@
+//! Opt-in diagnostics for the asynchronous cluster driver.
+//!
+//! The counters in this module are deliberately aggregate-only: enabling the
+//! feature does not allocate or emit an event for every command. Durations are
+//! represented as count/total/max nanoseconds so callers can export them to
+//! their metrics system without redis-rs choosing a histogram implementation.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+#[derive(Default)]
+struct Timing {
+    count: AtomicU64,
+    total_nanos: AtomicU64,
+    max_nanos: AtomicU64,
+}
+
+impl Timing {
+    fn record(&self, duration: Duration) {
+        let nanos = duration.as_nanos().min(u64::MAX as u128) as u64;
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.total_nanos.fetch_add(nanos, Ordering::Relaxed);
+        update_max_u64(&self.max_nanos, nanos);
+    }
+
+    fn snapshot(&self) -> ClusterTimingSnapshot {
+        ClusterTimingSnapshot {
+            count: self.count.load(Ordering::Relaxed),
+            total_nanos: self.total_nanos.load(Ordering::Relaxed),
+            max_nanos: self.max_nanos.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    api_calls: AtomicU64,
+    enqueued: AtomicU64,
+    driver_received: AtomicU64,
+    routed: AtomicU64,
+    node_enqueued: AtomicU64,
+    socket_buffered: AtomicU64,
+    socket_flushes: AtomicU64,
+    responses_received: AtomicU64,
+    driver_completed: AtomicU64,
+    caller_delivered: AtomicU64,
+    cancelled_before_dispatch: AtomicU64,
+    cancelled_in_flight: AtomicU64,
+    refresh_started: AtomicU64,
+    refresh_completed: AtomicU64,
+    refresh_failed: AtomicU64,
+    reconnect_started: AtomicU64,
+    reconnect_completed: AtomicU64,
+    reconnect_failed: AtomicU64,
+    reconnect_triggers: AtomicU64,
+    reconnect_claimed: AtomicU64,
+    reconnect_deduplicated: AtomicU64,
+    reconnect_installed: AtomicU64,
+    reconnect_discarded: AtomicU64,
+    reconnect_active: AtomicUsize,
+    max_reconnect_active: AtomicUsize,
+    top_channel_immediate: AtomicU64,
+    top_channel_full: AtomicU64,
+    node_channel_immediate: AtomicU64,
+    node_channel_full: AtomicU64,
+    connection_lock_immediate: AtomicU64,
+    connection_lock_contended: AtomicU64,
+    driver_polls: AtomicU64,
+    commands_dispatched: AtomicU64,
+    completions_processed: AtomicU64,
+    max_received_per_poll: AtomicUsize,
+    max_dispatched_per_poll: AtomicUsize,
+    max_completions_per_poll: AtomicUsize,
+    top_level_queue_depth: AtomicUsize,
+    max_top_level_queue_depth: AtomicUsize,
+    pending_depth: AtomicUsize,
+    max_pending_depth: AtomicUsize,
+    in_flight: AtomicUsize,
+    max_in_flight: AtomicUsize,
+    enqueue_wait: Timing,
+    cluster_queue_wait: Timing,
+    routing: Timing,
+    node_enqueue_wait: Timing,
+    node_queue_wait: Timing,
+    socket_flush: Timing,
+    request_total: Timing,
+    refresh: Timing,
+    reconnect: Timing,
+    connection_lock_wait: Timing,
+    routing_sync_wall: Timing,
+    routing_sync_cpu: Timing,
+    driver_poll_wall: Timing,
+    driver_poll_cpu: Timing,
+    driver_poll_off_cpu: Timing,
+    dispatch_wall: Timing,
+    dispatch_cpu: Timing,
+    dispatch_off_cpu: Timing,
+    completion_wall: Timing,
+    completion_cpu: Timing,
+    completion_off_cpu: Timing,
+    profile_sequence: AtomicU64,
+}
+
+/// Aggregate timing values for one phase of the request path.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ClusterTimingSnapshot {
+    /// Number of observations.
+    pub count: u64,
+    /// Sum of all observed durations, in nanoseconds.
+    pub total_nanos: u64,
+    /// Largest observed duration, in nanoseconds.
+    pub max_nanos: u64,
+}
+
+impl ClusterTimingSnapshot {
+    /// Returns the arithmetic mean, or `None` when no values were observed.
+    pub fn mean(&self) -> Option<Duration> {
+        (self.count > 0).then(|| Duration::from_nanos(self.total_nanos / self.count))
+    }
+
+    /// Returns the maximum observed duration.
+    pub fn max(&self) -> Duration {
+        Duration::from_nanos(self.max_nanos)
+    }
+
+    fn merge(&mut self, other: &Self) {
+        self.count = self.count.saturating_add(other.count);
+        self.total_nanos = self.total_nanos.saturating_add(other.total_nanos);
+        self.max_nanos = self.max_nanos.max(other.max_nanos);
+    }
+
+    fn delta_since(&self, earlier: &Self) -> Self {
+        Self {
+            count: self.count.saturating_sub(earlier.count),
+            total_nanos: self.total_nanos.saturating_sub(earlier.total_nanos),
+            // A cumulative maximum cannot be losslessly differenced. Retain it
+            // so an interval exporter never hides a process-lifetime peak.
+            max_nanos: self.max_nanos,
+        }
+    }
+}
+
+/// A point-in-time snapshot of async cluster-driver activity.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ClusterDiagnosticsSnapshot {
+    /// API calls entering this `ClusterConnection` driver.
+    pub api_calls: u64,
+    /// Commands successfully enqueued on the top-level driver channel.
+    pub enqueued: u64,
+    /// Commands received by the cluster driver.
+    pub driver_received: u64,
+    /// Commands for which cluster routing completed.
+    pub routed: u64,
+    /// Commands successfully enqueued on a node connection pipeline.
+    pub node_enqueued: u64,
+    /// Commands copied into a node connection's socket codec buffer.
+    pub socket_buffered: u64,
+    /// Successful socket-buffer flush polls.
+    pub socket_flushes: u64,
+    /// RESP replies decoded by node connections.
+    pub responses_received: u64,
+    /// Requests completed by the cluster driver, before caller wake-up.
+    pub driver_completed: u64,
+    /// Requests observed as complete by their API caller.
+    pub caller_delivered: u64,
+    /// Cancelled requests discarded before node dispatch.
+    pub cancelled_before_dispatch: u64,
+    /// Cancelled requests removed while in flight in the cluster driver.
+    pub cancelled_in_flight: u64,
+    /// Topology refresh attempts started.
+    pub refresh_started: u64,
+    /// Successful topology refresh attempts.
+    pub refresh_completed: u64,
+    /// Failed topology refresh attempts.
+    pub refresh_failed: u64,
+    /// Node reconnect attempts started.
+    pub reconnect_started: u64,
+    /// Successful node reconnect attempts.
+    pub reconnect_completed: u64,
+    /// Failed node reconnect attempts.
+    pub reconnect_failed: u64,
+    /// Failure notifications that requested a node reconnect.
+    pub reconnect_triggers: u64,
+    /// Reconnect triggers that won single-flight ownership.
+    pub reconnect_claimed: u64,
+    /// Reconnect triggers suppressed because a repair was already active.
+    pub reconnect_deduplicated: u64,
+    /// Repaired connections atomically installed for routing.
+    pub reconnect_installed: u64,
+    /// Successfully-created connections discarded because another repair won.
+    pub reconnect_discarded: u64,
+    /// Current number of connection attempts in progress.
+    pub reconnect_active: usize,
+    /// Largest number of concurrent connection attempts.
+    pub max_reconnect_active: usize,
+    /// Top-level channel admissions that obtained capacity immediately.
+    pub top_channel_immediate: u64,
+    /// Top-level channel admissions that initially found the channel full.
+    pub top_channel_full: u64,
+    /// Node-pipeline admissions that obtained capacity immediately.
+    pub node_channel_immediate: u64,
+    /// Node-pipeline admissions that initially found the channel full.
+    pub node_channel_full: u64,
+    /// Connection-map read locks obtained without waiting.
+    pub connection_lock_immediate: u64,
+    /// Connection-map read locks that initially reported contention.
+    pub connection_lock_contended: u64,
+    /// Calls to the cluster driver's `poll_flush` implementation.
+    pub driver_polls: u64,
+    /// Requests dispatched by the cluster driver.
+    pub commands_dispatched: u64,
+    /// Ready requests processed from the in-flight set.
+    pub completions_processed: u64,
+    /// Largest top-level intake batch observed before a driver flush poll.
+    pub max_received_per_poll: usize,
+    /// Largest request-dispatch batch in one driver poll.
+    pub max_dispatched_per_poll: usize,
+    /// Largest ready-completion batch in one driver poll.
+    pub max_completions_per_poll: usize,
+    /// Current top-level intake backlog: commands in the bounded channel plus
+    /// an item, if any, handed to the stream/sink adapter but not yet received
+    /// by the cluster driver.
+    pub top_level_queue_depth: usize,
+    /// Largest observed top-level intake backlog. Because the forwarding
+    /// adapter can hold one item, this can be one larger than channel capacity.
+    pub max_top_level_queue_depth: usize,
+    /// Current number of requests awaiting dispatch inside the driver.
+    pub pending_depth: usize,
+    /// Largest observed internal pending depth.
+    pub max_pending_depth: usize,
+    /// Current number of request futures owned by the cluster driver.
+    pub in_flight: usize,
+    /// Largest observed cluster-driver in-flight count.
+    pub max_in_flight: usize,
+    /// Time awaiting capacity in the top-level bounded channel.
+    pub enqueue_wait: ClusterTimingSnapshot,
+    /// Time from top-level enqueue completion until cluster-driver receipt.
+    pub cluster_queue_wait: ClusterTimingSnapshot,
+    /// Time spent selecting or establishing the routed node connection.
+    pub routing: ClusterTimingSnapshot,
+    /// Time awaiting capacity in a node connection's bounded pipeline channel.
+    pub node_enqueue_wait: ClusterTimingSnapshot,
+    /// Time queued between node-channel enqueue and node-driver receipt.
+    pub node_queue_wait: ClusterTimingSnapshot,
+    /// Time spent in successful node socket flush polls.
+    pub socket_flush: ClusterTimingSnapshot,
+    /// End-to-end time from cluster API entry until caller delivery.
+    pub request_total: ClusterTimingSnapshot,
+    /// Topology refresh duration.
+    pub refresh: ClusterTimingSnapshot,
+    /// Node reconnect-attempt duration.
+    pub reconnect: ClusterTimingSnapshot,
+    /// Wait after an initially-contended connection-map read lock.
+    pub connection_lock_wait: ClusterTimingSnapshot,
+    /// Sampled wall time spent in synchronous route/connection selection.
+    pub routing_sync_wall: ClusterTimingSnapshot,
+    /// Sampled thread CPU time spent in synchronous route/connection selection.
+    pub routing_sync_cpu: ClusterTimingSnapshot,
+    /// Sampled wall time inside one cluster-driver `poll_flush` invocation.
+    pub driver_poll_wall: ClusterTimingSnapshot,
+    /// Sampled thread CPU time inside one cluster-driver `poll_flush` invocation.
+    pub driver_poll_cpu: ClusterTimingSnapshot,
+    /// Sampled driver-poll wall time not accounted for by thread CPU time.
+    pub driver_poll_off_cpu: ClusterTimingSnapshot,
+    /// Sampled wall time spent dispatching pending requests.
+    pub dispatch_wall: ClusterTimingSnapshot,
+    /// Sampled thread CPU time spent dispatching pending requests.
+    pub dispatch_cpu: ClusterTimingSnapshot,
+    /// Sampled dispatch wall time not accounted for by thread CPU time.
+    pub dispatch_off_cpu: ClusterTimingSnapshot,
+    /// Sampled wall time spent polling ready request completions.
+    pub completion_wall: ClusterTimingSnapshot,
+    /// Sampled thread CPU time spent polling ready request completions.
+    pub completion_cpu: ClusterTimingSnapshot,
+    /// Sampled completion wall time not accounted for by thread CPU time.
+    pub completion_off_cpu: ClusterTimingSnapshot,
+}
+
+impl ClusterDiagnosticsSnapshot {
+    /// Returns counter and timing deltas since `earlier`.
+    ///
+    /// Current gauges and cumulative maxima are copied from the newer
+    /// snapshot. Maxima cannot be losslessly differenced without resetting the
+    /// shared instrumentation, which would make concurrent exporters race.
+    pub fn delta_since(&self, earlier: &Self) -> Self {
+        macro_rules! difference {
+            ($result:ident; $($field:ident),+ $(,)?) => {
+                $($result.$field = self.$field.saturating_sub(earlier.$field);)+
+            };
+        }
+
+        let mut result = Self {
+            max_received_per_poll: self.max_received_per_poll,
+            max_dispatched_per_poll: self.max_dispatched_per_poll,
+            max_completions_per_poll: self.max_completions_per_poll,
+            top_level_queue_depth: self.top_level_queue_depth,
+            max_top_level_queue_depth: self.max_top_level_queue_depth,
+            pending_depth: self.pending_depth,
+            max_pending_depth: self.max_pending_depth,
+            in_flight: self.in_flight,
+            max_in_flight: self.max_in_flight,
+            reconnect_active: self.reconnect_active,
+            max_reconnect_active: self.max_reconnect_active,
+            enqueue_wait: self.enqueue_wait.delta_since(&earlier.enqueue_wait),
+            cluster_queue_wait: self
+                .cluster_queue_wait
+                .delta_since(&earlier.cluster_queue_wait),
+            routing: self.routing.delta_since(&earlier.routing),
+            node_enqueue_wait: self
+                .node_enqueue_wait
+                .delta_since(&earlier.node_enqueue_wait),
+            node_queue_wait: self.node_queue_wait.delta_since(&earlier.node_queue_wait),
+            socket_flush: self.socket_flush.delta_since(&earlier.socket_flush),
+            request_total: self.request_total.delta_since(&earlier.request_total),
+            refresh: self.refresh.delta_since(&earlier.refresh),
+            reconnect: self.reconnect.delta_since(&earlier.reconnect),
+            connection_lock_wait: self
+                .connection_lock_wait
+                .delta_since(&earlier.connection_lock_wait),
+            routing_sync_wall: self
+                .routing_sync_wall
+                .delta_since(&earlier.routing_sync_wall),
+            routing_sync_cpu: self.routing_sync_cpu.delta_since(&earlier.routing_sync_cpu),
+            driver_poll_wall: self.driver_poll_wall.delta_since(&earlier.driver_poll_wall),
+            driver_poll_cpu: self.driver_poll_cpu.delta_since(&earlier.driver_poll_cpu),
+            driver_poll_off_cpu: self
+                .driver_poll_off_cpu
+                .delta_since(&earlier.driver_poll_off_cpu),
+            dispatch_wall: self.dispatch_wall.delta_since(&earlier.dispatch_wall),
+            dispatch_cpu: self.dispatch_cpu.delta_since(&earlier.dispatch_cpu),
+            dispatch_off_cpu: self.dispatch_off_cpu.delta_since(&earlier.dispatch_off_cpu),
+            completion_wall: self.completion_wall.delta_since(&earlier.completion_wall),
+            completion_cpu: self.completion_cpu.delta_since(&earlier.completion_cpu),
+            completion_off_cpu: self
+                .completion_off_cpu
+                .delta_since(&earlier.completion_off_cpu),
+            ..Self::default()
+        };
+        difference!(result;
+            api_calls,
+            enqueued,
+            driver_received,
+            routed,
+            node_enqueued,
+            socket_buffered,
+            socket_flushes,
+            responses_received,
+            driver_completed,
+            caller_delivered,
+            cancelled_before_dispatch,
+            cancelled_in_flight,
+            refresh_started,
+            refresh_completed,
+            refresh_failed,
+            reconnect_started,
+            reconnect_completed,
+            reconnect_failed,
+            reconnect_triggers,
+            reconnect_claimed,
+            reconnect_deduplicated,
+            reconnect_installed,
+            reconnect_discarded,
+            top_channel_immediate,
+            top_channel_full,
+            node_channel_immediate,
+            node_channel_full,
+            connection_lock_immediate,
+            connection_lock_contended,
+            driver_polls,
+            commands_dispatched,
+            completions_processed,
+        );
+        result
+    }
+
+    /// Merges another snapshot into this one.
+    ///
+    /// Counters, current gauges, and timing counts/totals are summed; maxima
+    /// retain the largest value. This is useful for aggregating an application
+    /// pool containing multiple independent `ClusterConnection` drivers.
+    pub fn merge(&mut self, other: &Self) {
+        macro_rules! sum {
+            ($($field:ident),+ $(,)?) => {
+                $(self.$field = self.$field.saturating_add(other.$field);)+
+            };
+        }
+        macro_rules! maximum {
+            ($($field:ident),+ $(,)?) => {
+                $(self.$field = self.$field.max(other.$field);)+
+            };
+        }
+
+        sum!(
+            api_calls,
+            enqueued,
+            driver_received,
+            routed,
+            node_enqueued,
+            socket_buffered,
+            socket_flushes,
+            responses_received,
+            driver_completed,
+            caller_delivered,
+            cancelled_before_dispatch,
+            cancelled_in_flight,
+            refresh_started,
+            refresh_completed,
+            refresh_failed,
+            reconnect_started,
+            reconnect_completed,
+            reconnect_failed,
+            reconnect_triggers,
+            reconnect_claimed,
+            reconnect_deduplicated,
+            reconnect_installed,
+            reconnect_discarded,
+            top_channel_immediate,
+            top_channel_full,
+            node_channel_immediate,
+            node_channel_full,
+            connection_lock_immediate,
+            connection_lock_contended,
+            driver_polls,
+            commands_dispatched,
+            completions_processed,
+            top_level_queue_depth,
+            pending_depth,
+            in_flight,
+            reconnect_active,
+        );
+        maximum!(
+            max_received_per_poll,
+            max_dispatched_per_poll,
+            max_completions_per_poll,
+            max_top_level_queue_depth,
+            max_pending_depth,
+            max_in_flight,
+            max_reconnect_active,
+        );
+        self.enqueue_wait.merge(&other.enqueue_wait);
+        self.cluster_queue_wait.merge(&other.cluster_queue_wait);
+        self.routing.merge(&other.routing);
+        self.node_enqueue_wait.merge(&other.node_enqueue_wait);
+        self.node_queue_wait.merge(&other.node_queue_wait);
+        self.socket_flush.merge(&other.socket_flush);
+        self.request_total.merge(&other.request_total);
+        self.refresh.merge(&other.refresh);
+        self.reconnect.merge(&other.reconnect);
+        self.connection_lock_wait.merge(&other.connection_lock_wait);
+        self.routing_sync_wall.merge(&other.routing_sync_wall);
+        self.routing_sync_cpu.merge(&other.routing_sync_cpu);
+        self.driver_poll_wall.merge(&other.driver_poll_wall);
+        self.driver_poll_cpu.merge(&other.driver_poll_cpu);
+        self.driver_poll_off_cpu.merge(&other.driver_poll_off_cpu);
+        self.dispatch_wall.merge(&other.dispatch_wall);
+        self.dispatch_cpu.merge(&other.dispatch_cpu);
+        self.dispatch_off_cpu.merge(&other.dispatch_off_cpu);
+        self.completion_wall.merge(&other.completion_wall);
+        self.completion_cpu.merge(&other.completion_cpu);
+        self.completion_off_cpu.merge(&other.completion_off_cpu);
+    }
+}
+
+/// Shared aggregate diagnostics for one async cluster connection driver.
+///
+/// Cloned `ClusterConnection` handles report the same diagnostics, matching
+/// their shared driver and queue. A separately-created connection has its own
+/// counters.
+#[derive(Clone, Default)]
+pub struct ClusterDiagnostics {
+    inner: Arc<Inner>,
+}
+
+#[cfg(feature = "cluster-async-profiling")]
+const PROFILE_SAMPLE_MASK: u64 = 1024 - 1;
+
+#[cfg(feature = "cluster-async-profiling")]
+#[derive(Clone, Copy)]
+pub(crate) enum ProfilePhase {
+    RoutingSync,
+    DriverPoll,
+    Dispatch,
+    Completion,
+}
+
+/// A sampled synchronous section. Because a future cannot migrate while one
+/// invocation of its `poll` method is executing, Linux thread CPU time can be
+/// compared with wall time for these sections without attributing another
+/// executor thread's work to this driver.
+#[cfg(feature = "cluster-async-profiling")]
+pub(crate) struct ProfileGuard {
+    diagnostics: ClusterDiagnostics,
+    phase: ProfilePhase,
+    wall_started: Instant,
+    cpu_started: Option<Duration>,
+}
+
+#[cfg(feature = "cluster-async-profiling")]
+impl Drop for ProfileGuard {
+    fn drop(&mut self) {
+        let wall = self.wall_started.elapsed();
+        let cpu = self
+            .cpu_started
+            .zip(thread_cpu_time())
+            .map(|(started, finished)| finished.saturating_sub(started));
+        self.diagnostics.record_profile(self.phase, wall, cpu);
+    }
+}
+
+impl std::fmt::Debug for ClusterDiagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.snapshot().fmt(f)
+    }
+}
+
+impl ClusterDiagnostics {
+    /// Captures the current counters, gauges, and aggregate timings.
+    pub fn snapshot(&self) -> ClusterDiagnosticsSnapshot {
+        let inner = &self.inner;
+        ClusterDiagnosticsSnapshot {
+            api_calls: load(&inner.api_calls),
+            enqueued: load(&inner.enqueued),
+            driver_received: load(&inner.driver_received),
+            routed: load(&inner.routed),
+            node_enqueued: load(&inner.node_enqueued),
+            socket_buffered: load(&inner.socket_buffered),
+            socket_flushes: load(&inner.socket_flushes),
+            responses_received: load(&inner.responses_received),
+            driver_completed: load(&inner.driver_completed),
+            caller_delivered: load(&inner.caller_delivered),
+            cancelled_before_dispatch: load(&inner.cancelled_before_dispatch),
+            cancelled_in_flight: load(&inner.cancelled_in_flight),
+            refresh_started: load(&inner.refresh_started),
+            refresh_completed: load(&inner.refresh_completed),
+            refresh_failed: load(&inner.refresh_failed),
+            reconnect_started: load(&inner.reconnect_started),
+            reconnect_completed: load(&inner.reconnect_completed),
+            reconnect_failed: load(&inner.reconnect_failed),
+            reconnect_triggers: load(&inner.reconnect_triggers),
+            reconnect_claimed: load(&inner.reconnect_claimed),
+            reconnect_deduplicated: load(&inner.reconnect_deduplicated),
+            reconnect_installed: load(&inner.reconnect_installed),
+            reconnect_discarded: load(&inner.reconnect_discarded),
+            reconnect_active: load_usize(&inner.reconnect_active),
+            max_reconnect_active: load_usize(&inner.max_reconnect_active),
+            top_channel_immediate: load(&inner.top_channel_immediate),
+            top_channel_full: load(&inner.top_channel_full),
+            node_channel_immediate: load(&inner.node_channel_immediate),
+            node_channel_full: load(&inner.node_channel_full),
+            connection_lock_immediate: load(&inner.connection_lock_immediate),
+            connection_lock_contended: load(&inner.connection_lock_contended),
+            driver_polls: load(&inner.driver_polls),
+            commands_dispatched: load(&inner.commands_dispatched),
+            completions_processed: load(&inner.completions_processed),
+            max_received_per_poll: load_usize(&inner.max_received_per_poll),
+            max_dispatched_per_poll: load_usize(&inner.max_dispatched_per_poll),
+            max_completions_per_poll: load_usize(&inner.max_completions_per_poll),
+            top_level_queue_depth: load_usize(&inner.top_level_queue_depth),
+            max_top_level_queue_depth: load_usize(&inner.max_top_level_queue_depth),
+            pending_depth: load_usize(&inner.pending_depth),
+            max_pending_depth: load_usize(&inner.max_pending_depth),
+            in_flight: load_usize(&inner.in_flight),
+            max_in_flight: load_usize(&inner.max_in_flight),
+            enqueue_wait: inner.enqueue_wait.snapshot(),
+            cluster_queue_wait: inner.cluster_queue_wait.snapshot(),
+            routing: inner.routing.snapshot(),
+            node_enqueue_wait: inner.node_enqueue_wait.snapshot(),
+            node_queue_wait: inner.node_queue_wait.snapshot(),
+            socket_flush: inner.socket_flush.snapshot(),
+            request_total: inner.request_total.snapshot(),
+            refresh: inner.refresh.snapshot(),
+            reconnect: inner.reconnect.snapshot(),
+            connection_lock_wait: inner.connection_lock_wait.snapshot(),
+            routing_sync_wall: inner.routing_sync_wall.snapshot(),
+            routing_sync_cpu: inner.routing_sync_cpu.snapshot(),
+            driver_poll_wall: inner.driver_poll_wall.snapshot(),
+            driver_poll_cpu: inner.driver_poll_cpu.snapshot(),
+            driver_poll_off_cpu: inner.driver_poll_off_cpu.snapshot(),
+            dispatch_wall: inner.dispatch_wall.snapshot(),
+            dispatch_cpu: inner.dispatch_cpu.snapshot(),
+            dispatch_off_cpu: inner.dispatch_off_cpu.snapshot(),
+            completion_wall: inner.completion_wall.snapshot(),
+            completion_cpu: inner.completion_cpu.snapshot(),
+            completion_off_cpu: inner.completion_off_cpu.snapshot(),
+        }
+    }
+
+    pub(crate) fn api_started(&self) {
+        self.inner.api_calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn enqueued(&self, started: Instant) {
+        self.inner.enqueued.fetch_add(1, Ordering::Relaxed);
+        self.inner.enqueue_wait.record(started.elapsed());
+        increment_gauge(
+            &self.inner.top_level_queue_depth,
+            &self.inner.max_top_level_queue_depth,
+        );
+    }
+
+    pub(crate) fn driver_received(&self, enqueued_at: Instant) {
+        self.inner.driver_received.fetch_add(1, Ordering::Relaxed);
+        self.inner.cluster_queue_wait.record(enqueued_at.elapsed());
+        decrement_gauge(&self.inner.top_level_queue_depth);
+    }
+
+    pub(crate) fn pending_added(&self) {
+        increment_gauge(&self.inner.pending_depth, &self.inner.max_pending_depth);
+    }
+
+    pub(crate) fn pending_removed(&self) {
+        decrement_gauge(&self.inner.pending_depth);
+    }
+
+    pub(crate) fn routing_completed(&self, started: Instant) {
+        self.inner.routed.fetch_add(1, Ordering::Relaxed);
+        self.inner.routing.record(started.elapsed());
+    }
+
+    pub(crate) fn node_enqueued(&self, started: Instant) {
+        self.inner.node_enqueued.fetch_add(1, Ordering::Relaxed);
+        self.inner.node_enqueue_wait.record(started.elapsed());
+    }
+
+    pub(crate) fn socket_buffered(&self, enqueued_at: Instant) {
+        self.inner.socket_buffered.fetch_add(1, Ordering::Relaxed);
+        self.inner.node_queue_wait.record(enqueued_at.elapsed());
+    }
+
+    pub(crate) fn socket_flushed(&self, started: Instant) {
+        self.inner.socket_flushes.fetch_add(1, Ordering::Relaxed);
+        self.inner.socket_flush.record(started.elapsed());
+    }
+
+    pub(crate) fn response_received(&self) {
+        self.inner
+            .responses_received
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn driver_completed(&self) {
+        self.inner.driver_completed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn caller_delivered(&self, started: Instant) {
+        self.inner.caller_delivered.fetch_add(1, Ordering::Relaxed);
+        self.inner.request_total.record(started.elapsed());
+    }
+
+    pub(crate) fn cancelled_before_dispatch(&self) {
+        self.inner
+            .cancelled_before_dispatch
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn cancelled_in_flight(&self) {
+        self.inner
+            .cancelled_in_flight
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn refresh_started(&self) -> Instant {
+        self.inner.refresh_started.fetch_add(1, Ordering::Relaxed);
+        Instant::now()
+    }
+
+    pub(crate) fn refresh_finished(&self, started: Instant, success: bool) {
+        let counter = if success {
+            &self.inner.refresh_completed
+        } else {
+            &self.inner.refresh_failed
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        self.inner.refresh.record(started.elapsed());
+    }
+
+    pub(crate) fn reconnect_started(&self) -> Instant {
+        self.inner.reconnect_started.fetch_add(1, Ordering::Relaxed);
+        increment_gauge(
+            &self.inner.reconnect_active,
+            &self.inner.max_reconnect_active,
+        );
+        Instant::now()
+    }
+
+    pub(crate) fn reconnect_finished(&self, started: Instant, success: bool) {
+        let counter = if success {
+            &self.inner.reconnect_completed
+        } else {
+            &self.inner.reconnect_failed
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        decrement_gauge(&self.inner.reconnect_active);
+        self.inner.reconnect.record(started.elapsed());
+    }
+
+    pub(crate) fn reconnect_triggered(&self, claimed: bool) {
+        self.inner
+            .reconnect_triggers
+            .fetch_add(1, Ordering::Relaxed);
+        let counter = if claimed {
+            &self.inner.reconnect_claimed
+        } else {
+            &self.inner.reconnect_deduplicated
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn reconnect_install(&self, installed: bool) {
+        let counter = if installed {
+            &self.inner.reconnect_installed
+        } else {
+            &self.inner.reconnect_discarded
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn driver_poll(&self, received: usize) {
+        self.inner.driver_polls.fetch_add(1, Ordering::Relaxed);
+        update_max_usize(&self.inner.max_received_per_poll, received);
+    }
+
+    pub(crate) fn dispatch_batch(&self, count: usize, in_flight: usize) {
+        self.inner
+            .commands_dispatched
+            .fetch_add(count as u64, Ordering::Relaxed);
+        update_max_usize(&self.inner.max_dispatched_per_poll, count);
+        self.inner.in_flight.store(in_flight, Ordering::Relaxed);
+        update_max_usize(&self.inner.max_in_flight, in_flight);
+    }
+
+    pub(crate) fn completion_batch(&self, count: usize, in_flight: usize) {
+        self.inner
+            .completions_processed
+            .fetch_add(count as u64, Ordering::Relaxed);
+        update_max_usize(&self.inner.max_completions_per_poll, count);
+        self.inner.in_flight.store(in_flight, Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "cluster-async-profiling")]
+    pub(crate) fn top_channel_admission(&self, immediate: bool) {
+        let counter = if immediate {
+            &self.inner.top_channel_immediate
+        } else {
+            &self.inner.top_channel_full
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "cluster-async-profiling")]
+    pub(crate) fn node_channel_admission(&self, immediate: bool) {
+        let counter = if immediate {
+            &self.inner.node_channel_immediate
+        } else {
+            &self.inner.node_channel_full
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[cfg(all(
+        feature = "cluster-async-profiling",
+        not(feature = "cluster-async-atomic-node-connections")
+    ))]
+    pub(crate) fn connection_lock_acquired(&self, waited_since: Option<Instant>) {
+        match waited_since {
+            Some(started) => {
+                self.inner
+                    .connection_lock_contended
+                    .fetch_add(1, Ordering::Relaxed);
+                self.inner.connection_lock_wait.record(started.elapsed());
+            }
+            None => {
+                self.inner
+                    .connection_lock_immediate
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    #[cfg(feature = "cluster-async-profiling")]
+    pub(crate) fn profile(&self, phase: ProfilePhase) -> Option<ProfileGuard> {
+        let sequence = self.inner.profile_sequence.fetch_add(1, Ordering::Relaxed);
+        if sequence & PROFILE_SAMPLE_MASK != 0 {
+            return None;
+        }
+        Some(ProfileGuard {
+            diagnostics: self.clone(),
+            phase,
+            wall_started: Instant::now(),
+            cpu_started: thread_cpu_time(),
+        })
+    }
+
+    #[cfg(feature = "cluster-async-profiling")]
+    fn record_profile(&self, phase: ProfilePhase, wall: Duration, cpu: Option<Duration>) {
+        let (wall_timing, cpu_timing, off_cpu_timing) = match phase {
+            ProfilePhase::RoutingSync => {
+                self.inner.routing_sync_wall.record(wall);
+                if let Some(cpu) = cpu {
+                    self.inner.routing_sync_cpu.record(cpu);
+                }
+                return;
+            }
+            ProfilePhase::DriverPoll => (
+                &self.inner.driver_poll_wall,
+                &self.inner.driver_poll_cpu,
+                &self.inner.driver_poll_off_cpu,
+            ),
+            ProfilePhase::Dispatch => (
+                &self.inner.dispatch_wall,
+                &self.inner.dispatch_cpu,
+                &self.inner.dispatch_off_cpu,
+            ),
+            ProfilePhase::Completion => (
+                &self.inner.completion_wall,
+                &self.inner.completion_cpu,
+                &self.inner.completion_off_cpu,
+            ),
+        };
+        wall_timing.record(wall);
+        if let Some(cpu) = cpu {
+            cpu_timing.record(cpu);
+            off_cpu_timing.record(wall.saturating_sub(cpu));
+        }
+    }
+}
+
+#[cfg(all(feature = "cluster-async-profiling", target_os = "linux"))]
+fn thread_cpu_time() -> Option<Duration> {
+    let mut value = std::mem::MaybeUninit::<libc::timespec>::uninit();
+    // SAFETY: `clock_gettime` initializes the supplied `timespec` on success,
+    // and the pointer is valid for the duration of the call.
+    if unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, value.as_mut_ptr()) } != 0 {
+        return None;
+    }
+    // SAFETY: the return code above confirmed successful initialization.
+    let value = unsafe { value.assume_init() };
+    Some(Duration::new(value.tv_sec as u64, value.tv_nsec as u32))
+}
+
+#[cfg(all(feature = "cluster-async-profiling", not(target_os = "linux")))]
+fn thread_cpu_time() -> Option<Duration> {
+    None
+}
+
+fn load(value: &AtomicU64) -> u64 {
+    value.load(Ordering::Relaxed)
+}
+
+fn load_usize(value: &AtomicUsize) -> usize {
+    value.load(Ordering::Relaxed)
+}
+
+fn increment_gauge(value: &AtomicUsize, maximum: &AtomicUsize) {
+    let next = value.fetch_add(1, Ordering::Relaxed) + 1;
+    update_max_usize(maximum, next);
+}
+
+fn decrement_gauge(value: &AtomicUsize) {
+    let _ = value.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        Some(current.saturating_sub(1))
+    });
+}
+
+fn update_max_u64(maximum: &AtomicU64, candidate: u64) {
+    let _ = maximum.fetch_max(candidate, Ordering::Relaxed);
+}
+
+fn update_max_usize(maximum: &AtomicUsize, candidate: usize) {
+    let _ = maximum.fetch_max(candidate, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_tracks_counts_gauges_and_maxima() {
+        let diagnostics = ClusterDiagnostics::default();
+        diagnostics.api_started();
+        diagnostics.enqueued(Instant::now());
+        diagnostics.driver_received(Instant::now());
+        diagnostics.pending_removed();
+        diagnostics.dispatch_batch(3, 3);
+        diagnostics.completion_batch(2, 1);
+
+        let snapshot = diagnostics.snapshot();
+        assert_eq!(snapshot.api_calls, 1);
+        assert_eq!(snapshot.enqueued, 1);
+        assert_eq!(snapshot.driver_received, 1);
+        assert_eq!(snapshot.top_level_queue_depth, 0);
+        assert_eq!(snapshot.pending_depth, 0);
+        assert_eq!(snapshot.commands_dispatched, 3);
+        assert_eq!(snapshot.completions_processed, 2);
+        assert_eq!(snapshot.max_dispatched_per_poll, 3);
+        assert_eq!(snapshot.max_in_flight, 3);
+        assert_eq!(snapshot.in_flight, 1);
+    }
+}

--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -102,8 +102,13 @@ use std::{
     time::Duration,
 };
 
+use arc_swap::ArcSwap;
+mod connection_store;
+#[cfg(feature = "cluster-async-diagnostics")]
+mod diagnostics;
 mod request;
 mod routing;
+mod routing_table;
 use crate::{
     AsyncConnectionConfig, Cmd, ConnectionInfo, ErrorKind, IntoConnectionInfo, RedisError,
     RedisFuture, RedisResult, ToRedisArgs, Value,
@@ -118,17 +123,20 @@ use crate::{
             MultipleNodeRoutingInfo, Redirect, ResponsePolicy, RoutingInfo, SingleNodeRoutingInfo,
         },
         slot_cmd,
-        slot_map::{SlotMap, SlotRange},
+        slot_map::SlotRange,
         topology::parse_slots,
     },
     cmd,
     errors::closed_connection_error,
     subscription_tracker::SubscriptionTracker,
 };
+#[cfg(feature = "cluster-async-diagnostics")]
+pub use diagnostics::{ClusterDiagnostics, ClusterDiagnosticsSnapshot, ClusterTimingSnapshot};
 
 use crate::ProtocolVersion;
 #[cfg(feature = "cache-aio")]
 use crate::caching::{CacheManager, CacheStatistics};
+use connection_store::ConnectionStore;
 use futures_util::{
     future::{self, BoxFuture, FutureExt},
     ready,
@@ -136,16 +144,18 @@ use futures_util::{
     stream::{self, Stream, StreamExt},
 };
 use log::{debug, info, trace, warn};
-use rand::{rng, seq::IteratorRandom};
 use request::{CmdArg, PendingRequest, Request, RequestState, Retry};
 use routing::{InternalRoutingInfo, InternalSingleNodeRouting, route_for_pipeline};
-use tokio::sync::{RwLock, mpsc, oneshot};
+use routing_table::RoutingTable;
+use tokio::sync::{mpsc, oneshot};
 
 struct ClientSideState {
     protocol: ProtocolVersion,
     _task_handle: HandleContainer,
     overall_response_timeout: Option<Duration>,
     runtime: Runtime,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    diagnostics: ClusterDiagnostics,
     #[cfg(feature = "cache-aio")]
     cache_manager: Option<CacheManager>,
 }
@@ -187,11 +197,19 @@ where
         initial_nodes: &[ConnectionInfo],
         cluster_params: ClusterParams,
     ) -> (ClusterConnection<C>, oneshot::Receiver<RedisResult<()>>) {
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let mut cluster_params = cluster_params;
         let protocol = cluster_params.protocol.unwrap_or_default();
         let overall_response_timeout = cluster_params.overall_response_timeout;
         #[cfg(feature = "cache-aio")]
         let cache_manager = cluster_params.cache_manager.clone();
         let runtime = Runtime::locate();
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let diagnostics = ClusterDiagnostics::default();
+        #[cfg(feature = "cluster-async-diagnostics")]
+        {
+            cluster_params.diagnostics = diagnostics.clone();
+        }
         let mut inner = ClusterConnInner::new(initial_nodes, cluster_params);
 
         let (connect_sender, connect_receiver) = oneshot::channel::<RedisResult<()>>();
@@ -215,6 +233,8 @@ where
                     _task_handle,
                     overall_response_timeout,
                     runtime,
+                    #[cfg(feature = "cluster-async-diagnostics")]
+                    diagnostics,
                     #[cfg(feature = "cache-aio")]
                     cache_manager,
                 }),
@@ -226,8 +246,56 @@ where
     /// Send a command to the given `routing`, and aggregate the response according to `response_policy`.
     pub async fn route_command(&mut self, cmd: Cmd, routing: RoutingInfo) -> RedisResult<Value> {
         trace!("send_packed_command");
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let api_started = {
+            self.state.diagnostics.api_started();
+            std::time::Instant::now()
+        };
         let (sender, receiver) = oneshot::channel();
         let request = async {
+            #[cfg(feature = "cluster-async-diagnostics")]
+            {
+                let enqueue_started = std::time::Instant::now();
+                #[cfg(feature = "cluster-async-profiling")]
+                let permit = match self.sender.try_reserve() {
+                    Ok(permit) => {
+                        self.state.diagnostics.top_channel_admission(true);
+                        permit
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        self.state.diagnostics.top_channel_admission(false);
+                        self.sender.reserve().await.map_err(|_| {
+                            RedisError::from(io::Error::new(
+                                io::ErrorKind::BrokenPipe,
+                                "redis_cluster: Unable to send command",
+                            ))
+                        })?
+                    }
+                    Err(_) => {
+                        return Err(RedisError::from(io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "redis_cluster: Unable to send command",
+                        )));
+                    }
+                };
+                #[cfg(not(feature = "cluster-async-profiling"))]
+                let permit = self.sender.reserve().await.map_err(|_| {
+                    RedisError::from(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "redis_cluster: Unable to send command",
+                    ))
+                })?;
+                self.state.diagnostics.enqueued(enqueue_started);
+                permit.send(Message {
+                    cmd: CmdArg::Cmd {
+                        cmd: Arc::new(cmd),
+                        routing: routing.into(),
+                    },
+                    sender,
+                    enqueued_at: std::time::Instant::now(),
+                });
+            }
+            #[cfg(not(feature = "cluster-async-diagnostics"))]
             self.sender
                 .send(Message {
                     cmd: CmdArg::Cmd {
@@ -244,7 +312,7 @@ where
                     ))
                 })?;
 
-            receiver
+            let result = receiver
                 .await
                 .unwrap_or_else(|_| {
                     Err(RedisError::from(io::Error::new(
@@ -255,7 +323,10 @@ where
                 .map(|response| match response {
                     Response::Single(value) => value,
                     Response::Multiple(_) => unreachable!(),
-                })
+                });
+            #[cfg(feature = "cluster-async-diagnostics")]
+            self.state.diagnostics.caller_delivered(api_started);
+            result
         };
 
         match self.state.overall_response_timeout {
@@ -272,9 +343,51 @@ where
         count: usize,
         route: SingleNodeRoutingInfo,
     ) -> RedisResult<Vec<Value>> {
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let api_started = {
+            self.state.diagnostics.api_started();
+            std::time::Instant::now()
+        };
         let (sender, receiver) = oneshot::channel();
 
         let request = async {
+            #[cfg(feature = "cluster-async-diagnostics")]
+            {
+                let enqueue_started = std::time::Instant::now();
+                #[cfg(feature = "cluster-async-profiling")]
+                let permit = match self.sender.try_reserve() {
+                    Ok(permit) => {
+                        self.state.diagnostics.top_channel_admission(true);
+                        permit
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        self.state.diagnostics.top_channel_admission(false);
+                        self.sender
+                            .reserve()
+                            .await
+                            .map_err(|_| closed_connection_error())?
+                    }
+                    Err(_) => return Err(closed_connection_error()),
+                };
+                #[cfg(not(feature = "cluster-async-profiling"))]
+                let permit = self
+                    .sender
+                    .reserve()
+                    .await
+                    .map_err(|_| closed_connection_error())?;
+                self.state.diagnostics.enqueued(enqueue_started);
+                permit.send(Message {
+                    cmd: CmdArg::Pipeline {
+                        pipeline: Arc::new(pipeline),
+                        offset,
+                        count,
+                        route: route.into(),
+                    },
+                    sender,
+                    enqueued_at: std::time::Instant::now(),
+                });
+            }
+            #[cfg(not(feature = "cluster-async-diagnostics"))]
             self.sender
                 .send(Message {
                     cmd: CmdArg::Pipeline {
@@ -287,19 +400,29 @@ where
                 })
                 .await
                 .map_err(|_| closed_connection_error())?;
-            receiver
+            let result = receiver
                 .await
                 .unwrap_or_else(|_| Err(closed_connection_error()))
                 .map(|response| match response {
                     Response::Multiple(values) => values,
                     Response::Single(_) => unreachable!(),
-                })
+                });
+            #[cfg(feature = "cluster-async-diagnostics")]
+            self.state.diagnostics.caller_delivered(api_started);
+            result
         };
 
         match self.state.overall_response_timeout {
             Some(duration) => self.state.runtime.timeout(duration, request).await?,
             None => request.await,
         }
+    }
+
+    /// Returns aggregate queue, timing, cancellation, refresh, and reconnect diagnostics
+    /// for the shared cluster driver backing this handle.
+    #[cfg(feature = "cluster-async-diagnostics")]
+    pub fn diagnostics(&self) -> ClusterDiagnostics {
+        self.state.diagnostics.clone()
     }
 
     /// Subscribes to a new channel(s).
@@ -431,67 +554,12 @@ where
     }
 }
 
-type ConnectionMap<C> = HashMap<NodeAddress, ConnState<C>>;
-
-enum ConnState<C> {
-    // Connection has been successfully established at some point.
-    Connected(C),
-    // Connection is being repaired/reconnected. The old C is retained for faster reconnect.
-    Reconnecting(C),
-    // New connection that we are trying to connect to.
-    Connecting,
-}
-
-impl<C> ConnState<C> {
-    fn connected(&self) -> Option<C>
-    where
-        C: Clone,
-    {
-        match self {
-            ConnState::Connected(conn) => Some(conn.clone()),
-            ConnState::Reconnecting(_) | ConnState::Connecting => None,
-        }
-    }
-
-    // Get the underlying connection anyway whether it is being reconnected or not.
-    fn connected_or_reconnecting(&self) -> Option<C>
-    where
-        C: Clone,
-    {
-        match self {
-            ConnState::Connected(conn) | ConnState::Reconnecting(conn) => Some(conn.clone()),
-            ConnState::Connecting => None,
-        }
-    }
-
-    fn into_conn(self) -> Option<C> {
-        match self {
-            ConnState::Connected(conn) | ConnState::Reconnecting(conn) => Some(conn),
-            ConnState::Connecting => None,
-        }
-    }
-}
-
-fn mark_reconnecting<C>(connections: &mut ConnectionMap<C>, addr: NodeAddress) {
-    connections
-        .entry(addr.clone())
-        .and_modify(|state| {
-            *state = match std::mem::replace(state, ConnState::Connecting) {
-                ConnState::Connected(conn) => {
-                    warn!("ClusterConnInner: connection to {addr:?} lost; repairing in background");
-                    ConnState::Reconnecting(conn)
-                }
-                other => other,
-            };
-        })
-        .or_insert(ConnState::Connecting);
-}
-
 /// This is the internal representation of an async Redis Cluster connection. It stores the
 /// underlying connections maintained for each node in the cluster, as well
 /// as common parameters for connecting to nodes and executing commands.
 struct InnerCore<C> {
-    conn_lock: RwLock<(ConnectionMap<C>, SlotMap)>,
+    routing: ArcSwap<RoutingTable>,
+    connections: ConnectionStore<C>,
     cluster_params: ClusterParams,
     pending_requests_tx: mpsc::UnboundedSender<PendingRequest<C>>,
     initial_nodes: Vec<ConnectionInfo>,
@@ -521,8 +589,8 @@ where
         routing: &'a MultipleNodeRoutingInfo,
         response_policy: Option<ResponsePolicy>,
     ) -> OperationResult {
-        let read_guard = self.conn_lock.read().await;
-        if read_guard.0.is_empty() {
+        let snapshot = self.routing.load();
+        if snapshot.is_empty() {
             return (
                 OperationTarget::FanOut,
                 Result::Err(
@@ -534,71 +602,75 @@ where
                 ),
             );
         }
-        let (receivers, requests): (Vec<_>, Vec<_>) = {
-            let to_request = |(addr, cmd): (&NodeAddress, Arc<Cmd>)| {
-                read_guard
-                    .0
-                    .get(addr)
-                    // For a fan-out, we do not want to silently return a partial response
-                    // by skipping a shard because of a connection issue.
-                    // We are intentionally using a connection under repair (Reconnecting state).
-                    // It may or may not succeed. But the aggregate response will be honest.
-                    .and_then(ConnState::connected_or_reconnecting)
-                    .map(|conn| {
-                        let (sender, receiver) = oneshot::channel();
-                        let addr = addr.clone();
-                        (
-                            (addr.clone(), receiver),
-                            PendingRequest {
-                                retry: 0,
-                                sender: request::ResultExpectation::External(sender),
-                                cmd: CmdArg::Cmd {
-                                    cmd,
-                                    routing: InternalSingleNodeRouting::Connection {
-                                        identifier: addr,
-                                        conn,
-                                    }
-                                    .into(),
-                                },
-                            },
-                        )
+        let targets = match routing {
+            MultipleNodeRoutingInfo::AllNodes => snapshot
+                .topology_addresses(false)
+                .into_iter()
+                .map(|address| (address.clone(), cmd.clone()))
+                .collect::<Vec<_>>(),
+            MultipleNodeRoutingInfo::AllMasters => snapshot
+                .topology_addresses(true)
+                .into_iter()
+                .map(|address| (address.clone(), cmd.clone()))
+                .collect::<Vec<_>>(),
+            MultipleNodeRoutingInfo::MultiSlot((routes, _)) => snapshot
+                .addresses_for_multi_slot(routes, self.routing_strategy.as_deref())
+                .into_iter()
+                .enumerate()
+                .filter_map(|(index, address)| {
+                    address.map(|address| {
+                        let (_, indices) = routes.get(index).unwrap();
+                        let command =
+                            Arc::new(crate::cluster_routing::command_for_multi_slot_indices(
+                                cmd.as_ref(),
+                                indices.iter(),
+                            ));
+                        (address.clone(), command)
                     })
-            };
-            let slot_map = &read_guard.1;
-
-            // TODO - these filter_map calls mean that we ignore nodes that are missing. Should we report an error in such cases?
-            // since some of the operators drop other requests, mapping to errors here might mean that no request is sent.
-            match routing {
-                MultipleNodeRoutingInfo::AllNodes => slot_map
-                    .addresses_for_all_nodes()
-                    .into_iter()
-                    .filter_map(|addr| to_request((addr, cmd.clone())))
-                    .unzip(),
-                MultipleNodeRoutingInfo::AllMasters => slot_map
-                    .addresses_for_all_primaries()
-                    .into_iter()
-                    .filter_map(|addr| to_request((addr, cmd.clone())))
-                    .unzip(),
-                MultipleNodeRoutingInfo::MultiSlot((routes, _)) => slot_map
-                    .addresses_for_multi_slot(routes, self.routing_strategy.as_deref())
-                    .enumerate()
-                    .filter_map(|(index, addr_opt)| {
-                        addr_opt.and_then(|addr| {
-                            let (_, indices) = routes.get(index).unwrap();
-                            let cmd =
-                                Arc::new(crate::cluster_routing::command_for_multi_slot_indices(
-                                    cmd.as_ref(),
-                                    indices.iter(),
-                                ));
-                            to_request((addr, cmd))
-                        })
-                    })
-                    .unzip(),
-            }
+                })
+                .collect::<Vec<_>>(),
         };
-        drop(read_guard);
+        drop(snapshot);
+
+        let target_addresses = targets
+            .iter()
+            .map(|(address, _)| address.clone())
+            .collect::<Vec<_>>();
+        // A fan-out must not silently return a partial response. Retain the old
+        // connection while it is being repaired and let the aggregate report
+        // any actual per-shard failure.
+        let available = self
+            .connections
+            .connected_for_addresses(&target_addresses, true, &self.cluster_params)
+            .await
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        let (receivers, requests): (Vec<_>, Vec<_>) = targets
+            .into_iter()
+            .filter_map(|(address, cmd)| {
+                let conn = available.get(&address)?.clone();
+                let (sender, receiver) = oneshot::channel();
+                Some((
+                    (address.clone(), receiver),
+                    PendingRequest {
+                        retry: 0,
+                        sender: request::ResultExpectation::External(sender),
+                        #[cfg(feature = "cluster-async-diagnostics")]
+                        diagnostics: self.cluster_params.diagnostics.clone(),
+                        cmd: CmdArg::Cmd {
+                            cmd,
+                            routing: InternalSingleNodeRouting::Connection {
+                                identifier: address,
+                                conn,
+                            }
+                            .into(),
+                        },
+                    },
+                ))
+            })
+            .unzip();
         for request in requests {
-            let _ = self.pending_requests_tx.send(request);
+            self.send_pending(request);
         }
 
         (
@@ -752,16 +824,28 @@ where
         cmd: Arc<Cmd>,
         routing: InternalRoutingInfo<C>,
     ) -> OperationResult {
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let routing_started = std::time::Instant::now();
         let route = match routing {
             InternalRoutingInfo::SingleNode(single_node_routing) => single_node_routing,
             InternalRoutingInfo::MultiNode((multi_node_routing, response_policy)) => {
-                return self
+                let result = self
                     .execute_on_multiple_nodes(&cmd, &multi_node_routing, response_policy)
                     .await;
+                #[cfg(feature = "cluster-async-diagnostics")]
+                self.cluster_params
+                    .diagnostics
+                    .routing_completed(routing_started);
+                return result;
             }
         };
 
-        match self.get_connection(route).await {
+        let connection = self.get_connection(route).await;
+        #[cfg(feature = "cluster-async-diagnostics")]
+        self.cluster_params
+            .diagnostics
+            .routing_completed(routing_started);
+        match connection {
             Ok((addr, mut conn)) => (
                 addr.into(),
                 conn.req_packed_command(&cmd)
@@ -789,7 +873,14 @@ where
         count: usize,
         route: InternalSingleNodeRouting<C>,
     ) -> OperationResult {
-        match self.get_connection(route).await {
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let routing_started = std::time::Instant::now();
+        let connection = self.get_connection(route).await;
+        #[cfg(feature = "cluster-async-diagnostics")]
+        self.cluster_params
+            .diagnostics
+            .routing_completed(routing_started);
+        match connection {
             Ok((addr, mut conn)) => (
                 OperationTarget::Node { address: addr },
                 conn.req_packed_commands(&pipeline, offset, count)
@@ -846,14 +937,23 @@ where
         }
     }
 
+    fn send_pending(&self, request: PendingRequest<C>) {
+        #[cfg(feature = "cluster-async-diagnostics")]
+        request.diagnostics.pending_added();
+        let _ = self.pending_requests_tx.send(request);
+    }
+
     async fn get_connection(
         &self,
         route: InternalSingleNodeRouting<C>,
     ) -> RedisResult<(NodeAddress, C)> {
         let route = match route {
             InternalSingleNodeRouting::Random => {
-                let read_guard = self.conn_lock.read().await;
-                return match get_random_connection(&read_guard.0) {
+                return match self
+                    .connections
+                    .random_connected(&self.cluster_params)
+                    .await
+                {
                     Some((addr, conn)) => Ok((addr, conn)),
                     None => {
                         Err((ErrorKind::ClusterConnectionNotFound, "No connections found").into())
@@ -869,8 +969,11 @@ where
                 return self.get_redirected_connection(redirect).await;
             }
             InternalSingleNodeRouting::ByAddress(address) => {
-                let read_guard = self.conn_lock.read().await;
-                return match read_guard.0.get(&address).and_then(ConnState::connected) {
+                return match self
+                    .connections
+                    .connected(&address, &self.cluster_params)
+                    .await
+                {
                     Some(conn) => Ok((address, conn)),
                     None => Err((
                         ErrorKind::Client,
@@ -882,39 +985,49 @@ where
             }
         };
 
-        let read_guard = self.conn_lock.read().await;
-        let preferred = read_guard
-            .1
-            .slot_addr_for_route(&route, self.routing_strategy.as_deref())
-            .cloned();
+        #[cfg(feature = "cluster-async-profiling")]
+        let _routing_profile = self
+            .cluster_params
+            .diagnostics
+            .profile(diagnostics::ProfilePhase::RoutingSync);
 
-        if let Some(ref addr) = preferred
-            && let Some(conn) = read_guard.0.get(addr).and_then(ConnState::connected)
+        let snapshot = self.routing.load();
+        let preferred = snapshot
+            .preferred_address(&route, self.routing_strategy.as_deref())
+            .cloned();
+        let fallbacks = snapshot
+            .fallback_addresses(&route)
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        drop(snapshot);
+
+        if let Some(preferred) = preferred
+            && let Some(conn) = self
+                .connections
+                .connected(&preferred, &self.cluster_params)
+                .await
         {
-            return Ok((addr.clone(), conn));
+            return Ok((preferred, conn));
         }
 
         // The preferred node is not connected (e.g. it is being repaired by the `reconnect_loop` future).
         // Instead of erroring or waiting we try a fallback (within the same shard).
-        let fallback = read_guard
-            .1
-            .shard_fallback_addrs(&route)
-            .into_iter()
-            .find_map(|candidate| {
-                read_guard
-                    .0
-                    .get(&candidate)
-                    .and_then(ConnState::connected)
-                    .map(|conn| (candidate, conn))
-            });
-        drop(read_guard);
-        if let Some(found) = fallback {
-            return Ok(found);
+        for fallback in fallbacks {
+            if let Some(conn) = self
+                .connections
+                .connected(&fallback, &self.cluster_params)
+                .await
+            {
+                return Ok((fallback, conn));
+            }
         }
 
-        let read_guard = self.conn_lock.read().await;
-        if let Some((random_addr, random_conn)) = get_random_connection(&read_guard.0) {
-            drop(read_guard);
+        if let Some((random_addr, random_conn)) = self
+            .connections
+            .random_connected(&self.cluster_params)
+            .await
+        {
             return Ok((random_addr, random_conn));
         }
 
@@ -927,9 +1040,10 @@ where
             Redirect::Moved(addr) => addr,
             Redirect::Ask(addr) => addr,
         };
-        let read_guard = self.conn_lock.read().await;
-        let conn = read_guard.0.get(&addr).and_then(ConnState::connected);
-        drop(read_guard);
+        let conn = self
+            .connections
+            .connected(&addr, &self.cluster_params)
+            .await;
         let mut conn = match conn {
             Some(conn) => conn,
             None => self.connect_check_and_add(&addr).await?,
@@ -948,41 +1062,47 @@ where
 
     async fn connect_check_and_add(&self, addr: &NodeAddress) -> RedisResult<C> {
         let conn = connect_and_check::<C>(addr, &self.cluster_params).await?;
-        self.conn_lock
-            .write()
-            .await
-            .0
-            .insert(addr.clone(), ConnState::Connected(conn.clone()));
+        self.connections
+            .install_connected(addr.clone(), conn.clone(), &self.cluster_params)
+            .await;
         Ok(conn)
     }
 
-    async fn query_slots(conn: &mut C, addr: &NodeAddress, slots: &mut SlotMap) -> RedisResult<()> {
+    async fn query_slots(conn: &mut C, addr: &NodeAddress) -> RedisResult<Vec<SlotRange>> {
         let mut slot_refresh_cmd = slot_cmd();
         slot_refresh_cmd.skip_concurrency_limit = true;
         let value = conn
             .req_packed_command(&slot_refresh_cmd)
             .await
             .and_then(|value| value.extract_error())?;
-        let v: Vec<SlotRange> = parse_slots(value, addr.host())?;
-        build_slot_map(slots, v)
+        parse_slots(value, addr.host())
     }
 
     // Query a node to discover slot-> master mappings.
     async fn refresh_slots(self) -> RedisResult<()> {
-        let mut write_guard = self.conn_lock.write().await;
-        let (connections, slots) = &mut *write_guard;
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let diagnostics_started = self.cluster_params.diagnostics.refresh_started();
+        let previous_generation = self.routing.load().generation();
+        let known_connections = self
+            .connections
+            .known_connections(&self.cluster_params)
+            .await;
 
-        let mut found = false;
+        let mut discovered_slots = None;
         let mut last_err = None;
 
         // First pass is to query previously-known good connections for the new slots.
-        for (addr, state) in &mut *connections {
-            let ConnState::Connected(conn) = state else {
+        for (address, _) in &known_connections {
+            let Some(mut conn) = self
+                .connections
+                .connected(address, &self.cluster_params)
+                .await
+            else {
                 continue;
             };
-            match Self::query_slots(conn, addr, slots).await {
-                Ok(()) => {
-                    found = true;
+            match Self::query_slots(&mut conn, address).await {
+                Ok(slots) => {
+                    discovered_slots = Some(slots);
                     break;
                 }
                 Err(err) => last_err = Some(err),
@@ -992,16 +1112,17 @@ where
         // Second pass is to attempt to repair connections on-demand as we iterate through each one.
         // We include Connected connections in this pass, in addition to the first pass above,
         // so that we can do inline connection repairs, if needed (via `get_or_create_conn`).
-        if !found {
-            for (addr, state) in &mut *connections {
-                let prev = std::mem::replace(state, ConnState::Connecting).into_conn();
-                match get_or_create_conn(addr, prev, &self.cluster_params).await {
+        if discovered_slots.is_none() {
+            for (address, old_connection) in known_connections {
+                match get_or_create_conn(&address, old_connection, &self.cluster_params).await {
                     Ok(mut conn) => {
-                        let res = Self::query_slots(&mut conn, addr, slots).await;
-                        *state = ConnState::Connected(conn);
+                        let res = Self::query_slots(&mut conn, &address).await;
+                        self.connections
+                            .install_connected(address.clone(), conn, &self.cluster_params)
+                            .await;
                         match res {
-                            Ok(()) => {
-                                found = true;
+                            Ok(slots) => {
+                                discovered_slots = Some(slots);
                                 break;
                             }
                             Err(err) => last_err = Some(err),
@@ -1012,51 +1133,71 @@ where
             }
         }
 
-        if !found {
+        let Some(slots) = discovered_slots else {
+            #[cfg(feature = "cluster-async-diagnostics")]
+            self.cluster_params
+                .diagnostics
+                .refresh_finished(diagnostics_started, false);
             return Err(last_err.unwrap_or_else(|| {
                 (ErrorKind::ClusterConnectionNotFound, "No connections found").into()
             }));
+        };
+
+        let addresses = slots
+            .iter()
+            .flat_map(|slot| std::iter::once(&slot.master).chain(slot.replicas.iter()))
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        self.refresh_connections(&addresses).await;
+
+        let candidate = RoutingTable::from_slots(previous_generation.wrapping_add(1), slots)?;
+        let topology = self
+            .routing_strategy
+            .as_ref()
+            .map(|_| candidate.slot_map().topology());
+        self.routing.store(Arc::new(candidate));
+        self.connections
+            .retain(&addresses, &self.cluster_params)
+            .await;
+
+        if let (Some(strategy), Some(topology)) = (&self.routing_strategy, topology) {
+            strategy.on_topology_changed(topology);
         }
 
-        if let Some(ref strategy) = self.routing_strategy {
-            strategy.on_topology_changed(slots.topology());
-        }
-
-        let nodes = slots.values().flatten().cloned().collect::<HashSet<_>>();
-
-        connections.retain(|addr, _| nodes.contains(addr));
-
-        self.refresh_connections_locked(connections, nodes).await;
-
+        #[cfg(feature = "cluster-async-diagnostics")]
+        self.cluster_params
+            .diagnostics
+            .refresh_finished(diagnostics_started, true);
         Ok(())
     }
 
-    async fn refresh_connections_locked(
-        &self,
-        connections: &mut ConnectionMap<C>,
-        nodes: HashSet<NodeAddress>,
-    ) {
-        let nodes_len = nodes.len();
-        let addresses_and_connections_iter = nodes
-            .into_iter()
-            .map(|addr| {
-                let connection = connections.remove(&addr).and_then(ConnState::into_conn);
-                async move {
-                    let res = get_or_create_conn(&addr, connection, &self.cluster_params).await;
-                    (addr, res)
-                }
-            })
-            .collect::<Vec<_>>();
+    async fn refresh_connections(&self, addresses: &HashSet<NodeAddress>) {
+        let mut connection_futures = Vec::with_capacity(addresses.len());
+        for address in addresses {
+            let address = address.clone();
+            let old_connection = self
+                .connections
+                .connection_for_repair(&address, &self.cluster_params)
+                .await;
+            connection_futures.push(async move {
+                let result =
+                    get_or_create_conn(&address, old_connection, &self.cluster_params).await;
+                (address, result)
+            });
+        }
 
-        stream::iter(addresses_and_connections_iter)
-            .buffer_unordered(nodes_len.max(8))
-            .fold(connections, |connections, (addr, result)| async move {
-                if let Ok(conn) = result {
-                    connections.insert(addr, ConnState::Connected(conn));
-                }
-                connections
-            })
+        let results = stream::iter(connection_futures)
+            .buffer_unordered(addresses.len().max(8))
+            .collect::<Vec<_>>()
             .await;
+        for (address, result) in results {
+            if let Ok(connection) = result {
+                self.connections
+                    .install_connected(address, connection, &self.cluster_params)
+                    .await;
+            }
+        }
     }
 
     fn resubscribe(&self) {
@@ -1077,6 +1218,8 @@ where
             PendingRequest {
                 retry: 0,
                 sender: request::ResultExpectation::Internal,
+                #[cfg(feature = "cluster-async-diagnostics")]
+                diagnostics: self.cluster_params.diagnostics.clone(),
                 cmd: CmdArg::Cmd {
                     cmd: Arc::new(cmd),
                     routing,
@@ -1084,7 +1227,7 @@ where
             }
         });
         for request in requests {
-            let _ = self.pending_requests_tx.send(request);
+            self.send_pending(request);
         }
     }
 }
@@ -1097,69 +1240,77 @@ struct ClusterConnInner<C> {
     state: ConnectionState,
     #[allow(clippy::complexity)]
     in_flight_requests: stream::FuturesUnordered<Pin<Box<Request<C>>>>,
-    reconnect_futures: stream::FuturesUnordered<BoxFuture<'static, ()>>,
+    reconnect_futures: stream::FuturesUnordered<BoxFuture<'static, (NodeAddress, bool)>>,
+    reconnect_pending: HashSet<NodeAddress>,
     pending_requests_rx: mpsc::UnboundedReceiver<PendingRequest<C>>,
     refresh_error: Option<RedisError>,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    received_since_poll: usize,
 }
 
-// Keep trying to repair `addr` until it is re-connected, or the node
+// Keep trying to repair `node` until it is re-connected, or the node
 // has left the topology.
 // This is a continuous attempt to reconnect rather than one-shot.
-async fn reconnect_loop<C>(core: Core<C>, addr: NodeAddress)
+async fn reconnect_loop<C>(core: Core<C>, addr: NodeAddress) -> (NodeAddress, bool)
 where
     C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
 {
+    if !core
+        .connections
+        .begin_reconnect(addr.clone(), &core.cluster_params)
+        .await
     {
-        let mut guard = core.conn_lock.write().await;
-        if matches!(
-            guard.0.get(&addr),
-            Some(ConnState::Reconnecting(_) | ConnState::Connecting)
-        ) {
-            return;
-        }
-        mark_reconnecting(&mut guard.0, addr.clone());
+        return (addr, false);
     }
+    warn!("ClusterConnInner: connection to {addr:?} lost; repairing in background");
 
     let mut backoff = Duration::from_millis(50);
     loop {
-        let prev = {
-            let guard = core.conn_lock.read().await;
-            let in_topology = guard.1.addresses_for_all_nodes().contains(&addr);
-            let entry = guard.0.get(&addr);
-            if matches!(entry, Some(ConnState::Connected(_))) {
-                break;
-            }
-            let prev_conn = entry.and_then(ConnState::connected_or_reconnecting);
-            drop(guard);
+        let snapshot = core.routing.load();
+        let in_topology = snapshot.contains_topology_address(&addr);
+        drop(snapshot);
+        if !in_topology {
+            core.connections.remove(&addr, &core.cluster_params).await;
+            return (addr, false);
+        }
+        if core
+            .connections
+            .is_connected(&addr, &core.cluster_params)
+            .await
+        {
+            return (addr, false);
+        }
+        let previous_connection = core
+            .connections
+            .connection_for_repair(&addr, &core.cluster_params)
+            .await;
 
-            if !in_topology {
-                core.conn_lock.write().await.0.remove(&addr);
-                break;
-            }
-            prev_conn
-        };
-
-        match get_or_create_conn(&addr, prev, &core.cluster_params).await {
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let reconnect_started = core.cluster_params.diagnostics.reconnect_started();
+        match get_or_create_conn(&addr, previous_connection, &core.cluster_params).await {
             Ok(conn) => {
-                let newly_installed = {
-                    let mut guard = core.conn_lock.write().await;
-                    if matches!(guard.0.get(&addr), Some(ConnState::Connected(_))) {
-                        false
-                    } else {
-                        guard.0.insert(addr.clone(), ConnState::Connected(conn));
-                        true
-                    }
-                };
+                let newly_installed = core
+                    .connections
+                    .install_repaired(addr.clone(), conn, &core.cluster_params)
+                    .await;
+                #[cfg(feature = "cluster-async-diagnostics")]
+                core.cluster_params
+                    .diagnostics
+                    .reconnect_install(newly_installed);
                 if newly_installed {
                     info!("ClusterConnInner: reconnected to {addr:?}");
-                    // TODO: make the resubscribe semantic more granular.
-                    // Right now resubscribe() re-sends every subscription across all nodes.
-                    // We should re-subscribe for the newly repaired node.
-                    core.resubscribe();
                 }
-                break;
+                #[cfg(feature = "cluster-async-diagnostics")]
+                core.cluster_params
+                    .diagnostics
+                    .reconnect_finished(reconnect_started, true);
+                return (addr, newly_installed);
             }
             Err(err) => {
+                #[cfg(feature = "cluster-async-diagnostics")]
+                core.cluster_params
+                    .diagnostics
+                    .reconnect_finished(reconnect_started, false);
                 debug!("repair_node: failed to reconnect {addr:?}: {err:?}");
             }
         }
@@ -1195,6 +1346,8 @@ impl From<NodeAddress> for OperationTarget {
 struct Message<C> {
     cmd: CmdArg<C>,
     sender: oneshot::Sender<RedisResult<Response>>,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    enqueued_at: std::time::Instant,
 }
 
 enum RecoverFuture {
@@ -1220,13 +1373,6 @@ impl fmt::Debug for ConnectionState {
     }
 }
 
-fn build_slot_map(slot_map: &mut SlotMap, slots_data: Vec<SlotRange>) -> RedisResult<()> {
-    slot_map.clear();
-    slot_map.fill_slots(slots_data);
-    trace!("{slot_map:?}");
-    Ok(())
-}
-
 impl<C> ClusterConnInner<C>
 where
     C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
@@ -1245,7 +1391,8 @@ where
 
         let (pending_requests_tx, pending_requests_rx) = mpsc::unbounded_channel();
         let inner = Arc::new(InnerCore {
-            conn_lock: RwLock::new((Default::default(), SlotMap::new())),
+            routing: ArcSwap::from_pointee(RoutingTable::empty(0)),
+            connections: ConnectionStore::new(),
             cluster_params,
             pending_requests_tx,
             initial_nodes: initial_nodes.to_vec(),
@@ -1257,8 +1404,11 @@ where
             inner: core.clone(),
             in_flight_requests: Default::default(),
             reconnect_futures: Default::default(),
+            reconnect_pending: Default::default(),
             pending_requests_rx,
             refresh_error: None,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            received_since_poll: 0,
             state: ConnectionState::PollComplete,
         };
         inner.state = ConnectionState::Recover(RecoverFuture::ReconnectInitial(Box::pin(
@@ -1270,7 +1420,7 @@ where
     async fn create_initial_connections(
         initial_nodes: &[ConnectionInfo],
         params: &ClusterParams,
-    ) -> RedisResult<ConnectionMap<C>> {
+    ) -> RedisResult<HashMap<NodeAddress, C>> {
         let (connections, error) = stream::iter(initial_nodes.iter().cloned())
             .map(async move |info| {
                 let addr = NodeAddress::try_from(&info.addr)?;
@@ -1285,11 +1435,11 @@ where
             })
             .buffer_unordered(initial_nodes.len())
             .fold(
-                (ConnectionMap::<C>::with_capacity(initial_nodes.len()), None),
+                (HashMap::with_capacity(initial_nodes.len()), None),
                 |(mut connections, mut error), result| async move {
                     match result {
                         Ok((addr, conn)) => {
-                            connections.insert(addr, ConnState::Connected(conn));
+                            connections.insert(addr, conn);
                         }
                         Err(err) => {
                             // Store at least one error to use as detail in the connection error if
@@ -1322,10 +1472,13 @@ where
         debug!("Received request to reconnect to initial nodes");
         let inner = self.inner.clone();
         async move {
-            let connection_map =
+            let initial_connections =
                 Self::create_initial_connections(&inner.initial_nodes, &inner.cluster_params)
                     .await?;
-            *inner.conn_lock.write().await = (connection_map, SlotMap::new());
+            inner
+                .connections
+                .replace_connected(initial_connections, &inner.cluster_params)
+                .await;
             inner.refresh_slots().await?;
             Ok(())
         }
@@ -1334,17 +1487,17 @@ where
     // Create reconnecting futures and register them into `reconnect_futures`
     // so we can poll them at the next poll_flush iteration.
     fn register_reconnect_futures(&mut self, addrs: HashSet<NodeAddress>) {
-        // This is best-effort, non-blocking, opportunistic check to see
-        // if there is already a repair in progress.
-        // This is not load-bearing since the real dedupe logic lives inside reconnect_loop.
-        let opportunistic_read_guard = self.inner.conn_lock.try_read().ok();
         for addr in addrs {
-            if let Some(guard) = &opportunistic_read_guard
-                && matches!(
-                    guard.0.get(&addr),
-                    Some(ConnState::Reconnecting(_) | ConnState::Connecting)
-                )
-            {
+            // Deduplicate before queueing. This prevents a stale queued future from
+            // starting a second repair after the first has already restored the node,
+            // independently of which connection-state backend is under test.
+            let claimed = self.reconnect_pending.insert(addr.clone());
+            #[cfg(feature = "cluster-async-diagnostics")]
+            self.inner
+                .cluster_params
+                .diagnostics
+                .reconnect_triggered(claimed);
+            if !claimed {
                 continue;
             }
             self.reconnect_futures
@@ -1353,7 +1506,21 @@ where
     }
 
     fn poll_reconnects(&mut self, cx: &mut task::Context<'_>) {
-        while let Poll::Ready(Some(())) = Pin::new(&mut self.reconnect_futures).poll_next(cx) {}
+        let topology_recovery_in_progress = matches!(self.state, ConnectionState::Recover(_));
+        let mut repaired_any = false;
+        while let Poll::Ready(Some((address, repaired))) =
+            Pin::new(&mut self.reconnect_futures).poll_next(cx)
+        {
+            self.reconnect_pending.remove(&address);
+            repaired_any |= repaired;
+        }
+
+        // A topology recovery reconnects every node and replays subscriptions when
+        // it completes. Suppress per-node replay while that recovery is active so
+        // parallel, off-lock repairs cannot enqueue duplicate subscription pushes.
+        if repaired_any && !topology_recovery_in_progress {
+            self.inner.resubscribe();
+        }
     }
 
     async fn wait_for_initial_connection(&mut self) -> RedisResult<()> {
@@ -1404,7 +1571,7 @@ where
     fn handle_retries(&mut self, request_handling: Option<Retry<C>>) {
         match request_handling {
             Some(Retry::MoveToPending { request }) => {
-                let _ = self.inner.pending_requests_tx.send(request);
+                self.inner.send_pending(request);
             }
             Some(Retry::Immediately { request }) => {
                 let future = self.inner.clone().try_request(request.cmd.clone());
@@ -1434,6 +1601,14 @@ where
     }
 
     fn dispatch_pending(&mut self) {
+        #[cfg(feature = "cluster-async-profiling")]
+        let _dispatch_profile = self
+            .inner
+            .cluster_params
+            .diagnostics
+            .profile(diagnostics::ProfilePhase::Dispatch);
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let mut dispatched = 0usize;
         loop {
             let request = match self.pending_requests_rx.try_recv() {
                 Ok(request) => request,
@@ -1441,24 +1616,51 @@ where
                 | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => break,
             };
 
-            // Drop the request if no-one is waiting for a response to free up resources for
-            // requests callers care about (load shedding). It will be ambiguous whether the
-            // request actually goes through regardless.
-            if request.sender.is_closed() {
-                continue;
+            #[cfg(feature = "cluster-async-diagnostics")]
+            request.diagnostics.pending_removed();
+            if self.dispatch_request(request) {
+                #[cfg(feature = "cluster-async-diagnostics")]
+                {
+                    dispatched += 1;
+                }
             }
-
-            let future = self.inner.clone().try_request(request.cmd.clone()).boxed();
-            self.in_flight_requests.push(Box::pin(Request {
-                retry_params: self.inner.cluster_params.retry_params.clone(),
-                request: Some(request),
-                future: RequestState::Future { future },
-            }));
         }
+        #[cfg(feature = "cluster-async-diagnostics")]
+        self.inner
+            .cluster_params
+            .diagnostics
+            .dispatch_batch(dispatched, self.in_flight_requests.len());
+    }
+
+    fn dispatch_request(&mut self, request: PendingRequest<C>) -> bool {
+        // Drop the request if no-one is waiting for a response to free up resources for
+        // requests callers care about (load shedding). It will be ambiguous whether the
+        // request actually goes through regardless.
+        if request.sender.is_closed() {
+            #[cfg(feature = "cluster-async-diagnostics")]
+            request.diagnostics.cancelled_before_dispatch();
+            return false;
+        }
+
+        let future = self.inner.clone().try_request(request.cmd.clone()).boxed();
+        self.in_flight_requests.push(Box::pin(Request {
+            retry_params: self.inner.cluster_params.retry_params.clone(),
+            request: Some(request),
+            future: RequestState::Future { future },
+        }));
+        true
     }
 
     fn poll_in_flight(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
+        #[cfg(feature = "cluster-async-profiling")]
+        let _completion_profile = self
+            .inner
+            .cluster_params
+            .diagnostics
+            .profile(diagnostics::ProfilePhase::Completion);
         let mut poll_flush_action = PollFlushAction::None;
+        #[cfg(feature = "cluster-async-diagnostics")]
+        let mut completed = 0usize;
 
         loop {
             let (request_handling, next) =
@@ -1469,7 +1671,17 @@ where
 
             self.handle_retries(request_handling);
             poll_flush_action = poll_flush_action.change_state(next);
+            #[cfg(feature = "cluster-async-diagnostics")]
+            {
+                completed += 1;
+            }
         }
+
+        #[cfg(feature = "cluster-async-diagnostics")]
+        self.inner
+            .cluster_params
+            .diagnostics
+            .completion_batch(completed, self.in_flight_requests.len());
 
         if !matches!(poll_flush_action, PollFlushAction::None) || self.in_flight_requests.is_empty()
         {
@@ -1578,13 +1790,30 @@ where
 
     fn start_send(self: Pin<&mut Self>, msg: Message<C>) -> Result<(), Self::Error> {
         trace!("start_send");
-        let Message { cmd, sender } = msg;
+        let Message {
+            cmd,
+            sender,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            enqueued_at,
+        } = msg;
+        let this = self.get_mut();
+        #[cfg(feature = "cluster-async-diagnostics")]
+        {
+            this.inner
+                .cluster_params
+                .diagnostics
+                .driver_received(enqueued_at);
+            this.received_since_poll += 1;
+        }
 
-        let _ = self.inner.pending_requests_tx.send(PendingRequest {
+        let request = PendingRequest {
             retry: 0,
             sender: request::ResultExpectation::External(sender),
+            #[cfg(feature = "cluster-async-diagnostics")]
+            diagnostics: this.inner.cluster_params.diagnostics.clone(),
             cmd,
-        });
+        };
+        this.inner.send_pending(request);
         Ok(())
     }
 
@@ -1593,6 +1822,17 @@ where
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::Error>> {
         trace!("poll_flush: {:?}", self.state);
+        #[cfg(feature = "cluster-async-profiling")]
+        let _driver_poll_profile = self
+            .inner
+            .cluster_params
+            .diagnostics
+            .profile(diagnostics::ProfilePhase::DriverPoll);
+        #[cfg(feature = "cluster-async-diagnostics")]
+        {
+            let received = std::mem::take(&mut self.received_since_poll);
+            self.inner.cluster_params.diagnostics.driver_poll(received);
+        }
         loop {
             self.send_refresh_error();
             self.poll_reconnects(cx);
@@ -1728,6 +1968,10 @@ where
     if let Some(boundary) = params.write_backpressure_boundary {
         config = config.set_write_backpressure_boundary(boundary);
     }
+    #[cfg(feature = "cluster-async-diagnostics")]
+    {
+        config = config.set_cluster_diagnostics(params.diagnostics.clone());
+    }
     let mut conn = match C::connect_with_config(info, config).await {
         Ok(conn) => conn,
         Err(err) => {
@@ -1754,14 +1998,4 @@ where
         .await
         .and_then(|v| v.extract_error())?;
     Ok(())
-}
-
-fn get_random_connection<C>(connections: &ConnectionMap<C>) -> Option<(NodeAddress, C)>
-where
-    C: Clone,
-{
-    connections
-        .iter()
-        .filter_map(|(addr, state)| state.connected().map(|conn| (addr.clone(), conn)))
-        .choose(&mut rng())
 }

--- a/redis/src/cluster_handling/async_connection/request.rs
+++ b/redis/src/cluster_handling/async_connection/request.rs
@@ -149,7 +149,17 @@ impl ResultExpectation {
 pub(super) struct PendingRequest<C> {
     pub(super) retry: u32,
     pub(super) sender: ResultExpectation,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    pub(super) diagnostics: super::ClusterDiagnostics,
     pub(super) cmd: CmdArg<C>,
+}
+
+impl<C> PendingRequest<C> {
+    fn send(self, result: RedisResult<super::Response>) {
+        #[cfg(feature = "cluster-async-diagnostics")]
+        self.diagnostics.driver_completed();
+        self.sender.send(result);
+    }
 }
 
 pin_project! {
@@ -182,7 +192,7 @@ pub(crate) fn choose_response<C>(
                 error
             } else {
                 trace!("Ok");
-                request.sender.send(Ok(item));
+                request.send(Ok(item));
                 return (None, PollFlushAction::None);
             }
         }
@@ -196,7 +206,7 @@ pub(crate) fn choose_response<C>(
             if has_retries_remaining {
                 Some($retry_func(request))
             } else {
-                let _ = request.sender.send(Err(err));
+                request.send(Err(err));
                 None
             }
         };
@@ -225,7 +235,7 @@ pub(crate) fn choose_response<C>(
 
         (OperationTarget::FanOut, _) => {
             // Fanout operation are retried per internal request, and don't need additional retries.
-            request.sender.send(Err(err));
+            request.send(Err(err));
             (None, PollFlushAction::None)
         }
         (OperationTarget::NotFound, _) => {
@@ -284,7 +294,7 @@ pub(crate) fn choose_response<C>(
         ),
 
         (_, RetryMethod::NoRetry) => {
-            request.sender.send(Err(err));
+            request.send(Err(err));
             (None, PollFlushAction::None)
         }
 
@@ -301,6 +311,10 @@ impl<C> Future for Request<C> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let mut this = self.as_mut().project();
         if this.request.is_none() || this.request.as_ref().unwrap().sender.is_closed() {
+            #[cfg(feature = "cluster-async-diagnostics")]
+            if let Some(request) = this.request.as_ref() {
+                request.diagnostics.cancelled_in_flight();
+            }
             return Poll::Ready((None, PollFlushAction::None));
         };
 
@@ -370,6 +384,8 @@ mod tests {
             PendingRequest::<usize> {
                 retry,
                 sender: ResultExpectation::External(sender),
+                #[cfg(feature = "cluster-async-diagnostics")]
+                diagnostics: crate::cluster_async::ClusterDiagnostics::default(),
                 cmd: super::CmdArg::Cmd {
                     cmd: Arc::new(crate::cmd("foo")),
                     routing: routing::InternalSingleNodeRouting::Random.into(),

--- a/redis/src/cluster_handling/async_connection/routing_table.rs
+++ b/redis/src/cluster_handling/async_connection/routing_table.rs
@@ -1,0 +1,236 @@
+use std::{collections::HashSet, sync::Arc};
+
+use crate::{
+    ErrorKind, RedisError, RedisResult,
+    cluster_handling::{
+        NodeAddress,
+        read_routing::{ReadCandidates, ReadRoutingStrategy, Replicas},
+        slot_map::{SLOT_SIZE, SlotMap, SlotRange},
+    },
+    cluster_routing::{Route, SlotAddr},
+};
+
+const UNASSIGNED_ROUTE: u16 = u16::MAX;
+
+struct SlotRoute {
+    primary: NodeAddress,
+    replicas: Arc<[NodeAddress]>,
+}
+
+impl SlotRoute {
+    fn address_for_route(
+        &self,
+        slot: u16,
+        slot_addr: SlotAddr,
+        strategy: Option<&dyn ReadRoutingStrategy>,
+    ) -> Option<&NodeAddress> {
+        let selected =
+            match strategy {
+                None => match slot_addr {
+                    SlotAddr::Master | SlotAddr::ReplicaOptional => return Some(&self.primary),
+                    SlotAddr::ReplicaRequired => {
+                        return match Replicas::new(&self.replicas) {
+                            Some(replicas) => Some(replicas.choose_random()),
+                            None => Some(&self.primary),
+                        };
+                    }
+                },
+                Some(strategy) => match Replicas::new(&self.replicas) {
+                    Some(replicas) => match slot_addr {
+                        SlotAddr::Master => return Some(&self.primary),
+                        SlotAddr::ReplicaOptional => strategy
+                            .route_read(&ReadCandidates::any_node(slot, &self.primary, replicas)),
+                        SlotAddr::ReplicaRequired => {
+                            strategy.route_read(&ReadCandidates::replicas_only(slot, replicas))
+                        }
+                    },
+                    None => return Some(&self.primary),
+                },
+            };
+
+        self.replicas
+            .iter()
+            .find(|address| *address == selected)
+            .or_else(|| (&self.primary == selected).then_some(&self.primary))
+    }
+
+    fn fallback_addresses(&self, slot_addr: SlotAddr) -> Vec<&NodeAddress> {
+        match slot_addr {
+            SlotAddr::Master => Vec::new(),
+            SlotAddr::ReplicaOptional => self
+                .replicas
+                .iter()
+                .chain(std::iter::once(&self.primary))
+                .collect(),
+            SlotAddr::ReplicaRequired => self.replicas.iter().collect(),
+        }
+    }
+}
+
+/// Immutable slot-to-address topology. Connection state deliberately remains
+/// in the original locked map so this variant isolates dense lookup and atomic
+/// topology publication from the `NodeHandle` reconnect experiment.
+pub(super) struct RoutingTable {
+    generation: u64,
+    slot_to_route: Arc<[u16]>,
+    routes: Arc<[SlotRoute]>,
+    topology_addresses: Arc<HashSet<NodeAddress>>,
+    slot_map: Arc<SlotMap>,
+}
+
+impl RoutingTable {
+    pub(super) fn empty(generation: u64) -> Self {
+        Self {
+            generation,
+            slot_to_route: vec![UNASSIGNED_ROUTE; SLOT_SIZE as usize].into(),
+            routes: Vec::new().into(),
+            topology_addresses: Arc::new(HashSet::new()),
+            slot_map: Arc::new(SlotMap::new()),
+        }
+    }
+
+    pub(super) fn from_slots(generation: u64, slots: Vec<SlotRange>) -> RedisResult<Self> {
+        let mut slot_to_route = vec![UNASSIGNED_ROUTE; SLOT_SIZE as usize];
+        let mut routes = Vec::with_capacity(slots.len());
+        let mut topology_addresses = HashSet::new();
+
+        for slot_range in &slots {
+            if slot_range.start > slot_range.end || slot_range.start >= SLOT_SIZE {
+                return Err(RedisError::from((
+                    ErrorKind::Client,
+                    "Cluster topology contains an invalid slot range",
+                )));
+            }
+
+            topology_addresses.insert(slot_range.master.clone());
+            topology_addresses.extend(slot_range.replicas.iter().cloned());
+            let route_index = if routes.len() < UNASSIGNED_ROUTE as usize {
+                routes.len() as u16
+            } else {
+                return Err(RedisError::from((
+                    ErrorKind::Client,
+                    "Cluster topology contains too many slot ranges",
+                )));
+            };
+            let last_slot = slot_range.end.min(SLOT_SIZE - 1);
+            for slot in slot_range.start..=last_slot {
+                slot_to_route[slot as usize] = route_index;
+            }
+            routes.push(SlotRoute {
+                primary: slot_range.master.clone(),
+                replicas: slot_range.replicas.clone().into(),
+            });
+        }
+
+        Ok(Self {
+            generation,
+            slot_to_route: slot_to_route.into(),
+            routes: routes.into(),
+            topology_addresses: Arc::new(topology_addresses),
+            slot_map: Arc::new(SlotMap::from_slots(slots)),
+        })
+    }
+
+    pub(super) fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.topology_addresses.is_empty()
+    }
+
+    fn route(&self, slot: u16) -> Option<&SlotRoute> {
+        let route = *self.slot_to_route.get(slot as usize)?;
+        (route != UNASSIGNED_ROUTE)
+            .then(|| self.routes.get(route as usize))
+            .flatten()
+    }
+
+    pub(super) fn preferred_address(
+        &self,
+        route: &Route,
+        strategy: Option<&dyn ReadRoutingStrategy>,
+    ) -> Option<&NodeAddress> {
+        self.route(route.slot())?
+            .address_for_route(route.slot(), route.slot_addr(), strategy)
+    }
+
+    pub(super) fn fallback_addresses(&self, route: &Route) -> Vec<&NodeAddress> {
+        self.route(route.slot())
+            .map(|slot_route| slot_route.fallback_addresses(route.slot_addr()))
+            .unwrap_or_default()
+    }
+
+    pub(super) fn topology_addresses(&self, only_primaries: bool) -> Vec<&NodeAddress> {
+        if only_primaries {
+            self.slot_map
+                .addresses_for_all_primaries()
+                .into_iter()
+                .collect()
+        } else {
+            self.slot_map
+                .addresses_for_all_nodes()
+                .into_iter()
+                .collect()
+        }
+    }
+
+    pub(super) fn addresses_for_multi_slot<'a>(
+        &'a self,
+        routes: &'a [(Route, Vec<usize>)],
+        strategy: Option<&dyn ReadRoutingStrategy>,
+    ) -> Vec<Option<&'a NodeAddress>> {
+        routes
+            .iter()
+            .map(|(route, _)| self.preferred_address(route, strategy))
+            .collect()
+    }
+
+    pub(super) fn contains_topology_address(&self, address: &NodeAddress) -> bool {
+        self.topology_addresses.contains(address)
+    }
+
+    pub(super) fn slot_map(&self) -> &SlotMap {
+        &self.slot_map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster_routing::Slot;
+
+    fn addr(value: &str) -> NodeAddress {
+        NodeAddress::try_from(value).unwrap()
+    }
+
+    fn route(slot: u16) -> Route {
+        Route::with_slot(Slot::new(slot).unwrap(), SlotAddr::Master)
+    }
+
+    #[test]
+    fn dense_lookup_covers_boundaries_and_holes() {
+        let table = RoutingTable::from_slots(
+            1,
+            vec![
+                SlotRange::new(0, 100, addr("node1:6379"), vec![]),
+                SlotRange::new(102, 200, addr("node2:6379"), vec![]),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            table.preferred_address(&route(0), None),
+            Some(&addr("node1:6379"))
+        );
+        assert_eq!(
+            table.preferred_address(&route(100), None),
+            Some(&addr("node1:6379"))
+        );
+        assert!(table.preferred_address(&route(101), None).is_none());
+        assert_eq!(
+            table.preferred_address(&route(102), None),
+            Some(&addr("node2:6379"))
+        );
+    }
+}

--- a/redis/src/cluster_handling/client.rs
+++ b/redis/src/cluster_handling/client.rs
@@ -34,6 +34,8 @@ use crate::connection::TlsConnParams;
 
 #[cfg(feature = "cluster-async")]
 use crate::cluster_async;
+#[cfg(feature = "cluster-async-diagnostics")]
+use crate::cluster_async::ClusterDiagnostics;
 
 #[cfg(feature = "tls-rustls")]
 use crate::tls::{TlsCertificates, retrieve_tls_certificates};
@@ -159,6 +161,8 @@ pub(crate) struct ClusterParams {
     pub(crate) connection_concurrency_limit: Option<usize>,
     #[cfg(feature = "cluster-async")]
     pub(crate) write_backpressure_boundary: Option<usize>,
+    #[cfg(feature = "cluster-async-diagnostics")]
+    pub(crate) diagnostics: ClusterDiagnostics,
 }
 
 impl ClusterParams {
@@ -225,6 +229,8 @@ impl ClusterParams {
             connection_concurrency_limit: value.connection_concurrency_limit,
             #[cfg(feature = "cluster-async")]
             write_backpressure_boundary: value.write_backpressure_boundary,
+            #[cfg(feature = "cluster-async-diagnostics")]
+            diagnostics: ClusterDiagnostics::default(),
         })
     }
 

--- a/redis/src/cluster_handling/slot_map.rs
+++ b/redis/src/cluster_handling/slot_map.rs
@@ -27,14 +27,6 @@ impl SlotMap {
         Self { slots: map }
     }
 
-    #[cfg(feature = "cluster-async")]
-    pub fn fill_slots(&mut self, slots: Vec<SlotRange>) {
-        for slot in slots {
-            self.slots
-                .insert(slot.start, slot.end, SlotAddrs::from_slot(slot));
-        }
-    }
-
     pub fn slot_addr_for_route(
         &self,
         route: &Route,
@@ -44,28 +36,6 @@ impl SlotMap {
         self.slots
             .get(slot)
             .map(|addrs| addrs.slot_addr(slot, &route.slot_addr(), strategy))
-    }
-
-    // TODO - Include the routing strategy in the fallback logic too.
-    #[cfg(feature = "cluster-async")]
-    pub(crate) fn shard_fallback_addrs(&self, route: &Route) -> Vec<NodeAddress> {
-        let Some(addrs) = self.slots.get(route.slot()) else {
-            return Vec::new();
-        };
-        match route.slot_addr() {
-            SlotAddr::Master => vec![],
-            SlotAddr::ReplicaOptional => {
-                let mut candidates = addrs.replicas.clone();
-                candidates.push(addrs.primary.clone());
-                candidates
-            }
-            SlotAddr::ReplicaRequired => addrs.replicas.clone(),
-        }
-    }
-
-    #[cfg(feature = "cluster-async")]
-    pub fn clear(&mut self) {
-        self.slots.clear();
     }
 
     pub fn values(&self) -> impl Iterator<Item = &SlotAddrs> {
@@ -356,64 +326,6 @@ mod tests {
                 .unwrap(),
             "replica1:6379"
         );
-    }
-
-    #[cfg(feature = "cluster-async")]
-    #[test]
-    fn test_shard_fallback_addrs_master_is_empty() {
-        let slot_map = get_slot_map();
-        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
-            Slot::new(1500).unwrap(),
-            SlotAddr::Master,
-        ));
-        assert!(fallback.is_empty());
-    }
-
-    #[cfg(feature = "cluster-async")]
-    #[test]
-    fn test_shard_fallback_addrs_replica_optional() {
-        let slot_map = get_slot_map();
-        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
-            Slot::new(1500).unwrap(),
-            SlotAddr::ReplicaOptional,
-        ));
-        assert_eq!(
-            fallback,
-            vec![
-                addr("replica2:6379"),
-                addr("replica3:6379"),
-                addr("node2:6379")
-            ]
-        );
-    }
-
-    #[cfg(feature = "cluster-async")]
-    #[test]
-    fn test_shard_fallback_addrs_replica_requiredy() {
-        let slot_map = get_slot_map();
-        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
-            Slot::new(2500).unwrap(),
-            SlotAddr::ReplicaRequired,
-        ));
-        assert_eq!(
-            fallback,
-            vec![
-                addr("replica4:6379"),
-                addr("replica5:6379"),
-                addr("replica6:6379")
-            ]
-        );
-    }
-
-    #[cfg(feature = "cluster-async")]
-    #[test]
-    fn test_shard_fallback_addrs_missing_slot_is_empty() {
-        let slot_map = get_slot_map();
-        let fallback = slot_map.shard_fallback_addrs(&Route::with_slot(
-            Slot::new(1001).unwrap(),
-            SlotAddr::ReplicaOptional,
-        ));
-        assert!(fallback.is_empty());
     }
 
     fn get_slot_map() -> SlotMap {

--- a/redis/src/cluster_handling/slot_range_map.rs
+++ b/redis/src/cluster_handling/slot_range_map.rs
@@ -37,11 +37,6 @@ impl<V> SlotRangeMap<V> {
     pub fn iter(&self) -> impl Iterator<Item = (u16, u16, &V)> {
         self.inner.iter().map(|(&end, (start, v))| (*start, end, v))
     }
-
-    #[cfg(feature = "cluster-async")]
-    pub fn clear(&mut self) {
-        self.inner.clear();
-    }
 }
 
 impl<V> Default for SlotRangeMap<V> {


### PR DESCRIPTION
## Summary

- publish a complete immutable async Cluster routing snapshot through `ArcSwap`
- replace range lookup on the command path with a dense 16,384-slot O(1) table
- separate routing state from connection state and share reconnect single-flight behavior
- add opt-in Cluster diagnostics/profiling for queueing, routing, completion, refresh, and reconnect behavior
- add an experimental feature-gated `NodeHandle` connection-state backend

## Why

In a fanout-heavy Redis Cluster workload, the client crossed a sharp queueing knee and exceeded a 17 ms application deadline more frequently through the OSS Cluster API than through a proxy endpoint. The original hypotheses were slot lookup and connection-map contention.

Profiling did not find connection-lock contention: the routing-only backend recorded zero contended acquisitions across 18 million commands. Slot routing used roughly one microsecond of thread CPU. The dominant tail came from queue residence, boxed request futures, channel/oneshot coordination, driver polling, task wakeups, and occasional executor descheduling across hundreds of in-flight command legs.

The immutable dense routing table is still useful independently: it increased median closed-loop successful capacity by 7.2% without increasing CPU or socket count. The `NodeHandle` backend produced a smaller incremental result and is intentionally kept experimental.

## Behavior and compatibility

- `cluster-async` now uses `arc-swap` for the routing snapshot.
- Aggregate diagnostics are disabled unless `cluster-async-diagnostics` is enabled.
- Sampled Linux CPU/wall profiling is disabled unless `cluster-async-profiling` is enabled.
- Stable atomic connection handles are disabled unless `cluster-async-atomic-node-connections` is enabled.
- Diagnostics expose a pull-based snapshot API and do not emit OpenTelemetry or other telemetry directly.
- Replica-required routing without an explicit strategy preserves the existing random-replica behavior.

## Benchmark results

- Production-shaped control: 2.412 million requests, zero timeouts and zero Redis errors.
- Fixed 50K requests/s with four Tokio workers: dense routing reduced deadline misses 16.8%; the `NodeHandle` variant reduced them 30.1% versus baseline.
- Closed-loop with four workers: dense routing increased median successful capacity 7.2%; `NodeHandle` added only 0.4% beyond dense routing.
- Fixed 50K requests/s with eight workers: zero timeouts and zero errors across nine million requests for baseline and both candidates, confirming executor/driver headroom as the primary cause of the tail.
- TLS connection-kill runs recovered with reconnect single-flight and no Redis errors; broader MOVED, reshard, replica, cancellation, and failure testing is still recommended before enabling `NodeHandle` by default.

## Validation

- `cargo fmt --all -- --check`
- Clippy with `-D warnings` for routing-only and `NodeHandle` profiling feature combinations
- async Cluster integration suite: 80/80 passed for both connection-state backends
- focused routing-table unit tests passed for both feature combinations
- GCP benchmark matrix against Redis Enterprise 8.0.6-54 with matched TLS Cluster API and proxy databases

This is opened as a draft because the dense routing optimization, diagnostics API, and experimental connection backend may be easier to review or land as separate follow-up changes.
