### PR TITLE
Fix cluster mass connection failure by escalating to blocking recovery

### DIFF
--- a/redis/src/cluster_handling/async_connection/mod.rs
+++ b/redis/src/cluster_handling/async_connection/mod.rs
@@ -1332,6 +1332,11 @@ struct Message<C> {
 enum RecoverFuture {
     RecoverSlots(BoxFuture<'static, RedisResult<()>>),
     ReconnectInitial(BoxFuture<'static, RedisResult<()>>),
+    /// Targeted blocking reconnection of specific nodes. Used when no
+    /// healthy connections remain and background repair would fail because
+    /// the retry loop would exhaust across stale nodes before any background
+    /// reconnect_loop is polled.
+    Reconnect(BoxFuture<'static, RedisResult<()>>),
 }
 
 enum ConnectionState {
@@ -1505,6 +1510,7 @@ where
             match fut {
                 RecoverFuture::RecoverSlots(fut) => fut.await?,
                 RecoverFuture::ReconnectInitial(fut) => fut.await?,
+                RecoverFuture::Reconnect(fut) => fut.await?,
             }
         }
         Ok(())
@@ -1536,6 +1542,20 @@ where
                     Err(err) => {
                         error!(
                             "async cluster client recovery: reconnect to initial nodes failed: `{err}`"
+                        );
+                    }
+                }
+                self.state = ConnectionState::PollComplete;
+                Ok(())
+            }
+            RecoverFuture::Reconnect(future) => {
+                match ready!(future.as_mut().poll(cx)) {
+                    Ok(()) => {
+                        info!("async cluster client recovery: targeted reconnection complete");
+                    }
+                    Err(err) => {
+                        error!(
+                            "async cluster client recovery: targeted reconnection failed: `{err}`"
                         );
                     }
                 }
@@ -1764,7 +1784,74 @@ where
                     )));
                 }
                 PollFlushAction::Reconnect(addrs) => {
-                    self.register_reconnect_futures(addrs);
+                    // Check whether there are healthy (Connected) nodes remaining
+                    // after accounting for the nodes that are about to be marked as
+                    // Reconnecting. If no healthy nodes will remain, the background
+                    // reconnect_loop approach fails because every retry in the retry
+                    // loop will hit another stale node, exhausting the retry budget
+                    // before any background repair task is polled. In that case we
+                    // escalate to blocking recovery.
+                    let should_block = self.inner.conn_lock.try_read().ok().is_some_and(|guard| {
+                        let total = guard.0.len();
+                        let healthy_count = guard.0.iter().filter(|(addr, state)| {
+                            matches!(state, ConnState::Connected(_)) && !addrs.contains(*addr)
+                        }).count();
+                        // Escalate to blocking recovery if no healthy nodes remain,
+                        // OR if less than half the cluster is healthy (indicating
+                        // widespread connection loss). The latter case prevents retry
+                        // exhaustion in large clusters where nodes > retries.
+                        total > 0 && healthy_count * 2 < total
+                    });
+
+                    if should_block {
+                        warn!(
+                            "async cluster client recovery: no healthy connections remain, \
+                             escalating to blocking reconnection for {} nodes",
+                            addrs.len()
+                        );
+                        let inner = self.inner.clone();
+                        self.state = ConnectionState::Recover(RecoverFuture::Reconnect(
+                            Box::pin(async move {
+                                // Gather ALL nodes that need reconnection (not just the
+                                // ones from this Reconnect action). This includes nodes
+                                // already marked Reconnecting by earlier iterations.
+                                let mut all_addrs = addrs;
+                                {
+                                    let guard = inner.conn_lock.read().await;
+                                    for (addr, state) in guard.0.iter() {
+                                        if !matches!(state, ConnState::Connected(_)) {
+                                            all_addrs.insert(addr.clone());
+                                        }
+                                    }
+                                }
+                                // Retry until at least one connection is established.
+                                let mut backoff = Duration::from_millis(10);
+                                loop {
+                                    {
+                                        let mut connections = inner.conn_lock.write().await;
+                                        inner
+                                            .refresh_connections_locked(
+                                                &mut connections.0,
+                                                all_addrs.clone(),
+                                            )
+                                            .await;
+                                        // Check if at least one node is now Connected
+                                        let any_connected = connections.0.values().any(|state| {
+                                            matches!(state, ConnState::Connected(_))
+                                        });
+                                        if any_connected {
+                                            break;
+                                        }
+                                    }
+                                    boxed_sleep(backoff).await;
+                                    backoff = (backoff * 2).min(Duration::from_secs(1));
+                                }
+                                Ok(())
+                            }),
+                        ));
+                    } else {
+                        self.register_reconnect_futures(addrs);
+                    }
                 }
                 PollFlushAction::ReconnectFromInitialConnections => {
                     warn!("async cluster client recovery: beginning reconnect to initial nodes");

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -3512,4 +3512,270 @@ mod cluster_async {
             check_unwatched(&mut con.clone()).await;
         }
     }
