### PR TITLE
Bump `azure_identity` to 1.0 and `azure_core` to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -260,7 +260,7 @@ checksum = "9343dc5acf07e79ff82d0c37899f079db3534d99f189a1837c8e549c99405bec"
 dependencies = [
  "futures-util",
  "native-tls",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
 ]
 
@@ -326,7 +326,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.31.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe45c6bd7ce3a592327ee4e35b5bd16681714c4443c8a9884abb5731cc4d833"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -380,6 +380,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "typespec",
  "typespec_client_core",
@@ -387,21 +388,21 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190d6e0622d17e2a28239b55d2829d98b348269adcd4ab86a21d3304aa3500cb"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
  "tracing",
 ]
 
 [[package]]
 name = "azure_identity"
-version = "0.31.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c0c8cb8886f2bdabb3501476fa53f87fa9efea9d457ff991c5ce80052c4774"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -473,14 +474,14 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -527,7 +528,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -855,7 +856,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1087,7 +1088,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1164,20 +1165,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1187,11 +1178,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1320,18 +1313,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
+name = "hyper-rustls"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "bytes",
- "http-body-util",
+ "http",
  "hyper",
  "hyper-util",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1474,7 +1466,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1522,16 +1514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,7 +1555,56 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1587,11 +1618,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1667,6 +1699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,7 +1732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -1799,7 +1837,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1899,7 +1937,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2001,7 +2039,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2011,7 +2049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2025,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2061,6 +2099,63 @@ dependencies = [
  "env_logger",
  "log",
  "rand 0.10.1",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.4",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.1",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.4",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2102,18 +2197,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -2138,16 +2223,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.0",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,19 +2233,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
-dependencies = [
- "getrandom 0.3.1",
- "zerocopy 0.8.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rayon"
@@ -2328,11 +2402,10 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "async-compression",
  "base64",
  "bytes",
  "futures-core",
@@ -2341,20 +2414,19 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2434,7 +2506,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -2521,7 +2593,7 @@ dependencies = [
  "openssl-probe 0.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.1.0",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2530,8 +2602,36 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2611,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.1.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.0",
@@ -2665,7 +2765,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2679,18 +2779,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -2712,6 +2800,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -2807,9 +2905,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2833,7 +2942,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2860,7 +2969,7 @@ name = "test-macros"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2869,7 +2978,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -2880,7 +2998,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2891,7 +3020,6 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2974,7 +3102,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3044,20 +3172,25 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3074,9 +3207,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -3085,20 +3218,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -3111,9 +3244,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typespec"
-version = "0.11.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd1eb4a538c1ab3d5c05437129bc16891296146b23c9b0bb3f5df99f5b3a18d"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
 dependencies = [
  "base64",
  "bytes",
@@ -3125,17 +3258,17 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.10.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e632235c99ae896a3c451d1ead00cea11a2219aeda1b35a74027fe99ea3f3b72"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "dyn-clone",
  "futures",
- "getrandom 0.3.1",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -3150,14 +3283,14 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.10.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7048df3b053daa72e8ea91894ebcb2f0511ba52737379834524d82074a94a458"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3261,15 +3394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
-dependencies = [
- "wit-bindgen-rt",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,49 +3413,33 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "serde",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3339,22 +3447,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -3383,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3408,12 +3516,31 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3648,15 +3775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "wit-bindgen-rust"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,7 +3784,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.114",
+ "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3682,7 +3800,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3777,7 +3895,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3788,16 +3906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
-dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -3808,18 +3917,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3839,7 +3937,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3868,7 +3966,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -110,10 +110,10 @@ arcstr = "1.2.0"
 socket2 = { version = "0.6", features = ["all"] }
 
 # Only needed for Entra ID authentication
-azure_identity = { version = "0.31", optional = true, features = [
+azure_identity = { version = "1.0.0", optional = true, features = [
   "client_certificate",
 ] }
-azure_core = { version = "0.31", optional = true }
+azure_core = { version = "1.1.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
 
 [target.'cfg(all(target_os = "wasi", target_env = "p2"))'.dependencies]

--- a/redis/src/entra_id.rs
+++ b/redis/src/entra_id.rs
@@ -856,6 +856,12 @@ mod tests {
             ClientCertificate::new(encoded),
         );
         assert!(provider.is_err());
+        assert!(
+            provider
+                .unwrap_err()
+                .to_string()
+                .contains("deserializing PKCS12 from DER failed")
+        );
     }
 
     #[test]
@@ -866,6 +872,12 @@ mod tests {
             ClientCertificate::new(PKCS12_WITH_PASSWORD.clone()),
         );
         assert!(provider.is_err());
+        assert!(
+            provider
+                .unwrap_err()
+                .to_string()
+                .contains("PKCS12 parsing failed")
+        );
 
         let provider = EntraIdCredentialsProvider::new_client_certificate(
             TENANT_ID.to_string(),

--- a/redis/src/entra_id.rs
+++ b/redis/src/entra_id.rs
@@ -40,6 +40,12 @@
 //!
 //! Add the `entra-id` feature to your `Cargo.toml`.
 //!
+//! The feature depends on `azure_identity` and `azure_core`, which use `rustls` together with the
+//! platform's certificate store for the HTTPS requests to the Entra ID token endpoint.
+//! That is independent of the TLS backend used for the connection to the server, so combining `entra-id`
+//! with `tls-native-tls` links both TLS implementations into the binary. Keep in mind that `rustls`
+//! validates certificates more strictly than OpenSSL, which can matter in environments that intercept TLS traffic.
+//!
 //! ## Basic Usage with DeveloperToolsCredential
 //!
 //! ```rust,no_run
@@ -114,19 +120,13 @@
 //! # use std::fs;
 //! # fn example() -> RedisResult<()> {
 //! // Load certificate from file
-//! let certificate_base64 = fs::read_to_string("path/to/base64_pkcs12_certificate")
-//!     .expect("Base64 PKCS12 certificate not found.")
-//!     .trim()
-//!     .to_string();
+//! let certificate = fs::read("path/to/pkcs12_certificate")?;
 //!
 //! // Create the credentials provider using service principal with client certificate
 //! let mut provider = EntraIdCredentialsProvider::new_client_certificate(
 //!     "your-tenant-id".to_string(),
 //!     "your-client-id".to_string(),
-//!     ClientCertificate {
-//!         base64_pkcs12: certificate_base64, // Base64 encoded PKCS12 data
-//!         password: None,
-//!     },
+//!     ClientCertificate::new(certificate), // Raw PKCS12 data
 //! )?;
 //! provider.start(RetryConfig::default());
 //! # Ok(())
@@ -263,14 +263,40 @@ const TOKEN_REFRESH_BUFFER_SECS: u64 = 240;
 
 /// A client certificate in PKCS12 (PFX) that can be used for client certificate authentication.
 ///
-/// The certificate data should be base64-encoded PKCS12 content.
-/// If the PKCS12 archive is password-protected, provide the password via `password`.
-#[derive(Debug, Clone)]
+/// The certificate data should be the raw bytes of the PKCS12 (PFX) archive,
+/// which has to contain the certificate together with its RSA private key.
+/// If the PKCS12 archive is password-protected, provide the password via [`set_password`](ClientCertificate::set_password).
+#[derive(Clone)]
 pub struct ClientCertificate {
-    /// Base64-encoded PKCS12 certificate data
-    pub base64_pkcs12: String,
+    /// Raw PKCS12 certificate data
+    pkcs12: Vec<u8>,
     /// The certificate's password if any
-    pub password: Option<String>,
+    password: Option<String>,
+}
+
+impl ClientCertificate {
+    /// Create a client certificate from raw PKCS12 (PFX) data
+    pub fn new(pkcs12: impl Into<Vec<u8>>) -> Self {
+        Self {
+            pkcs12: pkcs12.into(),
+            password: None,
+        }
+    }
+
+    /// Set the password protecting the PKCS12 archive
+    pub fn set_password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+}
+
+impl std::fmt::Debug for ClientCertificate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientCertificate")
+            .field("pkcs12", &"<PKCS12>")
+            .field("password", &self.password.as_ref().map(|_| "<password>"))
+            .finish()
+    }
 }
 
 type Subscriptions = Vec<Sender<RedisResult<BasicAuth>>>;
@@ -561,7 +587,7 @@ impl EntraIdCredentialsProvider {
         let credential_provider = ClientCertificateCredential::new(
             tenant_id,
             client_id,
-            client_certificate.base64_pkcs12.into(),
+            client_certificate.pkcs12.into(),
             options,
         )
         .map_err(Self::convert_error)?;
@@ -692,6 +718,56 @@ impl std::fmt::Debug for EntraIdCredentialsProvider {
 #[cfg(all(feature = "entra-id", test))]
 mod tests {
     use super::*;
+    use redis_test::utils::{CommandMultiArgs, OpensslCommand};
+    use std::fs;
+    use std::sync::LazyLock;
+    use tempfile::TempDir;
+
+    const TENANT_ID: &str = "tenant";
+    const CLIENT_ID: &str = "client";
+    const CLIENT_SECRET: &str = "secret";
+
+    const PKCS12_PASSWORD: &str = "pkcs12-password";
+
+    /// A PKCS12 archives holding a self-signed certificate and its RSA key.
+    static PKCS12: LazyLock<Vec<u8>> = LazyLock::new(|| create_pkcs12(None));
+    static PKCS12_WITH_PASSWORD: LazyLock<Vec<u8>> =
+        LazyLock::new(|| create_pkcs12(Some(PKCS12_PASSWORD)));
+
+    /// Creates a PKCS12 (PFX) archive with a self-signed certificate and its RSA private key.
+    fn create_pkcs12(password: Option<&str>) -> Vec<u8> {
+        let tempdir = TempDir::new().unwrap();
+        let key = tempdir.path().join("certificate.key");
+        let certificate = tempdir.path().join("certificate.crt");
+        let archive = tempdir.path().join("certificate.pfx");
+
+        OpensslCommand::new("self-sign client certificate")
+            .arg("req")
+            .arg("-x509")
+            .arg("-nodes")
+            .arg2("-newkey", "rsa:2048")
+            .arg2("-keyout", &key)
+            .arg2("-out", &certificate)
+            .arg2("-days", "365")
+            .arg2("-subj", "/CN=redis-rs-entra-id-test")
+            .spawn();
+
+        // The PBE algorithms are set explicitly because OpenSSL 1.x defaults to RC2,
+        // which OpenSSL 3.x refuses to read without the legacy provider.
+        OpensslCommand::new("export client certificate to PKCS12")
+            .arg("pkcs12")
+            .arg("-export")
+            .arg2("-inkey", &key)
+            .arg2("-in", &certificate)
+            .arg2("-out", &archive)
+            .arg2("-passout", format!("pass:{}", password.unwrap_or_default()))
+            .arg2("-keypbe", "aes-256-cbc")
+            .arg2("-certpbe", "aes-256-cbc")
+            .arg2("-macalg", "sha256")
+            .spawn();
+
+        fs::read(&archive).unwrap()
+    }
 
     #[test]
     fn test_entra_id_provider_creation() {
@@ -700,9 +776,9 @@ mod tests {
         assert!(_default_provider.is_ok());
 
         let _client_secret_provider = EntraIdCredentialsProvider::new_client_secret(
-            "tenant".to_string(),
-            "client".to_string(),
-            "secret".to_string(),
+            TENANT_ID.to_string(),
+            CLIENT_ID.to_string(),
+            CLIENT_SECRET.to_string(),
         );
         assert!(_client_secret_provider.is_ok());
 
@@ -757,6 +833,55 @@ mod tests {
         )
         .unwrap();
         assert_eq!(provider.scopes, custom_scopes);
+    }
+
+    #[test]
+    fn test_client_certificate_accepts_raw_pkcs12() {
+        let provider = EntraIdCredentialsProvider::new_client_certificate(
+            TENANT_ID.to_string(),
+            CLIENT_ID.to_string(),
+            ClientCertificate::new(PKCS12.clone()),
+        );
+        assert!(provider.is_ok());
+    }
+
+    #[test]
+    fn test_client_certificate_rejects_base64_pkcs12() {
+        use base64::Engine;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(PKCS12.as_slice());
+
+        let provider = EntraIdCredentialsProvider::new_client_certificate(
+            TENANT_ID.to_string(),
+            CLIENT_ID.to_string(),
+            ClientCertificate::new(encoded),
+        );
+        assert!(provider.is_err());
+    }
+
+    #[test]
+    fn test_client_certificate_password() {
+        let provider = EntraIdCredentialsProvider::new_client_certificate(
+            TENANT_ID.to_string(),
+            CLIENT_ID.to_string(),
+            ClientCertificate::new(PKCS12_WITH_PASSWORD.clone()),
+        );
+        assert!(provider.is_err());
+
+        let provider = EntraIdCredentialsProvider::new_client_certificate(
+            TENANT_ID.to_string(),
+            CLIENT_ID.to_string(),
+            ClientCertificate::new(PKCS12_WITH_PASSWORD.clone()).set_password(PKCS12_PASSWORD),
+        );
+        assert!(provider.is_ok());
+    }
+
+    #[test]
+    fn test_client_certificate_debug_hides_secrets() {
+        let certificate = ClientCertificate::new(PKCS12.clone()).set_password(PKCS12_PASSWORD);
+
+        let debug = format!("{certificate:?}");
+        assert!(!debug.contains(PKCS12_PASSWORD));
+        assert!(!debug.contains(&format!("{:?}", PKCS12.as_slice())));
     }
 }
 

--- a/redis/tests/test_auth.rs
+++ b/redis/tests/test_auth.rs
@@ -101,24 +101,15 @@ mod entra_id_tests {
     }
 
     fn setup_provider_with_client_certificate_and_scopes() -> EntraIdCredentialsProvider {
-        use base64::Engine;
         use std::fs;
 
         let certificate_path = get_env_var(AZURE_CLIENT_CERTIFICATE_PATH);
-        let certificate_data =
-            fs::read(&certificate_path).expect("Failed to read client certificate");
-
-        // Convert the certificate data to base64
-        let certificate_base64 =
-            base64::engine::general_purpose::STANDARD.encode(&certificate_data);
+        let certificate_data = fs::read(&certificate_path).unwrap();
 
         EntraIdCredentialsProvider::new_client_certificate_with_scopes(
             get_env_var(AZURE_TENANT_ID),
             get_env_var(AZURE_CLIENT_ID),
-            ClientCertificate {
-                base64_pkcs12: certificate_base64,
-                password: None,
-            },
+            ClientCertificate::new(certificate_data),
             get_redis_scopes().clone(),
             None,
         )

--- a/version2.md
+++ b/version2.md
@@ -221,3 +221,49 @@ pipe.reserve_for_commands(16).reserve_for_args(48);
 ```
 
 `Pipeline::new()` and `pipe()` are unchanged.
+
+### `ClientCertificate` holds the raw PKCS12 archive and is built through `ClientCertificate::new` (Breaking Change)
+
+The `entra-id` feature moved from `azure_identity` 0.31 to 1.0, whose `ClientCertificateCredential` expects the decoded PKCS12 (PFX) archive rather than a base64-encoded one. As a result, `ClientCertificate` changed and the `base64_pkcs12: String` field became `pkcs12: Vec<u8>`.
+Both fields are private now, so a certificate is built with `ClientCertificate::new`, and a password-protected archive gets its password through `ClientCertificate::set_password`.
+
+`ClientCertificate` continues to implement `Debug`, but it prints neither the certificate data nor the password.
+
+**Migration:** Replace the struct expression with `ClientCertificate::new` and hand it the decoded archive:
+
+```rust
+// Before:
+let certificate_base64 = fs::read_to_string("path/to/base64_pkcs12_certificate")?;
+let certificate = ClientCertificate {
+    base64_pkcs12: certificate_base64,
+    password: None,
+};
+
+// After:
+let certificate = ClientCertificate::new(fs::read("path/to/pkcs12_certificate")?);
+```
+
+For a password-protected archive:
+
+```rust
+// Before:
+let certificate = ClientCertificate {
+    base64_pkcs12: certificate_base64,
+    password: Some("your-password".to_string()),
+};
+
+// After:
+let certificate =
+    ClientCertificate::new(fs::read("path/to/pkcs12_certificate")?).set_password("your-password");
+```
+
+### `entra-id` uses `rustls` for the requests to the Entra ID token endpoint (Breaking Change)
+
+The bump to `azure_identity` 1.0 and `azure_core` 1.1 switches their HTTP stack from `native-tls` to `rustls` together with the platform's certificate store. This concerns only the HTTPS requests that fetch the tokens from Entra ID. The TLS backend for the connection to the server is unaffected and is still selected through the `tls-native-tls` and `tls-rustls` features.
+
+That has two consequences:
+
+* Enabling `entra-id` alongside `tls-native-tls` links both TLS implementations into the binary.
+* `rustls` validates certificates more strictly than OpenSSL, so fetching a token can start failing in environments that intercept TLS traffic.
+
+**Migration:** No code changes are needed. In an environment that intercepts TLS traffic, make sure that the intercepting certificate authority is installed in the platform's certificate store and that its chain is one that `rustls` accepts.


### PR DESCRIPTION
## Summary

The upstream 1.0 release changed how a client certificate is handed to `ClientCertificateCredential`, so `ClientCertificate` is reworked accordingly. It now holds the **decoded** PKCS12 archive instead of a base64-encoded one. 
This is a **breaking change** to the public API of the `entra-id` feature.

The release also changes which TLS implementation is used for the requests to the Entra ID token endpoint.

## Background

`azure_identity` 0.31 took the certificate as a base64-encoded `Secret` and decoded it internally:

```rust
// azure_identity-0.31.0/src/client_certificate_credential.rs
pub fn new(tenant_id: String, client_id: String, certificate: Secret, ...)
// ...
let cert_bytes = base64::decode(certificate.secret())
```

`azure_identity` 1.0.0 takes `SecretBytes` and parses the archive directly, with no decoding step:

```rust
// azure_identity-1.0.0/src/client_certificate_credential.rs
pub fn new(tenant_id: String, client_id: String, certificate: SecretBytes, ...)
// ...
let (key, cert, ca_chain) = parse_certificate(certificate.bytes(), options.password.as_ref())?;
```

`ClientCertificate`'s shape was changed so it follows upstream:

| | Before | After |
| --- | --- | --- |
| Certificate field | `pub base64_pkcs12: String` | `pkcs12: Vec<u8>` (private) |
| Password field | `pub password: Option<String>` | `password: Option<String>` (private) |
| Construction | struct expression | `ClientCertificate::new` |
| Password | `password` field | `ClientCertificate::set_password` |
| `Debug` | derived - could print sensitive data | manual - doesn't print sensitive data|

## API

```rust
// Before:
let certificate_base64 = fs::read_to_string("path/to/base64_pkcs12_certificate")?;
let certificate = ClientCertificate {
    base64_pkcs12: certificate_base64,
    password: None,
};

// After:
let certificate = ClientCertificate::new(fs::read("path/to/pkcs12_certificate")?);
// For a password-protected archive:
let certificate =
    ClientCertificate::new(fs::read("path/to/pkcs12_certificate")?).set_password("your-password");
```

## Behavior

**The bytes have to be the decoded archive.**
Handing a base64-encoded certificate to `ClientCertificate::new` still compiles.
It fails later, when `EntraIdCredentialsProvider::new_client_certificate` parses the archive, with an error originating in `azure_identity`. Because this cannot be caught by the compiler, it is pinned by a dedicated unit test and called out in `version2.md`.

**TLS for the token endpoint changed from `native-tls` to `rustls`.** `azure_core` 0.31 defaulted to `reqwest_native_tls`. 1.1.0 defaults to `reqwest_rustls` and `reqwest_native_tls` no longer exists as a feature. Visible in the lockfile as `hyper-tls` being replaced by `hyper-rustls`, `rustls-platform-verifier` and `webpki-root-certs`.

Consequences:
- Only the HTTPS requests that fetch tokens from Entra ID are affected. The TLS backend for the connection to the server is unchanged and still selected via `tls-native-tls` / `tls-rustls`.
- Combining `entra-id` with `tls-native-tls` links both TLS implementations into the binary.
- `rustls` validates certificates more strictly than OpenSSL, so token acquisition can start failing in environments that intercept TLS traffic. The platform certificate store is used, via `rustls-platform-verifier`.

## Testing

| Test | Type | Covers |
| --- | --- | --- |
| `test_client_certificate_accepts_raw_pkcs12` | unit | A decoded archive is accepted |
| `test_client_certificate_rejects_base64_pkcs12` | unit | A base64-encoded archive is rejected - pins the semantic this PR changes |
| `test_client_certificate_password` | unit | A protected archive fails without a password and succeeds via `set_password` |
| `test_client_certificate_debug_hides_secrets` | unit | `Debug` output contains neither the password nor the certificate bytes |
| `setup_provider_with_client_certificate_and_scopes` | integration | Adapted to the new API |

## Relevant documentation

- [`azure_identity` on docs.rs](https://docs.rs/azure_identity/1.0.0/azure_identity/struct.ClientCertificateCredential.html)
- [`azure_core::credentials::SecretBytes`](https://docs.rs/azure_core/1.1.0/azure_core/credentials/struct.SecretBytes.html)