### PR TITLE
RedisTest: Mark all types as non exhaustive.

### DIFF
--- a/redis-test/src/cluster.rs
+++ b/redis-test/src/cluster.rs
@@ -10,21 +10,21 @@ use crate::{
 
 /// Configuration for creating a Redis Cluster.
 pub struct RedisClusterConfiguration {
-    pub num_nodes: u16,
-    pub num_replicas: u16,
-    pub modules: Vec<Module>,
-    pub tls_insecure: bool,
-    pub mtls_enabled: bool,
-    pub ports: Vec<u16>,
-    pub certs_with_ip_alts: bool,
+    num_nodes: u16,
+    num_replicas: u16,
+    modules: Vec<Module>,
+    require_secure_tls: bool,
+    mtls_enabled: bool,
+    ports: Vec<u16>,
+    certs_with_ip_alts: bool,
     /// Number of logical databases each node should expose (`--cluster-databases`).
     ///
     /// `None` leaves the server default (`1`, i.e. only database `0`). Setting a
     /// value greater than `1` requires a server that supports numbered databases
     /// in cluster mode (Valkey 9.0+); older servers fail to start with this flag.
-    pub cluster_databases: Option<u16>,
+    cluster_databases: Option<u16>,
     /// Custom DNS hostname for TLS certificate SAN (used when `certs_with_ip_alts` is false).
-    pub dns_hostname: Option<String>,
+    dns_hostname: Option<String>,
 }
 
 impl RedisClusterConfiguration {
@@ -35,6 +35,67 @@ impl RedisClusterConfiguration {
             ..Default::default()
         }
     }
+
+    /// Set the number of nodes in the cluster.
+    pub fn num_nodes(mut self, num_nodes: u16) -> Self {
+        self.num_nodes = num_nodes;
+        self
+    }
+
+    /// Set the number of replicas per primary.
+    pub fn num_replicas(mut self, num_replicas: u16) -> Self {
+        self.num_replicas = num_replicas;
+        self
+    }
+
+    /// Set the modules to load into each server.
+    pub fn modules(mut self, modules: Vec<Module>) -> Self {
+        self.modules = modules;
+        self
+    }
+
+    /// Allow TLS connections to accept invalid certificates.
+    pub fn insecure_tls(mut self) -> Self {
+        self.require_secure_tls = false;
+        self
+    }
+
+    /// Set the cluster to enable mutual TLS (client certificate authentication).
+    pub fn mtls_enabled(mut self) -> Self {
+        self.mtls_enabled = true;
+        self
+    }
+
+    /// Set the explicit ports to use for the cluster nodes.
+    pub fn ports(mut self, ports: Vec<u16>) -> Self {
+        self.ports = ports;
+        self
+    }
+
+    /// Set the generated certificates to not include IP subject-alternative names.
+    pub fn certs_without_ip_alts(mut self) -> Self {
+        self.certs_with_ip_alts = false;
+        self
+    }
+
+    /// Set whether the generated certificates include IP subject-alternative names.
+    pub fn cluster_databases(mut self, cluster_databases: u16) -> Self {
+        self.cluster_databases = Some(cluster_databases);
+        self
+    }
+
+    pub fn dns_hostname(mut self, hostname: &str) -> Self {
+        self.dns_hostname = Some(hostname.to_string());
+        self
+    }
+
+    pub fn get_require_secure_tls(&self) -> bool {
+        self.require_secure_tls
+    }
+
+    pub fn get_mtls_enabled(&self) -> bool {
+        self.mtls_enabled
+    }
 }
 
 impl Default for RedisClusterConfiguration {
@@ -43,7 +104,7 @@ impl Default for RedisClusterConfiguration {
             num_nodes: 3,
             num_replicas: 0,
             modules: vec![],
-            tls_insecure: true,
+            require_secure_tls: true,
             mtls_enabled: false,
             ports: vec![],
             certs_with_ip_alts: true,
@@ -119,6 +180,7 @@ fn port_in_use(addr: &str) -> bool {
 /// let client = redis::cluster::ClusterClient::new(addresses).unwrap();
 /// let mut connection = client.get_connection().unwrap();
 /// ```
+#[non_exhaustive]
 pub struct RedisCluster {
     pub servers: Vec<RedisServer>,
     pub folders: Vec<TempDir>,
@@ -139,7 +201,7 @@ impl RedisCluster {
             num_nodes: nodes,
             num_replicas: replicas,
             modules,
-            tls_insecure,
+            require_secure_tls,
             mtls_enabled,
             ports,
             certs_with_ip_alts,
@@ -307,7 +369,7 @@ impl RedisCluster {
                     cmd.arg(ca_crt);
                     cmd.arg("--tls");
                 }
-            } else if !tls_insecure && tls_paths.is_some() {
+            } else if !require_secure_tls && tls_paths.is_some() {
                 let ca_crt = &tls_paths.as_ref().unwrap().ca_crt;
                 cmd.arg("--tls").arg("--cacert").arg(ca_crt);
             } else {

--- a/redis-test/src/sentinel.rs
+++ b/redis-test/src/sentinel.rs
@@ -25,6 +25,7 @@ use crate::{
 /// let mut sentinel_client = redis::sentinel::SentinelClient::build(sentinel_addresses, String::from("master0"), None, redis::sentinel::SentinelServerType::Master).unwrap();
 /// let mut connection = sentinel_client.get_connection().unwrap();
 /// ```
+#[non_exhaustive]
 pub struct RedisSentinelCluster {
     pub servers: Vec<RedisServer>,
     pub sentinel_servers: Vec<RedisServer>,

--- a/redis-test/src/server.rs
+++ b/redis-test/src/server.rs
@@ -169,6 +169,7 @@ impl RedisServerBuilder {
 /// let info = server.connection_info();
 /// // Connect to the server using `info`...
 /// ```
+#[non_exhaustive]
 pub struct RedisServer {
     pub process: process::Child,
     pub tempdir: tempfile::TempDir,

--- a/redis-test/src/utils.rs
+++ b/redis-test/src/utils.rs
@@ -6,6 +6,7 @@ use socket2::{Domain, Socket, Type};
 use tempfile::TempDir;
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct TlsFilePaths {
     pub redis_crt: PathBuf,
     pub redis_key: PathBuf,
@@ -14,6 +15,7 @@ pub struct TlsFilePaths {
 
 /// Client certificate and key paths for mTLS authentication
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ClientCertPaths {
     pub client_crt: PathBuf,
     pub client_key: PathBuf,

--- a/redis/tests/support/cluster.rs
+++ b/redis/tests/support/cluster.rs
@@ -32,30 +32,23 @@ pub struct TestClusterContext {
 
 impl TestClusterContext {
     pub fn new() -> TestClusterContext {
-        Self::new_with_config(RedisClusterConfiguration {
-            tls_insecure: false,
-            ..Default::default()
-        })
+        Self::new_with_config(RedisClusterConfiguration::default().insecure_tls())
     }
 
     pub fn new_with_mtls() -> TestClusterContext {
         Self::new_with_config_and_builder(
-            RedisClusterConfiguration {
-                mtls_enabled: true,
-                tls_insecure: false,
-                ..Default::default()
-            },
+            RedisClusterConfiguration::default()
+                .mtls_enabled()
+                .insecure_tls(),
             identity,
         )
     }
 
     pub fn new_without_ip_alts() -> TestClusterContext {
         Self::new_with_config_and_builder(
-            RedisClusterConfiguration {
-                tls_insecure: false,
-                certs_with_ip_alts: false,
-                ..Default::default()
-            },
+            RedisClusterConfiguration::default()
+                .insecure_tls()
+                .certs_without_ip_alts(),
             identity,
         )
     }
@@ -69,10 +62,7 @@ impl TestClusterContext {
         F: FnOnce(redis::cluster::ClusterClientBuilder) -> redis::cluster::ClusterClientBuilder,
     {
         Self::new_with_config_and_builder(
-            RedisClusterConfiguration {
-                tls_insecure: false,
-                ..Default::default()
-            },
+            RedisClusterConfiguration::default().insecure_tls(),
             initializer,
         )
     }
@@ -93,8 +83,8 @@ impl TestClusterContext {
     {
         start_tls_crypto_provider();
         #[cfg(feature = "tls-rustls")]
-        let tls_insecure = cluster_config.tls_insecure;
-        let mtls_enabled = cluster_config.mtls_enabled;
+        let secure_tls = cluster_config.get_require_secure_tls();
+        let mtls_enabled = cluster_config.get_mtls_enabled();
         let cluster = RedisCluster::new(cluster_config);
         let initial_nodes: Vec<ConnectionInfo> = cluster
             .iter_servers()
@@ -104,7 +94,7 @@ impl TestClusterContext {
             .use_protocol(use_protocol());
 
         #[cfg(feature = "tls-rustls")]
-        if (mtls_enabled || (ClusterType::get_intended() == ClusterType::TcpTls && !tls_insecure))
+        if (mtls_enabled || (ClusterType::get_intended() == ClusterType::TcpTls && !secure_tls))
             && let Some(tls_file_paths) = &cluster.tls_paths
         {
             builder = builder.certs(load_certs_from_file(tls_file_paths));

--- a/redis/tests/test_cluster.rs
+++ b/redis/tests/test_cluster.rs
@@ -4,6 +4,8 @@ mod support;
 
 #[cfg(test)]
 mod cluster {
+    #[cfg(feature = "tls-rustls")]
+    use redis_test::cluster::ClusterType;
     use std::collections::HashMap;
     use std::sync::{
         Arc,
@@ -55,11 +57,9 @@ mod cluster {
         run_test_if_version_supported!(VALKEY_9_0);
 
         let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration {
-                cluster_databases: Some(16),
-                tls_insecure: false,
-                ..Default::default()
-            },
+            RedisClusterConfiguration::default()
+                .cluster_databases(16)
+                .insecure_tls(),
             |builder| builder.database_id(4),
         );
 
@@ -106,37 +106,31 @@ mod cluster {
     #[cfg(feature = "tls-rustls")]
     #[test]
     fn test_default_reject_invalid_hostnames() {
-        use redis_test::cluster::ClusterType;
-
         if ClusterType::get_intended() != ClusterType::TcpTls {
             // Only TLS causes invalid certificates to be rejected as desired.
             return;
         }
 
-        let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
-            tls_insecure: false,
-            certs_with_ip_alts: false,
-            ..Default::default()
-        });
+        let cluster = TestClusterContext::new_with_config(
+            RedisClusterConfiguration::default()
+                .insecure_tls()
+                .certs_without_ip_alts(),
+        );
         assert!(cluster.client.get_connection().is_err());
     }
 
     #[cfg(feature = "tls-rustls-insecure")]
     #[test]
     fn test_danger_accept_invalid_hostnames() {
-        use redis_test::cluster::ClusterType;
-
         if ClusterType::get_intended() != ClusterType::TcpTls {
             // No point testing this TLS-specific mode in non-TLS configurations.
             return;
         }
 
         let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration {
-                tls_insecure: false,
-                certs_with_ip_alts: false,
-                ..Default::default()
-            },
+            RedisClusterConfiguration::default()
+                .insecure_tls()
+                .certs_without_ip_alts(),
             |builder| builder.danger_accept_invalid_hostnames(true),
         );
 
@@ -1111,10 +1105,7 @@ mod cluster {
         // TODO - this should be a NoConnectionError, but ATM we get the errors from the failing
         assert_matches!(result, Err(_));
 
-        let _cluster = RedisCluster::new(RedisClusterConfiguration {
-            ports,
-            ..Default::default()
-        });
+        let _cluster = RedisCluster::new(RedisClusterConfiguration::default().ports(ports));
 
         let result = connection
             .route_command(&cmd, RoutingInfo::SingleNode(SingleNodeRoutingInfo::Random))
@@ -1134,10 +1125,8 @@ mod cluster {
         drop(cluster);
 
         // recreate cluster
-        let _cluster: RedisCluster = RedisCluster::new(RedisClusterConfiguration {
-            ports,
-            ..Default::default()
-        });
+        let _cluster: RedisCluster =
+            RedisCluster::new(RedisClusterConfiguration::default().ports(ports));
 
         let cmd = cmd("PING");
         // explicitly route to all primaries and request all succeeded
@@ -1280,20 +1269,18 @@ mod cluster {
     #[cfg(feature = "tls-rustls")]
     #[test]
     fn test_cluster_node_address_map_fixes_tls_hostname_mismatch() {
-        use redis_test::cluster::ClusterType;
-
         if ClusterType::get_intended() != ClusterType::TcpTls {
             return;
         }
 
         // Certs issued for "localhost" only (no IP SAN), so connecting via
         // 127.0.0.1 will fail TLS verification without node_address_map.
-        let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
-            tls_insecure: false,
-            certs_with_ip_alts: false,
-            dns_hostname: Some("localhost".to_string()),
-            ..Default::default()
-        });
+        let cluster = TestClusterContext::new_with_config(
+            RedisClusterConfiguration::default()
+                .insecure_tls()
+                .certs_without_ip_alts()
+                .dns_hostname("localhost"),
+        );
 
         let err = match cluster.client.get_connection() {
             Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -4,6 +4,8 @@ mod support;
 
 #[cfg(test)]
 mod cluster_async {
+    #[cfg(feature = "tls-rustls")]
+    use redis_test::cluster::ClusterType;
     use std::{
         collections::HashMap,
         sync::{
@@ -68,11 +70,9 @@ mod cluster_async {
         run_test_if_version_supported!(VALKEY_9_0);
 
         let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration {
-                cluster_databases: Some(16),
-                tls_insecure: false,
-                ..Default::default()
-            },
+            RedisClusterConfiguration::default()
+                .cluster_databases(16)
+                .insecure_tls(),
             |builder| builder.database_id(4),
         );
 
@@ -294,11 +294,11 @@ mod cluster_async {
 
     #[async_test]
     async fn test_async_cluster_route_info_to_nodes() {
-        let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
-            num_nodes: 6,
-            num_replicas: 1,
-            ..Default::default()
-        });
+        let cluster = TestClusterContext::new_with_config(
+            RedisClusterConfiguration::default()
+                .num_nodes(6)
+                .num_replicas(1),
+        );
 
         let split_to_addresses_and_info = |res| -> (Vec<String>, Vec<String>) {
             if let Value::Map(values) = res {
@@ -474,18 +474,16 @@ mod cluster_async {
     #[cfg(feature = "tls-rustls")]
     #[async_test]
     async fn test_async_cluster_default_reject_invalid_hostnames() {
-        use redis_test::cluster::ClusterType;
-
         if ClusterType::get_intended() != ClusterType::TcpTls {
             // Only TLS causes invalid certificates to be rejected as desired.
             return;
         }
 
-        let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
-            tls_insecure: false,
-            certs_with_ip_alts: false,
-            ..Default::default()
-        });
+        let cluster = TestClusterContext::new_with_config(
+            RedisClusterConfiguration::default()
+                .insecure_tls()
+                .certs_without_ip_alts(),
+        );
 
         assert!(cluster.client.get_async_connection().await.is_err());
     }
@@ -493,19 +491,15 @@ mod cluster_async {
     #[cfg(feature = "tls-rustls-insecure")]
     #[async_test]
     async fn test_async_cluster_danger_accept_invalid_hostnames() {
-        use redis_test::cluster::ClusterType;
-
         if ClusterType::get_intended() != ClusterType::TcpTls {
             // No point testing this TLS-specific mode in non-TLS configurations.
             return;
         }
 
         let cluster = TestClusterContext::new_with_config_and_builder(
-            RedisClusterConfiguration {
-                tls_insecure: false,
-                certs_with_ip_alts: false,
-                ..Default::default()
-            },
+            RedisClusterConfiguration::default()
+                .insecure_tls()
+                .certs_without_ip_alts(),
             |builder| builder.danger_accept_invalid_hostnames(true),
         );
 
@@ -516,20 +510,18 @@ mod cluster_async {
     #[cfg(feature = "tls-rustls")]
     #[async_test]
     async fn async_cluster_node_address_map_fixes_tls_hostname_mismatch() {
-        use redis_test::cluster::ClusterType;
-
         if ClusterType::get_intended() != ClusterType::TcpTls {
             return;
         }
 
         // Certs issued for "localhost" only (no IP SAN), so connecting via
         // 127.0.0.1 will fail TLS verification without node_address_map.
-        let cluster = TestClusterContext::new_with_config(RedisClusterConfiguration {
-            tls_insecure: false,
-            certs_with_ip_alts: false,
-            dns_hostname: Some("localhost".to_string()),
-            ..Default::default()
-        });
+        let cluster = TestClusterContext::new_with_config(
+            RedisClusterConfiguration::default()
+                .insecure_tls()
+                .certs_without_ip_alts()
+                .dns_hostname("localhost"),
+        );
 
         let err = match cluster.client.get_async_connection().await {
             Ok(_) => panic!("connecting via IP address should fail TLS hostname verification"),
@@ -2480,10 +2472,7 @@ mod cluster_async {
         // TODO - this should be a NoConnectionError, but ATM we get the errors from the failing
         assert_matches!(result, Err(_));
 
-        let _cluster = RedisCluster::new(RedisClusterConfiguration {
-            ports: ports.clone(),
-            ..Default::default()
-        });
+        let _cluster = RedisCluster::new(RedisClusterConfiguration::default().ports(ports.clone()));
 
         let result = connection.req_packed_command(&cmd).await.unwrap();
         assert_eq!(result, redis_value!(simple:"PONG"));
@@ -2501,10 +2490,7 @@ mod cluster_async {
         drop(cluster);
 
         // recreate cluster
-        let _cluster = RedisCluster::new(RedisClusterConfiguration {
-            ports: ports.clone(),
-            ..Default::default()
-        });
+        let _cluster = RedisCluster::new(RedisClusterConfiguration::default().ports(ports.clone()));
 
         // explicitly route to all primaries and request all succeeded
         let result = connection
@@ -3150,10 +3136,8 @@ mod cluster_async {
             }
 
             // recreate cluster
-            let _cluster = RedisCluster::new(RedisClusterConfiguration {
-                ports: ports.clone(),
-                ..Default::default()
-            });
+            let _cluster =
+                RedisCluster::new(RedisClusterConfiguration::default().ports(ports.clone()));
 
             // verify that we didn't get any disconnect notices.
             assert_eq!(
@@ -3240,10 +3224,8 @@ mod cluster_async {
             }
 
             // recreate cluster
-            let _cluster = RedisCluster::new(RedisClusterConfiguration {
-                ports: ports.clone(),
-                ..Default::default()
-            });
+            let _cluster =
+                RedisCluster::new(RedisClusterConfiguration::default().ports(ports.clone()));
 
             // verify that we didn't get any disconnect notices.
             assert_eq!(


### PR DESCRIPTION
Use a builder for the cluster's configuration, and all other types are marked with non_exhaustive.