+
+    // ===================================================================
+    // Regression reproducer for redis-rs#2120 (merged in v1.4.0)
+    //
+    // PR #2120 changed cluster reconnection from blocking (synchronous) to
+    // background (asynchronous). This fixed head-of-line blocking when a
+    // SINGLE replica goes down (#2092), but introduced a regression: when
+    // ALL connections go stale simultaneously (e.g., after an idle timeout
+    // or network blip), retries exhaust before the background repair can
+    // complete, causing commands to fail with BrokenPipe.
+    //
+    // Production scenario (observed with clusters of hundreds of nodes):
+    //   1. All TCP connections go idle and are closed server-side
+    //   2. Next command hits a stale connection -> BrokenPipe
+    //   3. Background reconnect_loop spawns for that node
+    //   4. Retry picks another "Connected" node (still stale) -> BrokenPipe
+    //   5. Repeat until retries exhausted (default=16, but N < num_nodes)
+    //   6. Command fails, even though nodes would accept a fresh connection
+    //
+    // Before PR #2120: the cluster would BLOCK while creating a fresh
+    // connection (refresh_connections), the fresh connection succeeds, and
+    // the retry works. After PR #2120: the fresh connection is created in
+    // a background task that hasn't been polled yet when retries fire.
+    //
+    // The mock simulates this by:
+    //   - Tracking a "stale" flag and per-port reconnection counters
+    //   - First READONLY/PING per port fails (stale TCP socket -> BrokenPipe)
+    //   - Subsequent READONLY/PING succeeds (fresh TCP socket -> OK)
+    //   - Data commands succeed only AFTER a port has been "healed" (reconnected)
+    //   - In the old code, blocking refresh_connections creates a fresh connection
+    //     synchronously, heals the port, so the retry succeeds.
+    //   - In the new code, the background reconnect_loop would also heal the port,
+    //     but it hasn't been polled yet when the retry fires.
+    // ===================================================================
+
+    /// Reproducer: 2 nodes, retries=3. ALL connections go stale simultaneously.
+    /// Nodes are healthy (accept fresh connections) but old connections are dead.
+    ///
+    /// Pre-PR#2120: PASSES (blocking refresh_connections heals port before retry)
+    /// Post-PR#2120: FAILS (background repair not polled, retries hit stale ports)
+    #[test]
+    fn test_repro_all_connections_stale_retries_exhaust_before_recovery() {
+        let name = "test_repro_all_stale_2_nodes";
+
+        let stale_phase = Arc::new(AtomicBool::new(false));
+        let stale_phase_clone = stale_phase.clone();
+
+        // Track per-port connection check attempts (READONLY/PING calls).
+        //
+        // In the mock, reconnect_loop completes synchronously (no real I/O),
+        // so we must force it to FAIL on its first iteration so that it sleeps
+        // (yielding the executor). The sleep gives dispatch_pending a chance to
+        // fire the retry before the port is healed.
+        //
+        // Attempts 0 and 1: fail (stale socket PING + stale socket READONLY)
+        //   -> reconnect_loop's first get_or_create_conn fails, triggers backoff sleep
+        // Attempt 2+: succeed (fresh socket after sleep)
+        //   -> reconnect_loop's second iteration heals the port
+        //
+        // The key: between the first failure and the sleep wakeup, the retry
+        // fires and hits another (or the same) unhealed port.
+        let port_6379_checks = Arc::new(AtomicU32::new(0));
+        let port_6380_checks = Arc::new(AtomicU32::new(0));
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            ClusterClient::builder(vec![&*format!("redis://{name}")]).retries(2),
+            name,
+            {
+                let stale_phase = stale_phase.clone();
+                let p6379 = port_6379_checks.clone();
+                let p6380 = port_6380_checks.clone();
+                move |cmd: &[u8], port| {
+                    if !stale_phase.load(Ordering::SeqCst) {
+                        // Setup phase: everything works normally.
+                        respond_startup_two_nodes(name, cmd)?;
+                        Err(Ok(redis_value!("OK")))
+                    } else {
+                        let checks = match port {
+                            6379 => &p6379,
+                            6380 => &p6380,
+                            _ => panic!("unexpected port"),
+                        };
+
+                        if is_connection_check(cmd) {
+                            let attempt = checks.fetch_add(1, Ordering::SeqCst);
+                            if attempt < 2 {
+                                // Attempts 0-1: fail. This forces reconnect_loop to
+                                // fail on its first iteration (PING fail + READONLY
+                                // fail = get_or_create_conn returns Err), triggering
+                                // a backoff sleep which YIELDS the executor.
+                                Err(Err(broken_pipe_error()))
+                            } else {
+                                // Attempt 2+: fresh connection succeeds (after sleep)
+                                Err(Ok(Value::SimpleString("OK".into())))
+                            }
+                        } else if contains_slice(cmd, b"CLUSTER")
+                            && contains_slice(cmd, b"SLOTS")
+                        {
+                            // CLUSTER SLOTS: works only after port is healed.
+                            if checks.load(Ordering::SeqCst) > 2 {
+                                respond_startup_two_nodes(name, cmd)?;
+                                Err(Ok(redis_value!("OK")))
+                            } else {
+                                Err(Err(broken_pipe_error()))
+                            }
+                        } else {
+                            // Data commands: succeed only if port has been healed.
+                            // check_count > 2 means reconnect_loop completed its
+                            // second iteration successfully.
+                            if checks.load(Ordering::SeqCst) > 2 {
+                                Err(Ok(redis_value!("OK")))
+                            } else {
+                                Err(Err(broken_pipe_error()))
+                            }
+                        }
+                    }
+                }
+            },
+        );
+
+        // Enter the stale phase: all existing connections are now dead.
+        stale_phase_clone.store(true, Ordering::SeqCst);
+
+        let result = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<String>>(&mut connection),
+        );
+
+        // Pre-PR#2120: PASSES -- blocking refresh_connections heals the port,
+        //   the retry uses the healed connection.
+        // Post-PR#2120: FAILS -- background repair hasn't been polled,
+        //   retries exhaust against stale connections.
+        assert!(
+            result.is_ok(),
+            "Expected command to succeed after reconnection, but got: {:?}\n\
+             This demonstrates the regression: background repair hasn't been \
+             polled when retries fire, so all retries hit stale connections.",
+            result.unwrap_err()
+        );
+    }
+
+    /// Scale reproducer: 20 nodes with default retries (16).
+    /// This models production clusters (hundreds of nodes, 16 retries) where there are
+    /// always more stale-but-"Connected" nodes than retries. Each retry hits a
+    /// different stale node and burns a retry counter. After 16 retries, only
+    /// 16 of 20 nodes have been marked Reconnecting; 4 remain "Connected" (but
+    /// stale). ClusterConnectionNotFound is never reached, so the blocking
+    /// recovery path never activates. The request simply fails.
+    ///
+    /// Pre-PR#2120: PASSES (each Reconnect action blocks on refresh_connections,
+    ///   healing the node before the next retry fires)
+    /// Post-PR#2120: FAILS (background repair sleeps, retries fire instantly
+    ///   against remaining stale nodes)
+    #[test]
+    fn test_repro_all_connections_stale_many_nodes_retries_exhausted() {
+        let name = "test_repro_all_stale_20_nodes";
+
+        let stale_phase = Arc::new(AtomicBool::new(false));
+        let stale_phase_clone = stale_phase.clone();
+
+        // 20 ports: 6379..6398. More nodes than retries (16) means
+        // ClusterConnectionNotFound is never triggered.
+        const NUM_NODES: usize = 20;
+        let check_counts: Arc<Vec<AtomicU32>> = Arc::new(
+            (0..NUM_NODES).map(|_| AtomicU32::new(0)).collect(),
+        );
+
+        // Distribute hash slots evenly across 20 nodes.
+        let slots_per_node = 16384 / NUM_NODES as u16;
+        let slots_config: Vec<MockSlotRange> = (0..NUM_NODES)
+            .map(|i| {
+                let start = i as u16 * slots_per_node;
+                let end = if i == NUM_NODES - 1 {
+                    16383
+                } else {
+                    (i as u16 + 1) * slots_per_node - 1
+                };
+                MockSlotRange {
+                    primary_port: 6379 + i as u16,
+                    replica_ports: vec![],
+                    slot_range: (start..end),
+                }
+            })
+            .collect();
+
+        let MockEnv {
+            runtime,
+            async_connection: mut connection,
+            handler: _handler,
+            ..
+        } = MockEnv::with_client_builder(
+            // Default retries = 16. With 20 nodes, retries exhaust before all
+            // nodes are marked Reconnecting.
+            ClusterClient::builder(vec![&*format!("redis://{name}")]),
+            name,
+            {
+                let stale_phase = stale_phase.clone();
+                let slots_config = slots_config.clone();
+                let check_counts = check_counts.clone();
+                move |cmd: &[u8], port| {
+                    if !stale_phase.load(Ordering::SeqCst) {
+                        respond_startup_with_replica_using_config(
+                            name,
+                            cmd,
+                            Some(slots_config.clone()),
+                        )?;
+                        Err(Ok(redis_value!("OK")))
+                    } else {
+                        let idx = (port - 6379) as usize;
+                        let checks = &check_counts[idx];
+
+                        if is_connection_check(cmd) {
+                            let attempt = checks.fetch_add(1, Ordering::SeqCst);
+                            if attempt < 2 {
+                                Err(Err(broken_pipe_error()))
+                            } else {
+                                Err(Ok(Value::SimpleString("OK".into())))
+                            }
+                        } else if contains_slice(cmd, b"CLUSTER")
+                            && contains_slice(cmd, b"SLOTS")
+                        {
+                            if checks.load(Ordering::SeqCst) > 2 {
+                                respond_startup_with_replica_using_config(
+                                    name,
+                                    cmd,
+                                    Some(slots_config.clone()),
+                                )?;
+                                Err(Ok(redis_value!("OK")))
+                            } else {
+                                Err(Err(broken_pipe_error()))
+                            }
+                        } else {
+                            if checks.load(Ordering::SeqCst) > 2 {
+                                Err(Ok(redis_value!("OK")))
+                            } else {
+                                Err(Err(broken_pipe_error()))
+                            }
+                        }
+                    }
+                }
+            },
+        );
+
+        stale_phase_clone.store(true, Ordering::SeqCst);
+
+        let result = runtime.block_on(
+            cmd("GET")
+                .arg("test")
+                .query_async::<Option<String>>(&mut connection),
+        );
+
+        assert!(
+            result.is_ok(),
+            "Expected command to succeed after reconnection, but got: {:?}\n\
+             With 20 nodes and 16 retries (default), retries exhaust across \
+             stale nodes without ever triggering blocking recovery. This models \
+             the production scenario (hundreds of nodes, 16 retries).",
+            result.unwrap_err()
+        );
+    }
 }


