### PR TITLE
pipeline: pre-allocate vector capacity in encode_pipeline function

### DIFF
--- a/redis/src/pipeline.rs
+++ b/redis/src/pipeline.rs
@@ -259,7 +259,9 @@ impl Pipeline {
 }
 
 fn encode_pipeline(cmds: &[Cmd], atomic: bool) -> Vec<u8> {
-    let mut rv = vec![];
+    let cmds_len: usize = cmds.iter().map(cmd_len).sum();
+    let extra = if atomic { 32 } else { 0 };
+    let mut rv = Vec::with_capacity(cmds_len + extra);
     write_pipeline(&mut rv, cmds, atomic);
     rv
 }


### PR DESCRIPTION
### Summary
This PR optimizes `encode_pipeline` in `redis/src/pipeline.rs` by pre-allocating the byte buffer capacity using the total sum of command lengths before serializing packed Redis pipeline requests.

### Rationale & Performance Benefit
Previously, `encode_pipeline` initialized an empty `vec![]` and deferred buffer reservation until inside `write_pipeline`.

Pre-allocating `Vec::with_capacity(cmds_len + extra)` upfront:
- Prevents initial buffer reallocation overhead during RESP command encoding.
- Reduces memory fragmentation and improves pipeline encoding throughput.