### PR DESCRIPTION
Disclaimer: Analysis + PR were assisted by an AI agent.

## Summary


- Adds a circuit breaker to the `poll_flush` Reconnect handler that detects widespread connection loss
- When less than half the cluster nodes are healthy, escalates from background `reconnect_loop` to blocking `RecoverFuture::Reconnect`
- The blocking path gathers all non-Connected nodes, reconnects them in parallel via `refresh_connections_locked`, and retries with backoff until at least one succeeds
- Preserves the non-blocking background reconnection for single-node failures (the common case #2120 was designed for)
- Includes two regression tests: a minimal 2-node reproducer and a 20-node scale test modeling production clusters

## Problem

PR #2120 introduced background reconnection to avoid blocking all shards when a single replica fails. However, when ALL connections go stale simultaneously (e.g., after network
partition recovery or mass idle timeout), every retry in the retry loop hits a different stale node. The background reconnect_loop tasks sleep on failure (50ms+ backoff) and are
never polled before retries exhaust. In clusters with more nodes than the retry budget (default: 16), commands fail unconditionally.

## Fix


 The circuit breaker checks (via `try_read` on `conn_lock`) whether healthy nodes constitute less than half the cluster after accounting for the current `Reconnect` action. If so, it
 enters a blocking Recover state that:
 1. Gathers ALL non-Connected nodes (including those marked Reconnecting by earlier iterations)
 2. Attempts parallel reconnection via `refresh_connections_locked`
 3. Retries with exponential backoff until at least one node is restored
 4. Only then resumes the poll loop, allowing retried commands to reach healed connections

 Test plan

 - [x] `test_repro_all_connections_stale_retries_exhaust_before_recovery` -- 2-node, retries=2 (FAILS without fix, PASSES with fix)
 - [x] `test_repro_all_connections_stale_many_nodes_retries_exhausted` -- 20-node, default retries=16 (FAILS without fix, PASSES with fix)
 - [x] Both tests PASS on pre-#2120 code (commit f6f64a0), confirming they are valid regression tests

 
Fixes #2277